### PR TITLE
Add Babel transform for Object spread

### DIFF
--- a/ui/.babelrc
+++ b/ui/.babelrc
@@ -4,6 +4,7 @@
     "development": {
       "plugins": [
         ["transform-flow-strip-types"],
+        ["transform-object-rest-spread"],
         ["react-transform", {
           "transforms": [{
             "transform": "livereactload/babel-transform",

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/mit-teaching-systems-lab/threeflows#readme",
   "dependencies": {
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
+    "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "babelify": "^7.3.0",


### PR DESCRIPTION
I guess this isn't supported in ES6 proper yet, but this is a super useful CoffeeScript-ism so let's use it!  http://redux.js.org/docs/recipes/UsingObjectSpreadOperator.html for more info.

It lets us change code like this:
```
    logFn(Object.assign(response, {
      name: this.state.name,
      clientTimestampMs: new Date().getTime()
    }));
```

to:
```
    logFn({
      ...response,
      name: this.state.name,
      clientTimestampMs: new Date().getTime()
    }));
```

This isn't so much for clarity as it is for consistency with how the spread works for arrays, and for how it works in JSX.
