### PR TITLE
Added a hint card to message popup

### DIFF
--- a/ui/src/message_popup/data_lists.jsx
+++ b/ui/src/message_popup/data_lists.jsx
@@ -1,171 +1,248 @@
 export const allStudents = [
   { 
     id: 1,
-    name: 'Kevin',
-    grade: '7th grade',
-    gender: 'male',
-    race: 'Hispanic',
-    behavior: 'Disruptive in class',
+    name: `Kevin`,
+    grade: `7th grade`,
+    gender: `male`,
+    race: `Hispanic`,
+    behavior: `Disruptive in class`,
     ell: null,
     learningDisabilities: null,
-    academicPerformance: 'Grades are C/D and borderline failing. Failed science the last two semesters. Reading and writing is at the 5th grade level. Arrives late to class most of the time.',
+    academicPerformance: `Grades are C/D and borderline failing. Failed science the last two semesters. Reading and writing is at the 5th grade level. Arrives late to class most of the time.`,
     interests: null,
     familyBackground: null,
     ses: null,
   },
   {
     id: 2,
-    name: 'Floyd',
-    grade: '7th grade',
-    gender: 'male',
-    race: 'Caucasian',
-    behavior: 'Attendance issues',
+    name: `Floyd`,
+    grade: `7th grade`,
+    gender: `male`,
+    race: `Caucasian`,
+    behavior: `Attendance issues`,
     ell: null,
-    learningDisabilities: 'ADHD',
+    learningDisabilities: `ADHD`,
     academicPerformance: null,
-    interests: 'Wants to be a firefighter',
-    familyBackground: 'Divorced parents, younger brother',
-    ses: 'Free and reduced lunch'
+    interests: `Wants to be a firefighter`,
+    familyBackground: `Divorced parents, younger brother`,
+    ses: `Free and reduced lunch`
   },
   {
     id: 3,
-    name: 'Maia',
-    grade: '7th grade',
-    gender: 'female',
-    race: 'Caucasian',
-    behavior: 'Discipline report',
+    name: `Maia`,
+    grade: `7th grade`,
+    gender: `female`,
+    race: `Caucasian`,
+    behavior: `Discipline report`,
     ell: null,
     learningDisabilities: null,
     academicPerformance: null,
-    interests: 'In theater and loves art',
-    familyBackground: 'Single mom, two olders sisters',
+    interests: `In theater and loves art`,
+    familyBackground: `Single mom, two olders sisters`,
     ses: null
   },
   { 
     id: 4, 
-    name: 'Hayin',
-    grade: '7th grade',
-    gender: 'female',
-    race: 'Korean',
+    name: `Hayin`,
+    grade: `7th grade`,
+    gender: `female`,
+    race: `Korean`,
     behavior: null,
     ell: null,
     learningDisabilities: null,
     academicPerformance: null,
-    interests: 'Plays the flute, very involved in church, loves coding',
-    familyBackground: '1st generation parents, twin sister',
-    ses: 'Free and reduced lunch'
+    interests: `Plays the flute, very involved in church, loves coding`,
+    familyBackground: `1st generation parents, twin sister`,
+    ses: `Free and reduced lunch`
     
   },
   {
     id: 5,
-    name: 'Mike',
-    grade: '7th grade',
-    gender: 'male',
-    race: 'African American',
+    name: `Mike`,
+    grade: `7th grade`,
+    gender: `male`,
+    race: `African American`,
     behavior: null,
     ell: null,
     learningDisabilities: null,
     academicPerformance: null,
-    interests: 'Plays in a band, sings in the school chorus',
-    familyBackground: '1 older brother',
+    interests: `Plays in a band, sings in the school chorus`,
+    familyBackground: `1 older brother`,
     ses: null,
   },
   {
     id: 6,
-    name: 'Jasmine',
-    grade: '7th grade',
-    gender: 'female',
-    race: 'African American',
-    behavior: 'Quiet',
+    name: `Jasmine`,
+    grade: `7th grade`,
+    gender: `female`,
+    race: `African American`,
+    behavior: `Quiet`,
     ell: null,
     learningDisabilities: null,
     academicPerformance: null,
-    interests: 'Plays tennis and soccer',
-    familyBackground: 'Divorced parents, only child',
-    ses: 'Free and reduced lunch'
+    interests: `Plays tennis and soccer`,
+    familyBackground: `Divorced parents, only child`,
+    ses: `Free and reduced lunch`
   },
   {
     id: 7,
-    name: 'Miquel',
-    grade: '7th grade',
-    gender: 'male',
-    race: 'Latino',
-    behavior: 'Attendance issues',
-    ell: 'Yes, Spanish is native language',
+    name: `Miquel`,
+    grade: `7th grade`,
+    gender: `male`,
+    race: `Latino`,
+    behavior: `Attendance issues`,
+    ell: `Yes, Spanish is native language`,
     learningDisabilities: null,
     academicPerformance: null,
-    interests: 'Has an after school job',
-    familyBackground: '3 younger siblings',
-    ses: 'Free and reduced lunch'
+    interests: `Has an after school job`,
+    familyBackground: `3 younger siblings`,
+    ses: `Free and reduced lunch`
   },
   {
     id: 8,
-    name: 'Ada',
-    grade: '7th grade',
-    gender: 'female',
-    race: 'Haitian',
+    name: `Ada`,
+    grade: `7th grade`,
+    gender: `female`,
+    race: `Haitian`,
     behavior: null,
-    ell: 'Yes, Haitian Creole is native language',
-    learningDisabilities: 'Auditory disability',
+    ell: `Yes, Haitian Creole is native language`,
+    learningDisabilities: `Auditory disability`,
     academicPerformance: null,
     interests: `High-achiever, teacher's pet. Wants to be a doctor, is in yearbook`,
-    familyBackground: 'Aunt is guardian',
+    familyBackground: `Aunt is guardian`,
     ses: null
   },
   {
     id: 9,
-    name: 'Steve',
-    grade: '7th grade',
-    gender: 'male',
-    race: 'Caucasian',
-    behavior: 'Often tired in class',
+    name: `Steve`,
+    grade: `7th grade`,
+    gender: `male`,
+    race: `Caucasian`,
+    behavior: `Often tired in class`,
     ell: null,
     learningDisabilities: null,
     academicPerformance: null,
-    interests: 'Prefers ELA over math and science. Plays drums at home with his family. Has an after school job',
-    familyBackground: 'Younger sister',
+    interests: `Prefers ELA over math and science. Plays drums at home with his family. Has an after school job`,
+    familyBackground: `Younger sister`,
     ses: null
   },
   { 
     id: 10, 
-    name: 'Sasha',
-    grade: '7th grade',
-    gender: 'female',
-    race: 'African American'
+    name: `Sasha`,
+    grade: `7th grade`,
+    gender: `female`,
+    race: `African American`
   }
 ];
 
 export const allQuestions = [
   { 
     studentId: 4, 
-    text: 'At the conclusion of your lesson plan for this challenge, you seed a group discussion by asking "What are you curious about related to photosynthesis?"  Hayin says "Why are plants green?"  What do you do?' 
-  },
+    text: `At the conclusion of your lesson plan for this challenge, you seed a group discussion by asking "What are you curious about related to photosynthesis?"  Hayin says "Why are plants green?"  What do you do?`,
+    examples: [
+      `"We spent some time already studying that question, is there something else you're curious about, or how can you take that question to the next level?"`,
+      `"Oh, are all plants green?"`,
+      `"Okay, what kind of experiment would help you learn about that? Or how could you phrase it as something you could test?"`,
+      `"That is a great question. What do you think? Can anyone else add to Hayin's"`
+    ],
+    nonExamples: [
+      `"That's not a good question."`,
+      `"That's not a well-formed enough hypothesis, in order for it to be testable you need independent variables."`,
+      `"Well, most plants are green because of chloroplasts in their leaves that have a green pigment..."`,
+      `"We already talked about that question. Why don't you look for the answer on the internet. Any other things that folks are curious about?"`
+    ]
+  },  
   {
     studentId: 10, 
-    text: 'Imagine a new student, Sasha, joins your classroom during the lesson plan you developed for this challenge.  As part of helping her feel comfortable, you give her a quick overview of what’s happening.  She asks "what is photosynthesis again?"  How can you give a brief direct answer to her question?' 
+    text: `Imagine a new student, Sasha, joins your classroom during the lesson plan you developed for this challenge.  As part of helping her feel comfortable, you give her a quick overview of what's happening.  She asks "what is photosynthesis again?"  How can you give a brief direct answer to her question?`,
+    examples: [
+      `"Photosynthesis is the process where plants take in sunlight and carbon dioxide from the air, and produce sugar they can use and breathe out oxygen." [Candidate might use intonation or guestures]`,
+      `"Maia, this is Sasha. Sasha, this is Maia. Maia, will you take a couple minutes to help Sasha learn about photosynthesis. If you two have any questions, call me back over."`,
+      `"What have you heard about photosynthesis before in your last school? Let's build on what you remember."`,
+      `"Ok, what did you have for lunch? So, french fries come from what? How did that potato grow?"`
+    ],
+    nonExamples:[
+      `[A ten minute response.]`,
+      `"It's a biology concept."`,
+      `"Take out the textbook from under your desk and read pages 55-60."`
+    ]
   },
   { 
     studentId: 2, 
-    text: 'In the context of the lesson plan you developed for this challenge, Floyd says "why are we even doing this?"  Respond in way that engages his natural curiosity and tendency towards asking questions' 
+    text: `In the context of the lesson plan you developed for this challenge, Floyd says "why are we even doing this?"  Respond in way that engages his natural curiosity and tendency towards asking questions`,
+    examples: [
+      `"Well, imagine what would happen if there was no sunlight."`,
+      `"If we'll all going to live on Mars by the time you're an adult, we're going to have to figure out how plants can grow up there."`,
+      `"Take a breath. What are you breathing? Where do you think it came from?"`,
+      `[Take what you know about Floyd...he wants to be a firefighter] "What does fire need to burn? Let's talk about then where that oxygen comes from."`
+    ],
+    nonExamples:[
+      `"These are important skills for college."`,
+      `"It's part of the MCAS, so you need to do it to graduate."`,
+      `"Because."`
+    ]
   },
   {
     studentId: 8,
-    text: 'Imagine in the context of the lesson plan you developed for this challenge, there is an activity where students are coming up with questions to investigate.  Ada says "How many questions should I write and what do you want me to include in them?"  Respond in a way that draws out the student’s curiosity and pushes them towards asking questions that are meaningful to them.'
+    text: `Imagine in the context of the lesson plan you developed for this challenge, there is an activity where students are coming up with questions to investigate.  Ada says "How many questions should I write and what do you want me to include in them?"  Respond in a way that draws out the student's curiosity and pushes them towards asking questions that are meaningful to them.`,
+    examples: [
+      `"I want you to ask the kinds of questions you think are meaningful, not the ones I think are meaningful."`,
+      `"Well, you have to come up with your own questions that matter to you.  I'll share a question I think is interesting: Plants can get hurt and lose leaves and branches and they grow right back.  That's different than people - you can't break off an arm and have it grow right back or we wouldn't need doctors.  That's something I'm curious about, so you can't use that question, but what else are you curious about?"`,
+      `"Let's step back a second. What are you curious about after seeing the demonstration? What are you wondering? Ok, then let's work on turning that into a question that you can answer with an experiment."`,
+      `"Tell me one question that you are burning know the answer to."`
+    ],
+    nonExamples:[
+      `"To get an A, make three questions and include an IV, DV in each one."`,
+      `"At least 2 questions focused on how you could collect the oxygen made by a plant."`
+    ]
   },
   {
     studentId: 10,
-    text: 'Imagine a new student, Sasha, joins your classroom during the lesson plan you developed for this challenge.  As part of helping her feel comfortable, you pull her aside and give her a quick overview of what’s happening at the beginning of the class.  She interrupts and asks, "I do better with visuals, can you draw me a picture of photosynthesis?"  What could you quickly sketch to directly answer to her question?'
+    text: `Imagine a new student, Sasha, joins your classroom during the lesson plan you developed for this challenge.  As part of helping her feel comfortable, you pull her aside and give her a quick overview of what's happening at the beginning of the class.  She interrupts and asks, "I do better with visuals, can you draw me a picture of photosynthesis?"  What could you quickly sketch to directly answer to her question?`,
+    examples: [
+      `[Insert simple drawings here]`
+    ],
+    nonExamples:[
+      `"Go look in the textbook." (This is fine, but not answering the pop-up question.)`,
+      `[Insert very complex drawing here]`
+    ]
   },
   {
     studentId: 3,
-    text: 'Imagine in the context of the lesson plan you developed for this challenge, you pause and ask the whole class if they have anything they want to check their understanding on or clarify.  Maia asks "How can plants be breathing, you don’t see them inhaling and exhaling, and you don’t see their breath in the cold?"'
+    text: `Imagine in the context of the lesson plan you developed for this challenge, you pause and ask the whole class if they have anything they want to check their understanding on or clarify.  Maia asks "How can plants be breathing, you don't see them inhaling and exhaling, and you don't see their breath in the cold?"`,
+    examples: [
+      `"Well, is there a difference in scale?  Think of everything that's happening on your skin, but you can't see individual bacteria without a microscope."`,
+      `"Great question. How can set up an experiment to test out if plants really breathe?"`,
+      `"Great question. Everyone take a minute and write down how we might know that plants breathe?"`,
+    ],
+    nonExamples:[
+      `"Well, plants have stomata that open and close to take in oxygen and release carbon dioxide just like the stomata open and close to take in carbon dioxide and release oxygen."`
+    ]
   },
   {
     studentId: 5,
-    text: 'Imagine in the context of the lesson plan you developed for this challenge, you provide a summarizing explanation of photosynthesis to the whole class.  Mike asks, "I’m still a little confused, can you explain it again in a different way?"'
+    text: `Imagine in the context of the lesson plan you developed for this challenge, you provide a summarizing explanation of photosynthesis to the whole class.  Mike asks, "I'm still a little confused, can you explain it again in a different way?"`,
+    examples: [
+      `"Plants need to breathe and eat just like we do, and like all living things do.  Photosynthesis is like the process of you digesting your food, and your body giving you energy from it."`,
+      `"OK, everyone turn to a partner. Work together to come up with your own short explanation of photosynthesis. Draw or write explanation on your small whiteboard. Everyone will hold up their whiteboards when we're done to share our ideas."`,
+      `"Miquel, you had a great way to show photosynthesis in a drawing when we talked earlier. Will you share it with the class?"`
+    ],
+    nonExamples:[
+      `"Check out your textbook, pages 55-60."`,
+      `"Mike, we need to move on. Let's chat after class."`
+    ]
   },
   {
     studentId: 2,
-    text: 'Imagine in the context of the lesson plan you developed for this challenge, you provide a summarizing explanation of photosynthesis to the whole class.  Floyd asks, "But how can plants take in sunlight, do they like grab it?"'
+    text: `Imagine in the context of the lesson plan you developed for this challenge, you provide a summarizing explanation of photosynthesis to the whole class.  Floyd asks, "But how can plants take in sunlight, do they like grab it?"`,
+    examples: [
+      `"They absorb the light, yeah.  It's just like when you're outside in the sun, your skin absorbs the sunlight.  Your skin gets warmer, and if you're out there too long then you might even get sunburnt from absorbing too much of the sunlight energy."`,
+      `"What do you mean by grab? Can anyone else share another word that may help explain how plants take in sunlight?"`,
+      `"Great question. Let me pull out the small solar panel that we've used in different experiments. Let's talk about how a plant and this solar panel may be similar in how they get sunlight."`,
+      `"Look, there is sunshine coming in through the window. Mike, come hold your hand in the sunshine. What does it feel like?"`
+    ],
+    nonExamples:[
+      `"Plants absorb sunlight through chloroplasts."`
+    ]
   }
 ];

--- a/ui/src/message_popup/hint_card.jsx
+++ b/ui/src/message_popup/hint_card.jsx
@@ -1,20 +1,24 @@
-// @flow
 import React from 'react';
+import _ from 'lodash';
 import * as PropTypes from '../prop_types.js';
 import RaisedButton from 'material-ui/RaisedButton';
 import Divider from 'material-ui/Divider';
 
 /*
-Shows a card for a student from the virtual school.
+This shows a hint in the form of a toggleable good or bad example response
 */
 export default React.createClass({
   displayName: 'HintCard',
 
   getInitialState: function(){
+    var goodExamples = _.map(this.props.examples, function(example){return {type: 'Good', text: example}})
+    var badExamples = _.map(this.props.nonExamples, function(example){return {type: 'Bad', text: example}})
+    var allExamples = _.shuffle(goodExamples.concat(badExamples));
+    var originalAll = _.clone(allExamples);
     return ({
       hidden: true,
-      exampleIndex: 0,
-      nonExampleIndex: 0,
+      allExamples: allExamples,
+      originalAll: originalAll
     });
   },
   
@@ -24,21 +28,13 @@ export default React.createClass({
   },
   
   onNextExample(){
-    var length = this.props.examples.length;
-    var next = this.state.exampleIndex + 1;
-    if(next >= length){
-      next = 0;
+    if(this.state.allExamples.length <= 1){
+      this.setState({allExamples: _.clone(this.state.originalAll)});
+    }else{
+      var examples = this.state.allExamples;
+      examples.splice(0, 1);
+      this.setState({allExamples: examples});
     }
-    this.setState({exampleIndex: next});
-  },
-  
-  onNextNonExample(){
-    var length = this.props.nonExamples.length;
-    var next = this.state.nonExampleIndex + 1;
-    if(next >= length){
-      next = 0;
-    }
-    this.setState({nonExampleIndex: next});
   },
   
   onHintsToggled(){
@@ -47,47 +43,39 @@ export default React.createClass({
 
   render() {
     const {examples, nonExamples} = this.props;
-    const {hidden, exampleIndex, nonExampleIndex} = this.state;
+    const {hidden, allExamples} = this.state;
     return (
       <div>
         {hidden &&
           (<div>
             <div style={styles.buttonRow}>
+              <div style={styles.prompt}>Need a hint?</div>
               <RaisedButton
                 onTouchTap={this.onHintsToggled}
                 style={styles.button}
                 secondary={true}
                 label="Show Examples" />
-              <div style={styles.prompt}>Need a hint?</div>
             </div>
           </div>)
         }
         {!hidden &&
           (<div>
-            <div style={styles.examplesBox}>
-              <div style={styles.exampleSection}>
-                <div style={styles.exampleTitle}>Good Example</div>
-                <div style={styles.exampleText}>
-                  {examples[exampleIndex]}
-                </div>
+            <div style={styles.exampleBox}>
+              <div style={styles.exampleTopRow}>
+                <div style={styles.exampleTitle}>{allExamples[0].type} Example</div>
                 <RaisedButton
                   onTouchTap={this.onNextExample}
                   style={styles.button}
-                  label="Next example" />
+                  label="Show another" />
               </div>
-              <div style={styles.exampleSection}>
-                <div style={styles.exampleTitle}>Bad Example</div>
-                <div style={styles.exampleText}>
-                  {nonExamples[nonExampleIndex]}
-                </div>
-                <RaisedButton
-                  onTouchTap={this.onNextNonExample}
-                  style={styles.button}
-                  label="Next example" />
+              <div style={styles.exampleText}>
+                {allExamples[0].text}
               </div>
             </div>
             
             <div style={styles.buttonRow}>
+              
+              <div></div>
               <RaisedButton
                 onTouchTap={this.onHintsToggled}
                 style={styles.button}
@@ -103,36 +91,36 @@ export default React.createClass({
 
 
 const styles = {
-  exampleSection: {
-    display: 'block',
-    marginRight: 10
-  },
   buttonRow: {
     margin: 10,
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center'
   },
   prompt: {
     fontSize: 16,
     fontWeight: 'bold',
-    display: 'inline-block',
   },
-  button: {
-    display: 'inline-block',
-    float: 'right'
-    
+  exampleBox: {
+    display: 'flex',
+    flexDirection: 'column'
   },
-  examplesBox: {
-    display: 'inline-block'
+  exampleTopRow: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 10,
+    marginRight: 10
   },
   exampleTitle: {
     fontSize: 16,
     fontWeight: 'bold',
     marginTop: 6,
     marginBottom: 2,
-    display: 'block',
     clear: 'right'
   },
   exampleText: {
-    display: 'block',
     marginLeft: 10,
     marginRight: 10,
     marginBottom: 10,

--- a/ui/src/message_popup/hint_card.jsx
+++ b/ui/src/message_popup/hint_card.jsx
@@ -1,0 +1,141 @@
+// @flow
+import React from 'react';
+import * as PropTypes from '../prop_types.js';
+import RaisedButton from 'material-ui/RaisedButton';
+import Divider from 'material-ui/Divider';
+
+/*
+Shows a card for a student from the virtual school.
+*/
+export default React.createClass({
+  displayName: 'HintCard',
+
+  getInitialState: function(){
+    return ({
+      hidden: true,
+      exampleIndex: 0,
+      nonExampleIndex: 0,
+    });
+  },
+  
+  propTypes: {
+    examples: React.PropTypes.array.isRequired,
+    nonExamples: React.PropTypes.array.isRequired
+  },
+  
+  onNextExample(){
+    var length = this.props.examples.length;
+    var next = this.state.exampleIndex + 1;
+    if(next >= length){
+      next = 0;
+    }
+    this.setState({exampleIndex: next});
+  },
+  
+  onNextNonExample(){
+    var length = this.props.nonExamples.length;
+    var next = this.state.nonExampleIndex + 1;
+    if(next >= length){
+      next = 0;
+    }
+    this.setState({nonExampleIndex: next});
+  },
+  
+  onHintsToggled(){
+    this.setState({ hidden: !this.state.hidden });
+  },
+
+  render() {
+    const {examples, nonExamples} = this.props;
+    const {hidden, exampleIndex, nonExampleIndex} = this.state;
+    return (
+      <div>
+        {hidden &&
+          (<div>
+            <div style={styles.buttonRow}>
+              <RaisedButton
+                onTouchTap={this.onHintsToggled}
+                style={styles.button}
+                secondary={true}
+                label="Show Examples" />
+              <div style={styles.prompt}>Need a hint?</div>
+            </div>
+          </div>)
+        }
+        {!hidden &&
+          (<div>
+            <div style={styles.examplesBox}>
+              <div style={styles.exampleSection}>
+                <div style={styles.exampleTitle}>Good Example</div>
+                <div style={styles.exampleText}>
+                  {examples[exampleIndex]}
+                </div>
+                <RaisedButton
+                  onTouchTap={this.onNextExample}
+                  style={styles.button}
+                  label="Next example" />
+              </div>
+              <div style={styles.exampleSection}>
+                <div style={styles.exampleTitle}>Bad Example</div>
+                <div style={styles.exampleText}>
+                  {nonExamples[nonExampleIndex]}
+                </div>
+                <RaisedButton
+                  onTouchTap={this.onNextNonExample}
+                  style={styles.button}
+                  label="Next example" />
+              </div>
+            </div>
+            
+            <div style={styles.buttonRow}>
+              <RaisedButton
+                onTouchTap={this.onHintsToggled}
+                style={styles.button}
+                secondary={true}
+                label="Hide Examples" />
+            </div>
+          </div>)
+        }
+      </div>
+    );
+  }
+});
+
+
+const styles = {
+  exampleSection: {
+    display: 'block',
+    marginRight: 10
+  },
+  buttonRow: {
+    margin: 10,
+  },
+  prompt: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    display: 'inline-block',
+  },
+  button: {
+    display: 'inline-block',
+    float: 'right'
+    
+  },
+  examplesBox: {
+    display: 'inline-block'
+  },
+  exampleTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginTop: 6,
+    marginBottom: 2,
+    display: 'block',
+    clear: 'right'
+  },
+  exampleText: {
+    display: 'block',
+    marginLeft: 10,
+    marginRight: 10,
+    marginBottom: 10,
+    fontSize: 14
+  }
+};

--- a/ui/src/message_popup/hint_card.jsx
+++ b/ui/src/message_popup/hint_card.jsx
@@ -49,7 +49,7 @@ export default React.createClass({
         {hidden &&
           (<div>
             <div style={styles.buttonRow}>
-              <div style={styles.prompt}>Need a hint?</div>
+              <div></div>
               <RaisedButton
                 onTouchTap={this.onHintsToggled}
                 style={styles.button}
@@ -61,26 +61,17 @@ export default React.createClass({
         {!hidden &&
           (<div>
             <div style={styles.exampleBox}>
-              <div style={styles.exampleTopRow}>
+              <div style={styles.buttonRow}>
                 <div style={styles.exampleTitle}>{allExamples[0].type} Example</div>
                 <RaisedButton
                   onTouchTap={this.onNextExample}
                   style={styles.button}
+                  secondary={true}
                   label="Show another" />
               </div>
               <div style={styles.exampleText}>
                 {allExamples[0].text}
               </div>
-            </div>
-            
-            <div style={styles.buttonRow}>
-              
-              <div></div>
-              <RaisedButton
-                onTouchTap={this.onHintsToggled}
-                style={styles.button}
-                secondary={true}
-                label="Hide Example" />
             </div>
           </div>)
         }
@@ -93,25 +84,14 @@ export default React.createClass({
 const styles = {
   buttonRow: {
     margin: 10,
+    marginTop: 0,
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center'
   },
-  prompt: {
-    fontSize: 16,
-    fontWeight: 'bold',
-  },
   exampleBox: {
     display: 'flex',
     flexDirection: 'column'
-  },
-  exampleTopRow: {
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 10,
-    marginRight: 10
   },
   exampleTitle: {
     fontSize: 16,

--- a/ui/src/message_popup/hint_card.jsx
+++ b/ui/src/message_popup/hint_card.jsx
@@ -54,7 +54,7 @@ export default React.createClass({
                 onTouchTap={this.onHintsToggled}
                 style={styles.button}
                 secondary={true}
-                label="Show Examples" />
+                label="Show Example" />
             </div>
           </div>)
         }
@@ -80,7 +80,7 @@ export default React.createClass({
                 onTouchTap={this.onHintsToggled}
                 style={styles.button}
                 secondary={true}
-                label="Hide Examples" />
+                label="Hide Example" />
             </div>
           </div>)
         }

--- a/ui/src/message_popup/message_popup_page.jsx
+++ b/ui/src/message_popup/message_popup_page.jsx
@@ -181,7 +181,7 @@ export default React.createClass({
             label="With hints available"
             labelPosition="right"
             toggled={this.state.allowedToToggleHint}
-            onToggle={this.onHintsOptionToggled} /> />
+            onToggle={this.onHintsOptionToggled} />
         </div>
         <Divider />
       </div>

--- a/ui/src/message_popup/message_popup_page.jsx
+++ b/ui/src/message_popup/message_popup_page.jsx
@@ -89,6 +89,10 @@ export default React.createClass({
   onStudentCardsToggled() {
     this.setState({ shouldShowStudentCards: !this.state.shouldShowStudentCards });
   },
+  
+  onHintsOptionToggled(){
+    this.setState({ allowedToToggleHint: !this.state.allowedToToggleHint });
+  },
 
   onTextChanged({target:{value}}:TextChangeEvent) {
     this.setState({ name: value });
@@ -176,8 +180,8 @@ export default React.createClass({
           <Toggle
             label="With hints available"
             labelPosition="right"
-            toggled={false}
-            disabled={true} />
+            toggled={this.state.allowedToToggleHint}
+            onToggle={this.onHintsOptionToggled} /> />
         </div>
         <Divider />
       </div>

--- a/ui/src/message_popup/popup_question.jsx
+++ b/ui/src/message_popup/popup_question.jsx
@@ -112,9 +112,9 @@ export default React.createClass({
 
 const styles = {
   hintCard: {
-    backgroundColor: '',
     marginTop: 5,
-    padding: 10
+    padding: 10,
+    paddingBottom: 0
   },
   studentCard: {
     backgroundColor: '#F1C889',
@@ -126,6 +126,7 @@ const styles = {
     padding: 20
   },
   textAreaContainer: {
+    marginTop: 10,
     margin: 20,
     marginBottom: 10
   },

--- a/ui/src/message_popup/popup_question.jsx
+++ b/ui/src/message_popup/popup_question.jsx
@@ -6,6 +6,7 @@ import RaisedButton from 'material-ui/RaisedButton';
 import TextField from 'material-ui/TextField';
 import TextChangeEvent from '../types/dom_types.js';
 import StudentCard from './student_card.jsx';
+import HintCard from './hint_card.jsx'
 const ONE_SECOND = 1000;
 
 /*
@@ -29,6 +30,8 @@ export default React.createClass({
     limitMs: React.PropTypes.number.isRequired,
     question: React.PropTypes.shape({
       text: React.PropTypes.string.isRequired,
+      examples: React.PropTypes.array.isRequired,
+      nonExamples: React.PropTypes.array.isRequired,
       student: React.PropTypes.object.isRequired
     }).isRequired,
     onResponse: React.PropTypes.func.isRequired
@@ -69,8 +72,8 @@ export default React.createClass({
 
   render() {
     const {elapsedMs} = this.state;
-    const {limitMs, shouldShowStudentCard} = this.props;
-    const {text, student} = this.props.question;
+    const {limitMs, shouldShowStudentCard, allowedToToggleHint} = this.props;
+    const {text, student, examples, nonExamples} = this.props.question;
 
     return (
       <div>
@@ -78,6 +81,10 @@ export default React.createClass({
         {shouldShowStudentCard &&
           <div style={styles.studentCard}>
             <StudentCard student={student} />
+          </div>}
+        {allowedToToggleHint && 
+          <div style={styles.hintCard}>
+            <HintCard examples={examples} nonExamples={nonExamples} />
           </div>}
         <div style={styles.textAreaContainer}>
           <TextField
@@ -104,6 +111,11 @@ export default React.createClass({
 
 
 const styles = {
+  hintCard: {
+    backgroundColor: '',
+    marginTop: 5,
+    padding: 10
+  },
   studentCard: {
     backgroundColor: '#F1C889',
     marginTop: 5,


### PR DESCRIPTION
I added in the toggle hints functionality. The design layout is subject to change but just to keep the text area from being overwhelmed with examples whenever the hints were toggled I decided to display one at a time and have a button to cycle through them.

Below is how the popup looks before the hint is expanded.
![](https://i.gyazo.com/c9880e221756e4a76b055df8bd208c3c.png)

This is the section after it is expanded.
![](https://i.gyazo.com/4cf6c125914ddb1e005c75fb25d41567.png)
