### PR TITLE
Revising animation for showing examples

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -34,6 +34,7 @@
     "react-tap-event-plugin": "^1.0.0",
     "reactify": "^1.1.1",
     "superagent": "^2.0.0",
+    "velocity-animate": "^1.2.3",
     "velocity-react": "^1.1.5",
     "watchify": "3.7.0"
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,6 +34,7 @@
     "react-tap-event-plugin": "^1.0.0",
     "reactify": "^1.1.1",
     "superagent": "^2.0.0",
+    "velocity-react": "^1.1.5",
     "watchify": "3.7.0"
   },
   "devDependencies": {

--- a/ui/src/data/challenges.js
+++ b/ui/src/data/challenges.js
@@ -14,7 +14,7 @@ export const challenges = [{
     },
     {
       img: 'http://i-cdn.phonearena.com/images/article/41632-image/Google-Babel-references-appear-in-strings-of-code-pop-up-message.jpg',
-      href: '/message_popup?cards&hints',
+      href: '/message_popup?cards',
       title: 'Message PopUp practice',
     },
     {

--- a/ui/src/message_popup/hint_card.jsx
+++ b/ui/src/message_popup/hint_card.jsx
@@ -56,18 +56,16 @@ export default React.createClass({
         )}
         <VelocityTransitionGroup enter={{animation: "slideDown"}} runOnMount={true}>
           {!hidden && (
-            <div key="visible">
-              <div key={allExamples[0].text} style={styles.exampleBox}>
-                <div style={styles.buttonRow}>
-                  <div style={styles.exampleTitle}>{allExamples[0].type} Example</div>
-                  <RaisedButton
-                    onTouchTap={this.onNextExample}
-                    secondary={true}
-                    label="Show another" />
-                </div>
-                <div style={styles.exampleText}>
-                  {allExamples[0].text}
-                </div>
+            <div key={allExamples[0].text} style={styles.exampleBox}>
+              <div style={styles.buttonRow}>
+                <div style={styles.exampleTitle}>{allExamples[0].type} Example</div>
+                <RaisedButton
+                  onTouchTap={this.onNextExample}
+                  secondary={true}
+                  label="Show another" />
+              </div>
+              <div style={styles.exampleText}>
+                {allExamples[0].text}
               </div>
             </div>
           )}

--- a/ui/src/message_popup/hint_card.jsx
+++ b/ui/src/message_popup/hint_card.jsx
@@ -1,3 +1,4 @@
+//@flow
 import React from 'react';
 import _ from 'lodash';
 import RaisedButton from 'material-ui/RaisedButton';
@@ -43,39 +44,33 @@ export default React.createClass({
   render() {
     const {hidden, allExamples} = this.state;
     return (
-      <div>
-        <VelocityTransitionGroup leave={{animation: "slideUp"}} runOnMount={true}>
-          {hidden &&
-            (<div>
-              <div style={styles.buttonRow}>
-                <div></div>
-                <RaisedButton
-                  onTouchTap={this.onHintsToggled}
-                  style={styles.button}
-                  secondary={true}
-                  label="Show Example" />
-              </div>
-            </div>)
-          }
-        </VelocityTransitionGroup>
-        <VelocityTransitionGroup enter={{animation: "fadeIn"}} runOnMount={true}>
-          {!hidden &&
-            (<div>
-                <div style={styles.exampleBox}>
-                  <div style={styles.buttonRow}>
-                    <div style={styles.exampleTitle}>{allExamples[0].type} Example</div>
-                    <RaisedButton
-                      onTouchTap={this.onNextExample}
-                      style={styles.button}
-                      secondary={true}
-                      label="Show another" />
-                  </div>
-                  <div style={styles.exampleText}>
-                    {allExamples[0].text}
-                  </div>
+      <div className="HintCard">
+        {hidden && (
+          <div style={styles.buttonRow}>
+            <div />
+            <RaisedButton
+              onTouchTap={this.onHintsToggled}
+              secondary={true}
+              label="Show Example" />
+          </div>
+        )}
+        <VelocityTransitionGroup enter={{animation: "slideDown"}} runOnMount={true}>
+          {!hidden && (
+            <div key="visible">
+              <div key={allExamples[0].text} style={styles.exampleBox}>
+                <div style={styles.buttonRow}>
+                  <div style={styles.exampleTitle}>{allExamples[0].type} Example</div>
+                  <RaisedButton
+                    onTouchTap={this.onNextExample}
+                    secondary={true}
+                    label="Show another" />
                 </div>
-            </div>)
-          }
+                <div style={styles.exampleText}>
+                  {allExamples[0].text}
+                </div>
+              </div>
+            </div>
+          )}
         </VelocityTransitionGroup>
       </div>
     );
@@ -88,8 +83,7 @@ const styles = {
     margin: 10,
     marginTop: 0,
     display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center'
+    justifyContent: 'space-between'
   },
   exampleBox: {
     display: 'flex',

--- a/ui/src/message_popup/hint_card.jsx
+++ b/ui/src/message_popup/hint_card.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import _ from 'lodash';
 import RaisedButton from 'material-ui/RaisedButton';
+import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
 
 /*
 This shows a hint in the form of a toggleable good or bad example response
@@ -43,35 +44,39 @@ export default React.createClass({
     const {hidden, allExamples} = this.state;
     return (
       <div>
-        {hidden &&
-          (<div>
-            <div style={styles.buttonRow}>
-              <div></div>
-              <RaisedButton
-                onTouchTap={this.onHintsToggled}
-                style={styles.button}
-                secondary={true}
-                label="Show Example" />
-            </div>
-          </div>)
-        }
-        {!hidden &&
-          (<div>
-            <div style={styles.exampleBox}>
+        <VelocityTransitionGroup leave={{animation: "slideUp"}} runOnMount={true}>
+          {hidden &&
+            (<div>
               <div style={styles.buttonRow}>
-                <div style={styles.exampleTitle}>{allExamples[0].type} Example</div>
+                <div></div>
                 <RaisedButton
-                  onTouchTap={this.onNextExample}
+                  onTouchTap={this.onHintsToggled}
                   style={styles.button}
                   secondary={true}
-                  label="Show another" />
+                  label="Show Example" />
               </div>
-              <div style={styles.exampleText}>
-                {allExamples[0].text}
-              </div>
-            </div>
-          </div>)
-        }
+            </div>)
+          }
+        </VelocityTransitionGroup>
+        <VelocityTransitionGroup enter={{animation: "fadeIn"}} runOnMount={true}>
+          {!hidden &&
+            (<div>
+                <div style={styles.exampleBox}>
+                  <div style={styles.buttonRow}>
+                    <div style={styles.exampleTitle}>{allExamples[0].type} Example</div>
+                    <RaisedButton
+                      onTouchTap={this.onNextExample}
+                      style={styles.button}
+                      secondary={true}
+                      label="Show another" />
+                  </div>
+                  <div style={styles.exampleText}>
+                    {allExamples[0].text}
+                  </div>
+                </div>
+            </div>)
+          }
+        </VelocityTransitionGroup>
       </div>
     );
   }

--- a/ui/src/message_popup/message_popup_page.jsx
+++ b/ui/src/message_popup/message_popup_page.jsx
@@ -15,7 +15,7 @@ import {allStudents} from '../data/virtual_school.js';
 import {learningObjectives} from '../data/learning_objectives.js';
 import {allQuestions} from './questions.js';
 import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
-import * as VelocityUIPack from 'velocity-animate/velocity.ui';
+import 'velocity-animate/velocity.ui';
 
 const ALL_COMPETENCY_GROUPS = 'ALL_COMPETENCY_GROUPS';
 

--- a/ui/src/message_popup/message_popup_page.jsx
+++ b/ui/src/message_popup/message_popup_page.jsx
@@ -15,6 +15,7 @@ import {allStudents} from '../data/virtual_school.js';
 import {learningObjectives} from '../data/learning_objectives.js';
 import {allQuestions} from './questions.js';
 import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
+import * as VelocityUIPack from 'velocity-animate/velocity.ui';
 
 const ALL_COMPETENCY_GROUPS = 'ALL_COMPETENCY_GROUPS';
 
@@ -179,7 +180,7 @@ export default React.createClass({
 
   renderInstructions() {
     return (
-      <VelocityTransitionGroup enter={{animation: "slideDown"}} leave={{animation: "slideUp"}} runOnMount={true}>
+      <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
         <div style={_.merge(_.clone(styles.container), styles.instructions)}>
           <div style={styles.title}>Message Popup</div>
           {this.state.isSolutionMode &&

--- a/ui/src/message_popup/message_popup_page.jsx
+++ b/ui/src/message_popup/message_popup_page.jsx
@@ -165,7 +165,7 @@ export default React.createClass({
   renderDone() {
     return (
       <VelocityTransitionGroup enter={{animation: "slideDown"}} leave={{animation: "slideUp"}} runOnMount={true}>
-        <div style={_.merge(styles.done, styles.container)}>
+        <div style={_.merge(_.clone(styles.container), styles.done)}>
           <div>You finished!</div>
           <RaisedButton
             onTouchTap={this.onDonePressed}
@@ -180,7 +180,7 @@ export default React.createClass({
   renderInstructions() {
     return (
       <VelocityTransitionGroup enter={{animation: "slideDown"}} leave={{animation: "slideUp"}} runOnMount={true}>
-        <div style={_.merge(styles.instructions, styles.container)}>
+        <div style={_.merge(_.clone(styles.container), styles.instructions)}>
           <div style={styles.title}>Message Popup</div>
           {this.state.isSolutionMode &&
             <p style={styles.paragraph}>Clear 15 minutes.  Your work is timed, so being able to focus is important.</p>
@@ -266,16 +266,23 @@ export default React.createClass({
 
 const styles = {
   done: {
-    padding: 20
+    padding: 20,
+    width: 360
   },
   instructions: {
-    padding: 20
+    padding: 20,
+    width: 360
   },
   container: {
     border: '1px solid #ccc',
     margin: 20,
     width: 400,
+<<<<<<< aaa8a8f1aa06a06987385121aac172009fd395b9
     fontSize: 20
+=======
+    fontSize: 18,
+    padding: 0
+>>>>>>> Fixed sizing of instructions and done page in message_popup to match that of the question's page
   },
   title: {
     fontSize: 24,

--- a/ui/src/message_popup/message_popup_page.jsx
+++ b/ui/src/message_popup/message_popup_page.jsx
@@ -277,12 +277,8 @@ const styles = {
     border: '1px solid #ccc',
     margin: 20,
     width: 400,
-<<<<<<< aaa8a8f1aa06a06987385121aac172009fd395b9
-    fontSize: 20
-=======
-    fontSize: 18,
+    fontSize: 20,
     padding: 0
->>>>>>> Fixed sizing of instructions and done page in message_popup to match that of the question's page
   },
   title: {
     fontSize: 24,

--- a/ui/src/message_popup/message_popup_page.jsx
+++ b/ui/src/message_popup/message_popup_page.jsx
@@ -14,6 +14,7 @@ import TextChangeEvent from '../types/dom_types.js';
 import {allStudents} from '../data/virtual_school.js';
 import {learningObjectives} from '../data/learning_objectives.js';
 import {allQuestions} from './questions.js';
+import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
 
 const ALL_COMPETENCY_GROUPS = 'ALL_COMPETENCY_GROUPS';
 
@@ -147,57 +148,63 @@ export default React.createClass({
     const question = this.state.questions[questionsAnswered];
     return (
       <div style={styles.container}>
-        <PopupQuestion
-          key={JSON.stringify(question)}
-          question={question}
-          shouldShowStudentCard={shouldShowStudentCards}
-          helpType={helpType}
-          limitMs={90000}
-          onLog={this.onLog}
-          onDone={this.onQuestionDone}/>
+        <VelocityTransitionGroup enter={{animation: "slideDown"}} leave={{animation: "slideUp"}} runOnMount={true}>
+          <PopupQuestion
+            key={JSON.stringify(question)}
+            question={question}
+            shouldShowStudentCard={shouldShowStudentCards}
+            helpType={helpType}
+            limitMs={90000}
+            onLog={this.onLog}
+            onDone={this.onQuestionDone}/>
+        </VelocityTransitionGroup>
       </div>
     );
   },
 
   renderDone() {
     return (
-      <div style={_.merge(styles.done, styles.container)}>
-        <div>You finished!</div>
-        <RaisedButton
-          onTouchTap={this.onDonePressed}
-          style={styles.button}
-          primary={true}
-          label="Done" />
-      </div>
+      <VelocityTransitionGroup enter={{animation: "slideDown"}} leave={{animation: "slideUp"}} runOnMount={true}>
+        <div style={_.merge(styles.done, styles.container)}>
+          <div>You finished!</div>
+          <RaisedButton
+            onTouchTap={this.onDonePressed}
+            style={styles.button}
+            primary={true}
+            label="Done" />
+        </div>
+      </VelocityTransitionGroup>
     );
   },
 
   renderInstructions() {
     return (
-      <div style={_.merge(styles.instructions, styles.container)}>
-        <div style={styles.title}>Message Popup</div>
-        {this.state.isSolutionMode &&
-          <p style={styles.paragraph}>Clear 15 minutes.  Your work is timed, so being able to focus is important.</p>
-        }
-        <p style={styles.paragraph}>You may be asked to write, sketch or say your responses aloud.</p>
-        <p style={styles.paragraph}>Each question is timed to simulate responding in the moment in the classroom.  You'll have 90 seconds to respond to each question.</p>
-        <Divider />
-        {!this.state.isSolutionMode && this.renderScaffoldingOptions()}
-        <TextField
-          underlineShow={false}
-          floatingLabelText="What's your name?"
-          onChange={this.onTextChanged}
-          multiLine={true}
-          rows={2}/>
-        <div style={{display: 'flex', flexDirection: 'row', alignItems: 'flex-end'}}>
-          <RaisedButton
-            disabled={this.state.name === ''}
-            onTouchTap={this.onStartPressed}
-            style={styles.button}
-            primary={true}
-            label="Start" />
+      <VelocityTransitionGroup enter={{animation: "slideDown"}} leave={{animation: "slideUp"}} runOnMount={true}>
+        <div style={_.merge(styles.instructions, styles.container)}>
+          <div style={styles.title}>Message Popup</div>
+          {this.state.isSolutionMode &&
+            <p style={styles.paragraph}>Clear 15 minutes.  Your work is timed, so being able to focus is important.</p>
+          }
+          <p style={styles.paragraph}>You may be asked to write, sketch or say your responses aloud.</p>
+          <p style={styles.paragraph}>Each question is timed to simulate responding in the moment in the classroom.  You'll have 90 seconds to respond to each question.</p>
+          <Divider />
+          {!this.state.isSolutionMode && this.renderScaffoldingOptions()}
+          <TextField
+            underlineShow={false}
+            floatingLabelText="What's your name?"
+            onChange={this.onTextChanged}
+            multiLine={true}
+            rows={2}/>
+          <div style={{display: 'flex', flexDirection: 'row', alignItems: 'flex-end'}}>
+            <RaisedButton
+              disabled={this.state.name === ''}
+              onTouchTap={this.onStartPressed}
+              style={styles.button}
+              primary={true}
+              label="Start" />
+          </div>
         </div>
-      </div>
+      </VelocityTransitionGroup>
     );
   },
 

--- a/ui/src/message_popup/popup_question.jsx
+++ b/ui/src/message_popup/popup_question.jsx
@@ -7,6 +7,7 @@ import HintCard from './hint_card.jsx';
 import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 import FeedbackCard from './feedback_card.jsx';
+import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
 const ONE_SECOND = 1000;
 
 /*
@@ -144,14 +145,16 @@ export default React.createClass({
             <div style={styles.ticker}>{secondsRemaining}s</div>
           }
         </div>
-        {this.state.isRevising &&
-          <div style={styles.feedbackCard}>
-            <FeedbackCard
-              initialResponseText={this.state.initialResponseText}
-              onRevised={this.onRevised}
-              onPassed={this.onPassed}
-              examples={examples}/>  
-          </div>}
+        <VelocityTransitionGroup enter={{animation: "slideDown"}} runOnMount={true}>
+          {this.state.isRevising &&
+            <div style={styles.feedbackCard}>
+              <FeedbackCard
+                initialResponseText={this.state.initialResponseText}
+                onRevised={this.onRevised}
+                onPassed={this.onPassed}
+                examples={examples}/>  
+            </div>}
+        </VelocityTransitionGroup>
       </div>
     );
   }


### PR DESCRIPTION
@david-rosales To be able to merge this tonight before tomorrow morning, I took your awesome work in https://github.com/mit-teaching-systems-lab/threeflows/pull/32 and rebased it and resolved the merge conflicts, and then revised the way the "show another" animation looks so it slides down on the first one.

This also adds a little pop effect when you first start the game, let me know what you think of these and if there's other ways to make this feel more engaging and human :)