### PR TITLE
Add states and toggles for Message PopUp practice modes

### DIFF
--- a/ui/src/message_popup/popup_question.jsx
+++ b/ui/src/message_popup/popup_question.jsx
@@ -12,12 +12,20 @@ const ONE_SECOND = 1000;
 Shows a single question.
 */
 type Question = {text:string};
-export type Response = {question:Question,elapsedMs:number,responseText:string};
+export type Response = {
+  question:Question,
+  elapsedMs:number,
+  responseText:string,
+  shouldShowStudentCard:boolean,
+  allowedToToggleHint:boolean
+};
 export default React.createClass({
   displayName: 'PopupQuestion',
   mixins: [SetIntervalMixin],
 
   propTypes: {
+    shouldShowStudentCard: React.PropTypes.bool.isRequired,
+    allowedToToggleHint: React.PropTypes.bool.isRequired,
     limitMs: React.PropTypes.number.isRequired,
     question: React.PropTypes.shape({
       text: React.PropTypes.string.isRequired,
@@ -48,20 +56,29 @@ export default React.createClass({
 
   onSendPressed() {
     const {elapsedMs, responseText} = this.state;
-    const {question} = this.props;
-    const response:Response = {question, elapsedMs, responseText};
+    const {question, shouldShowStudentCard, allowedToToggleHint} = this.props;
+    const response:Response = {
+      question,
+      shouldShowStudentCard,
+      allowedToToggleHint,
+      elapsedMs,
+      responseText
+    }
     this.props.onResponse(response);
   },
 
   render() {
     const {elapsedMs} = this.state;
-    const {limitMs} = this.props;
+    const {limitMs, shouldShowStudentCard} = this.props;
     const {text, student} = this.props.question;
 
     return (
       <div>
         <div style={styles.question}>{text}</div>
-        <div style={styles.studentCard}><StudentCard student={student} /></div>
+        {shouldShowStudentCard &&
+          <div style={styles.studentCard}>
+            <StudentCard student={student} />
+          </div>}
         <div style={styles.textAreaContainer}>
           <TextField
             style={styles.textField}


### PR DESCRIPTION
This adds some state and toggles to the Message Pop Up game, configuring how much scaffolding is present for each popup.  Not all toggles work yet, so some are disabled.
![screen shot 2016-06-16 at 6 21 11 pm](https://cloud.githubusercontent.com/assets/1056957/16135364/2c22dba0-33f1-11e6-9b86-9b3f2595825f.png)

The mode state also gets threaded through as evidence (so we know what levels of support were present).
![screen shot 2016-06-16 at 6 34 54 pm](https://cloud.githubusercontent.com/assets/1056957/16135365/2c272494-33f1-11e6-87ce-90b76d87576b.png)