### PR TITLE
Fix syntax error on new tab for Message Pop solution

### DIFF
--- a/ui/src/challenge/challenge_page.jsx
+++ b/ui/src/challenge/challenge_page.jsx
@@ -84,7 +84,7 @@ export default React.createClass({
           <FlatButton
             label="Message PopUp"
             secondary={true}
-            onTouchTap={Routes.newTab.bind(Routes, Routes.messagePopupSolutionPath()} />
+            onTouchTap={Routes.newTab.bind(Routes, Routes.messagePopupSolutionPath())} />
         </CardText>
       </Card>
     );


### PR DESCRIPTION
Typo from changing https://github.com/mit-teaching-systems-lab/threeflows/pull/38 in the GitHub UI, woops!