### PR TITLE
Simplify for testing based on in-person changes

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -27,7 +27,6 @@
     "browserify": "^13.0.1",
     "lodash": "^4.13.1",
     "material-ui": "^0.15.0",
-    "querystring": "^0.2.0",
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
     "react-mini-router": "^2.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,6 +27,7 @@
     "browserify": "^13.0.1",
     "lodash": "^4.13.1",
     "material-ui": "^0.15.0",
+    "querystring": "^0.2.0",
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
     "react-mini-router": "^2.0.0",

--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -44,7 +44,7 @@ You need to also keep in mind that Margaret, who is both a colleague and your de
     {
       img: 'http://i-cdn.phonearena.com/images/article/41632-image/Google-Babel-references-appear-in-strings-of-code-pop-up-message.jpg',
       href: '/message_popup?cards&hints',
-      title: 'Message PopUp',
+      title: 'Message PopUp practice',
     },
     {
       img: 'http://cdn.rainbowresource.netdna-cdn.com/products/046383.jpg',
@@ -52,14 +52,9 @@ You need to also keep in mind that Margaret, who is both a colleague and your de
     },
     {
       img: 'http://ecx.images-amazon.com/images/I/41vC9AUIoSL._AC_UL320_SR256,320_.jpg',
-      title: 'Slate about formative assessment',
+      title: 'Slate on Formative Assessment',
       href: '/slate/32'
-    },
-    {
-      img: 'https://www.mursion.com/wp-content/uploads/2015/11/Teacher-Preparation-And-Professional-Development.png',
-      href: 'https://www.mursion.com/',
-      title: 'Mursion',
-    },
+    }
   ]
 }];
 

--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -5,6 +5,7 @@ import {rules} from './routes';
 import ChallengePage from './challenge/challenge_page.jsx';
 import HomePage from './home/home_page.jsx';
 import SlatePage from './slate/slate_page.jsx';
+import CSSTankPage from './csstank/csstank_page.jsx';
 import MessagePopupPage from './message_popup/message_popup_page.jsx'
 
 // material-ui
@@ -38,7 +39,7 @@ You need to also keep in mind that Margaret, who is both a colleague and your de
   ],
   learningExperiences: [{
       img: 'http://www.ballermindframe.com/pop-culture-spin/wp-content/uploads/sites/7/2015/04/sharktank.jpg',
-      href: 'https://rnplay.org/apps/KJBRnQ',
+      href: '/csstank',
       title: 'Cognitive Science Shark Tank',
     },
     {
@@ -48,6 +49,7 @@ You need to also keep in mind that Margaret, who is both a colleague and your de
     },
     {
       img: 'http://cdn.rainbowresource.netdna-cdn.com/products/046383.jpg',
+      href: 'https://docs.google.com/document/d/1DPwL3kXN7F5TWzo5UXCRgnaG5NNAwBVFqHjZa-io9t0/edit?usp=sharing',
       title: 'Inquiry Kit',
     },
     {
@@ -68,7 +70,8 @@ export default React.createClass({
     '/': 'home',
     '/challenge/:id': 'challenge',
     '/message_popup': 'messagePopup',
-    '/slate/:id': 'slate'
+    '/slate/:id': 'slate',
+    '/csstank': 'cssTank'
   },
 
   getInitialState: function() {
@@ -107,6 +110,10 @@ export default React.createClass({
 
   messagePopup(query = {}) {
     return <MessagePopupPage query={query} />;
+  },
+  
+  cssTank(query = {}) {
+    return <CSSTankPage query={query} />;
   },
 
   slate(id, query = {}) {

--- a/ui/src/challenge/challenge_page.jsx
+++ b/ui/src/challenge/challenge_page.jsx
@@ -33,7 +33,6 @@ export default React.createClass({
           <div style={styles.section}>{this.renderScenario()}</div>
           <div style={styles.section}>{this.renderSolution()}</div>
           <div style={styles.section}>{this.renderLearningObjectives()}</div>
-          <div style={styles.section}>{this.renderLearningPlan()}</div>
           <div style={styles.section}>{this.renderLearningExperiences()}</div>
         </div>
       </div>
@@ -145,6 +144,7 @@ const styles = {
     flexDirection: 'column',
     marginTop: 15,
     paddingRight: 10,
+    maxWidth: 800
   },
   challengeTitle: {
     display: 'block',

--- a/ui/src/challenge/challenge_page.jsx
+++ b/ui/src/challenge/challenge_page.jsx
@@ -28,12 +28,6 @@ export default React.createClass({
     const {challenge, user} = this.props;
     return (
       <div style={styles.page}>
-        <div style={styles.menu}>
-          <SideMenu
-            chatUrl={Routes.chatRoom('demo-academy')}
-            videoUrl={Routes.videoFor(challenge.name)}
-            driveUrl={Routes.driveFolder(user.driveFolderId)} />
-        </div>
         <div style={styles.content}>
           <a style={styles.challengeTitle} href={Routes.challengePath(challenge.id)}>{challenge.name} Challenge</a>
           <div style={styles.section}>{this.renderScenario()}</div>
@@ -65,13 +59,6 @@ export default React.createClass({
             secondary={true}
             label="Virtual classroom"
             onTouchTap={Routes.newTab.bind(Routes, 'https://docs.google.com/document/d/1y-F6SdaCLCSMw3GV5pR96MZHcZT2U4aWXXPTnRTd7ts/edit#heading=h.rphe0u4lat3v')} />
-          <FlatButton
-            secondary={true}
-            label="Clarify scenario"
-            onTouchTap={Routes.newTab.bind(Routes, Routes.chatMessage('ejspang'))} />
-          <div style={styles.driveContainer}>
-            <iframe src={`${Routes.embeddedDriveList(driveFolderId)}#list`} style={styles.driveIframe}></iframe>
-          </div>
         </CardActions>
       </Card>
     );
@@ -91,13 +78,14 @@ export default React.createClass({
         <CardActions expandable={true}>
           <FlatButton
             label="Lesson Sketch"
+            disabled={true}
             secondary={true}
             onTouchTap={Routes.newTab.bind(Routes, 'https://docs.google.com/document/d/1y-F6SdaCLCSMw3GV5pR96MZHcZT2U4aWXXPTnRTd7ts/edit#heading=h.yuqrdnz6q8dr')} />
           <FlatButton
             label="Message PopUp"
             secondary={true}
             linkButton={true}
-            href={Routes.messagePopupPath()} />
+            href={Routes.messagePopupSolutionPath()} />
         </CardActions>
       </Card>
     );
@@ -116,24 +104,6 @@ export default React.createClass({
         <CardText expandable={true}>
           <LearningObjectivesTable learningObjectives={learningObjectives} />
         </CardText>
-      </Card>
-    );
-  },
-
-  renderLearningPlan() {
-    return (
-      <Card
-        initiallyExpanded={false}>
-        <CardHeader
-          title="Learning Plan"
-          titleStyle={styles.cardTitleHeader}
-          subtitle="Make your plan and get feedback"
-          actAsExpander={true}
-          showExpandableButton={true}
-        />
-        <CardActions expandable={true}>
-          <LearningPlan />
-        </CardActions>
       </Card>
     );
   },
@@ -164,7 +134,8 @@ const styles = {
   page: {
     display: 'flex',
     flexDirection: 'row',
-    backgroundColor: '#5481a9'
+    backgroundColor: '#5481a9',
+    padding: 20
   },
   menu: {
     marginLeft: 10,

--- a/ui/src/challenge/learning_experiences_grid.jsx
+++ b/ui/src/challenge/learning_experiences_grid.jsx
@@ -23,7 +23,7 @@ export default React.createClass({
         {learningExperiences.map((tile, index) => {
           const key = `${tile.img}-${index}`;
           return (
-            <a key={key} href={tile.href || null}>
+            <a key={key} target="_blank" href={tile.href || null}>
               <GridTile
                 key={key}
                 title={tile.title}

--- a/ui/src/csstank/csstank_page.jsx
+++ b/ui/src/csstank/csstank_page.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+
+export default React.createClass({
+  displayName: 'CSSTankPage',
+
+  propTypes: {},
+
+  render() {
+    return (
+      <div style={styles.pageContainer}>
+        <h1>Cognitive Science Shark Tank</h1>
+        Meet in-person in the conference room at 10am!
+      </div>
+    );
+  }
+});
+
+const styles = {
+  pageContainer: {
+    padding: 20
+  }
+};

--- a/ui/src/message_popup/message_popup_page.jsx
+++ b/ui/src/message_popup/message_popup_page.jsx
@@ -54,11 +54,12 @@ export default React.createClass({
   getInitialState: function() {
     const questions = randomizedQuestionsWithStudents();
     const {query} = this.props;
-    
+
     return {
       name: '',
-      shouldShowStudentCards: query.cards || false,
-      allowedToToggleHint: query.hints || false,
+      shouldShowStudentCards: !query.solution && query.cards || false,
+      allowedToToggleHint: !query.solution && query.hints || false,
+      isSolutionMode: query.solution || false,
       hasStarted: false,
       totalQuestions: Math.min(10, questions.length),
       questionsAnswered: 0,
@@ -73,10 +74,11 @@ export default React.createClass({
   onResponse(response:Response) {
     const logFn = (window.location.host.indexOf('localhost') === 0)
       ? logLocalStorage : logDatabase;
-    logFn(Object.assign(response, {
+    logFn({
+      ...response,
       name: this.state.name,
       clientTimestampMs: new Date().getTime()
-    }));
+    });
     this.setState({ questionsAnswered: this.state.questionsAnswered + 1 });
   },
 
@@ -138,26 +140,7 @@ export default React.createClass({
         <p style={styles.paragraph}>You may be asked to write, sketch or say your responses aloud.</p>
         <p style={styles.paragraph}>Each question is timed to simulate responding in the moment in the classroom.  You'll have 60 seconds to respond to each question.</p>
         <Divider />
-        <div style={{}}>
-          <div style={{fontSize: 16, padding: 20}}>
-            <Toggle
-              label="With student cards"
-              labelPosition="right"
-              toggled={this.state.shouldShowStudentCards}
-              onToggle={this.onStudentCardsToggled} />
-            <Toggle
-              label="With feeback and revision"
-              labelPosition="right"
-              toggled={false}
-              disabled={true}  />
-            <Toggle
-              label="With hints available"
-              labelPosition="right"
-              toggled={false}
-              disabled={true} />
-          </div>
-        </div>
-        <Divider />
+        {!this.state.isSolutionMode && this.renderScaffoldingOptions()}
         <TextField
           underlineShow={false}
           floatingLabelText="What's your name?"
@@ -172,6 +155,31 @@ export default React.createClass({
             primary={true}
             label="Start" />
         </div>
+      </div>
+    );
+  },
+
+  renderScaffoldingOptions() {
+    return (
+      <div>
+        <div style={{fontSize: 16, padding: 20}}>
+          <Toggle
+            label="With student cards"
+            labelPosition="right"
+            toggled={this.state.shouldShowStudentCards}
+            onToggle={this.onStudentCardsToggled} />
+          <Toggle
+            label="With feeback and revision"
+            labelPosition="right"
+            toggled={false}
+            disabled={true}  />
+          <Toggle
+            label="With hints available"
+            labelPosition="right"
+            toggled={false}
+            disabled={true} />
+        </div>
+        <Divider />
       </div>
     );
   }

--- a/ui/src/routes.js
+++ b/ui/src/routes.js
@@ -2,7 +2,6 @@
 /*
 Navigation functions
 */
-import queryString from 'querystring';
 import ReactMiniRouter from 'react-mini-router';
 export const navigate = ReactMiniRouter.navigate;
 export function newTab(url:string):void {

--- a/ui/src/routes.js
+++ b/ui/src/routes.js
@@ -2,6 +2,7 @@
 /*
 Navigation functions
 */
+import queryString from 'querystring';
 import ReactMiniRouter from 'react-mini-router';
 export const navigate = ReactMiniRouter.navigate;
 export function newTab(url:string):void {
@@ -19,6 +20,10 @@ export function challengePath(id:number):string {
 
 export function messagePopupPath() {
   return `/message_popup`;
+}
+
+export function messagePopupSolutionPath() {
+  return `/message_popup?solution`;
 }
 
 


### PR DESCRIPTION
This has a set of small changes intended to simplify this experience for use in testing next week.

Mostly this involves removing pieces of the UI that won't be used or revising links or copy.

There's also some tweaks to the params in Message PopUp to allow linking to it in "solution" mode with a querystring where no scaffolding is allowed:
<img width="475" alt="screen shot 2016-06-17 at 2 47 44 pm" src="https://cloud.githubusercontent.com/assets/1056957/16161565/362a1e64-349c-11e6-81b0-3339649c24fb.png">

<img width="462" alt="screen shot 2016-06-17 at 2 49 00 pm" src="https://cloud.githubusercontent.com/assets/1056957/16161506/d4927840-349b-11e6-82fe-f4f36b9fe15a.png">
