### PR TITLE
Generalize evidence endpoint API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "5.9.1"
+  - "6.2.1"
 
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ $ heroku addons:create heroku-postgresql:hobby-dev
 Seed the database:
 ```
 $ heroku pg:psql
-threeflows:DATABASE=> CREATE TABLE message_popup_responses (
+threeflows:DATABASE=> CREATE TABLE evidence (
   id serial primary key,
+  app text,
+  type text,
+  version integer,
+  timestamp timestamp,
   json jsonb
 );
 ```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "threeflows",
   "version": "0.1.0",
   "engines": {
-    "node": "5.9.1"
+    "node": "6.2.1"
   },
   "main": "server/index.js",
   "scripts": {

--- a/server/index.js
+++ b/server/index.js
@@ -35,7 +35,7 @@ app.post('/server/evidence/:app/:type/:version', function(request, response) {
   const timestamp = new Date().getTime();
   const {app, type, version} = request.params;
   const payload = JSON.stringify(request.body);
-  const values = [app, type, version, payload, timestamp];
+  const values = [app, type, version, timestamp, payload];
 
   const sql = `
     INSERT INTO evidence(app, type, version, timestamp, json)

--- a/server/index.js
+++ b/server/index.js
@@ -27,9 +27,16 @@ function queryDatabase(text, values, cb) {
   });
 };
 
-app.post('/server/message_popup', function(request, response) {
-  const values = [JSON.stringify(request.body)];
-  queryDatabase('INSERT INTO message_popup_responses(json) VALUES ($1)', values, function(err, result) {
+app.post('/server/evidence', function(request, response) {
+  const timestamp = new Date().getTime();
+  const payload = JSON.stringify(request.body);
+  const {app, type, version} = url.parse(request.url, true).query;
+  const values = [app, type, version, payload, timestamp];
+
+  const sql = `
+    INSERT INTO evidence(app, type, version, payload, timestamp)
+    VALUES ($1,$2,$3,$4,$5)`;
+  queryDatabase(sql, values, function(err, result) {
     if (err) {
       console.log({ error: err });
       return response.code(500);
@@ -40,7 +47,7 @@ app.post('/server/message_popup', function(request, response) {
 });
 
 app.get('/server/dump', function(request, response) {
-  queryDatabase('SELECT * FROM message_popup_responses', [], function(err, result) {
+  queryDatabase('SELECT * FROM evidence', [], function(err, result) {
     if (err) {
       console.log({ error: err });
       return response.code(500);

--- a/server/index.js
+++ b/server/index.js
@@ -27,7 +27,10 @@ function queryDatabase(text, values, cb) {
   });
 };
 
-// This endpoint receives all evidence, 
+// This endpoint that receives all evidence.
+// The payload is determined by the type, but for now it only
+// supports JSON serialization and puts everything in the same
+// Postgres table with a jsonb column.
 app.post('/server/evidence/:app/:type/:version', function(request, response) {
   const timestamp = new Date().getTime();
   const {app, type, version} = request.params;
@@ -35,7 +38,7 @@ app.post('/server/evidence/:app/:type/:version', function(request, response) {
   const values = [app, type, version, payload, timestamp];
 
   const sql = `
-    INSERT INTO evidence(payload, timestamp)
+    INSERT INTO evidence(app, type, version, timestamp, json)
     VALUES ($1,$2,$3,$4,$5)`;
   queryDatabase(sql, values, function(err, result) {
     if (err) {
@@ -47,6 +50,7 @@ app.post('/server/evidence/:app/:type/:version', function(request, response) {
   });
 });
 
+// For debugging.
 app.get('/server/dump', function(request, response) {
   queryDatabase('SELECT * FROM evidence', [], function(err, result) {
     if (err) {

--- a/server/index.js
+++ b/server/index.js
@@ -27,14 +27,15 @@ function queryDatabase(text, values, cb) {
   });
 };
 
-app.post('/server/evidence', function(request, response) {
+// This endpoint receives all evidence, 
+app.post('/server/evidence/:app/:type/:version', function(request, response) {
   const timestamp = new Date().getTime();
+  const {app, type, version} = request.params;
   const payload = JSON.stringify(request.body);
-  const {app, type, version} = url.parse(request.url, true).query;
   const values = [app, type, version, payload, timestamp];
 
   const sql = `
-    INSERT INTO evidence(app, type, version, payload, timestamp)
+    INSERT INTO evidence(payload, timestamp)
     VALUES ($1,$2,$3,$4,$5)`;
   queryDatabase(sql, values, function(err, result) {
     if (err) {

--- a/server/index.js
+++ b/server/index.js
@@ -52,7 +52,8 @@ app.post('/server/evidence/:app/:type/:version', function(request, response) {
 
 // For debugging.
 app.get('/server/dump', function(request, response) {
-  queryDatabase('SELECT * FROM evidence', [], function(err, result) {
+  const limit = 100;
+  queryDatabase('SELECT * FROM evidence ORDER BY timestamp DESC LIMIT $1', [limit], function(err, result) {
     if (err) {
       console.log({ error: err });
       return response.code(500);

--- a/server/index.js
+++ b/server/index.js
@@ -32,7 +32,7 @@ function queryDatabase(text, values, cb) {
 // supports JSON serialization and puts everything in the same
 // Postgres table with a jsonb column.
 app.post('/server/evidence/:app/:type/:version', function(request, response) {
-  const timestamp = new Date().getTime();
+  const timestamp = Math.floor(new Date().getTime() / 1000);
   const {app, type, version} = request.params;
   const payload = JSON.stringify(request.body);
   const values = [app, type, version, timestamp, payload];

--- a/server/index.js
+++ b/server/index.js
@@ -39,7 +39,7 @@ app.post('/server/evidence/:app/:type/:version', function(request, response) {
 
   const sql = `
     INSERT INTO evidence(app, type, version, timestamp, json)
-    VALUES ($1,$2,$3,$4,$5)`;
+    VALUES ($1,$2,$3,to_timestamp($4),$5)`;
   queryDatabase(sql, values, function(err, result) {
     if (err) {
       console.log({ error: err });

--- a/ui/src/message_popup/message_popup_page.jsx
+++ b/ui/src/message_popup/message_popup_page.jsx
@@ -29,7 +29,12 @@ function logLocalStorage(record) {
 
 function logDatabase(record) {
   request
-    .post('/server/message_popup')
+    .post('/server/evidence')
+    .query({
+      app: 'threeflows',
+      type: 'message_popup',
+      version: 2
+    })
     .set('Content-Type', 'application/json')
     .send(record)
     .end(function(err, res) {

--- a/ui/src/message_popup/message_popup_page.jsx
+++ b/ui/src/message_popup/message_popup_page.jsx
@@ -36,9 +36,7 @@ function logDatabase(record) {
     }))
     .set('Content-Type', 'application/json')
     .send(record)
-    .end(function(err, res) {
-      if (err) console.log({err});
-    });
+    .end(function(err, res) { if (err) console.log({err}); });
 }
 
 /*

--- a/ui/src/message_popup/message_popup_page.jsx
+++ b/ui/src/message_popup/message_popup_page.jsx
@@ -29,12 +29,11 @@ function logLocalStorage(record) {
 
 function logDatabase(record) {
   request
-    .post('/server/evidence')
-    .query({
+    .post(Routes.evidencePath({
       app: 'threeflows',
       type: 'message_popup',
       version: 2
-    })
+    }))
     .set('Content-Type', 'application/json')
     .send(record)
     .end(function(err, res) {

--- a/ui/src/message_popup/message_popup_page.jsx
+++ b/ui/src/message_popup/message_popup_page.jsx
@@ -62,7 +62,7 @@ export default React.createClass({
   onResponse({question, elapsedMs, responseText}) {
     const logFn = (window.location.host.indexOf('localhost') === 0)
       ? logLocalStorage : logDatabase;
-    logDatabase({
+    logFn({
       question,
       elapsedMs,
       responseText,

--- a/ui/src/message_popup/message_popup_page.jsx
+++ b/ui/src/message_popup/message_popup_page.jsx
@@ -67,7 +67,7 @@ export default React.createClass({
       elapsedMs,
       responseText,
       name: this.state.name,
-      timestamp: new Date().getTime()
+      clientTimestampMs: new Date().getTime()
     });
     this.setState({ questionsAnswered: this.state.questionsAnswered + 1 });
   },

--- a/ui/src/message_popup/popup_question.jsx
+++ b/ui/src/message_popup/popup_question.jsx
@@ -43,7 +43,7 @@ export default React.createClass({
 
   onSendPressed() {
     const {elapsedMs, responseText} = this.state;
-    const {question} = this.props.question;
+    const {question} = this.props;
     this.props.onResponse({question, elapsedMs, responseText});
   },
 

--- a/ui/src/routes.js
+++ b/ui/src/routes.js
@@ -19,6 +19,12 @@ export function messagePopupPath() {
   return `/message_popup`;
 }
 
+
+/* Services */
+export function evidencePath({app, type, version}) {
+  return `/server/evidence/${app}/${type}/${version}`;
+}
+
 /* External links */
 export function chatRoom(room) {
   return `https://mittsl.slack.com/messages/${room}/`;


### PR DESCRIPTION
This will let us use this for a second type of evidence with the simple implementation of putting everything in the same table and only allowing JSON payloads.  It's directionally what we might want in a service.

This also upgrades to node 6.2.1 to get better ES6 support.