### PR TITLE
Add query endpoint back with basic auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build
 npm-debug.log.*
 node_modules
+tmp

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "cd ui && npm run test"
   },
   "dependencies": {
+    "basic-auth": "^1.0.4",
     "body-parser": "^1.15.1",
     "express": "4.13.3",
     "lodash": "^4.13.1",


### PR DESCRIPTION
Expose this for easy exploration and prototyping of scoring UIs, but put the tiniest barrier to access.  There's no real security yet since this is all friendly internal testing with nothing sensitive, but we'll likely add that for the next test.