### PR TITLE
Remove localStorage evidence, add broadcast to Slack

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "body-parser": "^1.15.1",
     "express": "4.13.3",
     "lodash": "^4.13.1",
-    "pg": "^5.1.0"
+    "pg": "^5.1.0",
+    "superagent": "^2.0.0"
   },
   "keywords": [],
   "license": "MIT",

--- a/ui/src/message_popup/message_popup_page.jsx
+++ b/ui/src/message_popup/message_popup_page.jsx
@@ -39,15 +39,6 @@ function questionsForCompetencies(competencyGroup) {
   return _.shuffle(withStudents(withCompetencyGroups));
 }
 
-function logLocalStorage(type, record) {
-  const KEY = 'messagePopupResponses';
-  const string = window.localStorage.getItem(KEY);
-  const records = string ? JSON.parse(string) : [];
-  const updatedRecords = records.concat(record);
-  const updatedString = JSON.stringify(updatedRecords);
-  window.localStorage.setItem(KEY, updatedString);
-}
-
 // For now, this fires and forgets and does not retry or
 // notify the user on success or failure.
 function logDatabase(type, record) {
@@ -106,9 +97,7 @@ export default React.createClass({
   },
 
   onLog(type, response:Response) {
-    const logFn = (window.location.host.indexOf('localhost') === 0)
-      ? logLocalStorage : logDatabase;
-    logFn(type, {
+    logDatabase(type, {
       ...response,
       name: this.state.name,
       clientTimestampMs: new Date().getTime()


### PR DESCRIPTION
This removes `localStorage` evidence collection from the UI, updates the server to work locally when there is no database and also adds an integration to broadcast evidence events in Slack (for observing testing).

Things should work the same locally, other than local storage and we should see new behavior in production after adding the Slack env variable.