### PR TITLE
Swap Babel config to use preset stage-2 instead of just object spread

### DIFF
--- a/ui/.babelrc
+++ b/ui/.babelrc
@@ -1,10 +1,9 @@
 {
-  "presets": ["react", "es2015"],
+  "presets": ["react", "es2015", "stage-2"],
   "env": {
     "development": {
       "plugins": [
         ["transform-flow-strip-types"],
-        ["transform-object-rest-spread"],
         ["react-transform", {
           "transforms": [{
             "transform": "livereactload/babel-transform",

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,9 +20,9 @@
   "homepage": "https://github.com/mit-teaching-systems-lab/threeflows#readme",
   "dependencies": {
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
-    "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-2": "^6.5.0",
     "babelify": "^7.3.0",
     "browserify": "^13.0.1",
     "lodash": "^4.13.1",


### PR DESCRIPTION
Trying to debug https://dashboard.heroku.com/apps/threeflows/activity/builds/92d23657-df2e-490c-b2e8-24ba18cf4cf2, not quite sure why it's failing in Heroku.