### PR TITLE
Add ui/node_modules to Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,8 @@ branches:
 
 before_script:
   - npm run heroku-prebuild
+
+cache:
+  directories:
+    - node_modules
+    - ui/node_modules


### PR DESCRIPTION
Trying to speed up the build, the `$ ui/npm install` currently takes ~48s out of 79s: https://travis-ci.org/mit-teaching-systems-lab/threeflows/builds/139871417