### PR TITLE
Refactoring the Instructions and Scaffolds to separate files

### DIFF
--- a/ui/src/data/challenges.js
+++ b/ui/src/data/challenges.js
@@ -16,7 +16,7 @@ export const challenges = [{
     },
     {
       img: 'http://i-cdn.phonearena.com/images/article/41632-image/Google-Babel-references-appear-in-strings-of-code-pop-up-message.jpg',
-      href: '/message_popup?cards',
+      href: '/message_popup?basic',
       title: 'Message PopUp practice',
     },
     {

--- a/ui/src/message_popup/experience_page.jsx
+++ b/ui/src/message_popup/experience_page.jsx
@@ -21,7 +21,6 @@ import InstructionsCard from './instructions_card.jsx';
 
 const ALL_COMPETENCY_GROUPS = 'ALL_COMPETENCY_GROUPS';
 
-
 /*
 Shows the MessagePopup game
 */
@@ -35,11 +34,11 @@ export default React.createClass({
   getInitialState: function() {
     const isSolutionMode = _.has(this.props.query, 'solution');
     const helpType = isSolutionMode ? 'none' : 'feedback';
-    const shouldShowStudentCards = isSolutionMode ? _.has(this.props.query, 'cards') : true;
+    const shouldShowStudentCard = isSolutionMode ? _.has(this.props.query, 'cards') : true;
     const shouldShowSummary = !isSolutionMode;
     const sessionId = uuid.v4();
     return {
-      shouldShowStudentCards,
+      shouldShowStudentCard,
       shouldShowSummary,
       helpType,
       isSolutionMode,
@@ -56,10 +55,14 @@ export default React.createClass({
     };
   },
 
-  onStartPressed() {
-    const questions = this.getQuestions();
+  onStartPressed(name, sessionLength, questions, shouldShowStudentCard,shouldShowSummary, helpType) {
     this.setState({
+      name,
+      sessionLength,
       questions,
+      shouldShowStudentCard,
+      shouldShowSummary,
+      helpType,
       hasStarted: true
     });
   },
@@ -76,28 +79,6 @@ export default React.createClass({
   
   addResponseTime(time){
     this.setState({responseTimes: this.state.responseTimes.concat(time)});
-  },
-  
-  getQuestions(competencyGroup=""){
-    var {competencyGroupValue, isSolutionMode} = this.state;
-    if(competencyGroup !== ""){
-      competencyGroupValue = competencyGroup;
-    }
-    const questions = (isSolutionMode || competencyGroupValue === ALL_COMPETENCY_GROUPS)
-      ? _.shuffle(withStudents(allQuestions))
-      : questionsForCompetencies(competencyGroupValue);
-    return questions;
-  },
-
-  onCompetencyGroupChanged(e, competencyGroupValue) {
-    const questions = this.getQuestions(competencyGroupValue);
-    const newLength = questions.length;
-    var sessionLength = this.state.sessionLength;
-    if(sessionLength > newLength){
-      sessionLength = newLength;
-    }
-    this.setState({questions, competencyGroupValue, sessionLength});
-    
   },
 
   onLog(type, response:Response) {
@@ -119,32 +100,12 @@ export default React.createClass({
     Routes.navigate(Routes.Home);
   },
 
-  onStudentCardsToggled() {
-    this.setState({ shouldShowStudentCards: !this.state.shouldShowStudentCards });
-  },
-  
-  onSummaryToggled(){
-    this.setState({ shouldShowSummary: !this.state.shouldShowSummary });
-  },
-  
-  onHelpToggled(event, value){
-    this.setState({ helpType: value});
-  },
-  
-  onSliderChange(event, value){
-    this.setState({ sessionLength: value});
-  },
-  
-  onTextChanged({target:{value}}:TextChangeEvent) {
-    this.setState({ name: value });
-  },
-
   render() {
     const {
       hasStarted,
       questions,
       questionsAnswered,
-      shouldShowStudentCards,
+      shouldShowStudentCard,
       shouldShowSummary,
       helpType,
       sessionLength
@@ -160,7 +121,7 @@ export default React.createClass({
           <PopupQuestion
             key={JSON.stringify(question)}
             question={question}
-            shouldShowStudentCard={shouldShowStudentCards}
+            shouldShowStudentCard={shouldShowStudentCard}
             shouldShowSummary={shouldShowSummary}
             helpType={helpType}
             limitMs={this.state.limitMs}
@@ -198,28 +159,9 @@ export default React.createClass({
   },
 
   renderInstructions() {
-    const {isSolutionMode, name, competencyGroupValue, sessionLength, questions, shouldShowStudentCards, shouldShowSummary, helpType} = this.state;
-    const competencyGroups = _.uniq(_.map(allQuestions, 'learningObjectiveId')).map((id) => {
-      return _.find(learningObjectives, {id}).competencyGroup;
-    });
     return (
       <InstructionsCard 
-        isSolutionMode={isSolutionMode}
-        onTextChanged={this.onTextChanged}
         onStartPressed={this.onStartPressed}
-        name={name}
-        competencyGroupValue={competencyGroupValue}
-        competencyGroups={competencyGroups}
-        onCompetencyGroupChanged={this.onCompetencyGroupChanged}
-        sessionLength={sessionLength}
-        questions={questions}
-        onSliderChange={this.onSliderChange}
-        shouldShowStudentCards={shouldShowStudentCards}
-        onStudentCardsToggled={this.onStudentCardsToggled}
-        shouldShowSummary={shouldShowSummary}
-        onSummaryToggled={this.onSummaryToggled}
-        helpType={helpType}
-        onHelpToggled={this.onHelpToggled}
         itemsToShow={this.props.query}
         />);
   }

--- a/ui/src/message_popup/experience_page.jsx
+++ b/ui/src/message_popup/experience_page.jsx
@@ -4,13 +4,9 @@ import React from 'react';
 import * as Routes from '../routes';
 import type {Response} from './popup_question.jsx';
 import RaisedButton from 'material-ui/RaisedButton';
-import Toggle from 'material-ui/Toggle';
 import Divider from 'material-ui/Divider';
 import PopupQuestion from './popup_question.jsx';
-import TextField from 'material-ui/TextField';
-import {RadioButton, RadioButtonGroup} from 'material-ui/RadioButton';
 import LinearProgress from 'material-ui/LinearProgress';
-import Slider from 'material-ui/Slider';
 import Snackbar from 'material-ui/Snackbar';
 import TextChangeEvent from '../types/dom_types.js';
 import {learningObjectives} from '../data/learning_objectives.js';
@@ -21,6 +17,7 @@ import * as Api from '../helpers/api.js';
 import 'velocity-animate/velocity.ui';
 import uuid from 'node-uuid';
 import FinalSummaryCard from './final_summary_card.jsx';
+import InstructionsCard from './instructions_card.jsx';
 
 const ALL_COMPETENCY_GROUPS = 'ALL_COMPETENCY_GROUPS';
 
@@ -38,9 +35,6 @@ export default React.createClass({
   getInitialState: function() {
     const isSolutionMode = _.has(this.props.query, 'solution');
     const helpType = isSolutionMode ? 'none' : 'feedback';
-    //I changed the bottom to true since the feedback listed it as a bug but I thought that not
-    //showing the student cards in solution mode was the initial intention since the users would
-    //have known each of the students by then..?
     const shouldShowStudentCards = isSolutionMode ? _.has(this.props.query, 'cards') : true;
     const shouldShowSummary = !isSolutionMode;
     const sessionId = uuid.v4();
@@ -204,111 +198,35 @@ export default React.createClass({
   },
 
   renderInstructions() {
-    return (
-      <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
-        <div style={_.merge(_.clone(styles.container), styles.instructions)}>
-          <div style={styles.title}>Message Popup</div>
-          {this.state.isSolutionMode &&
-            <p style={styles.paragraph}>Clear 15 minutes.  Your work is timed, so being able to focus is important.</p>
-          }
-          {!this.state.isSolutionMode && 
-            <p style={styles.paragraph}>This will feel uncomfortable at first, but better to get comfortable here than with real students.</p>
-          }
-          <p style={styles.paragraph}>You may be asked to write, sketch or say your responses aloud.</p>
-          <p style={styles.paragraph}>Each question is timed to simulate responding in the moment in the classroom.  You'll have 90 seconds to respond to each question.</p>
-          <Divider />
-          {!this.state.isSolutionMode && this.renderScaffoldingOptions()}
-          <TextField
-            underlineShow={false}
-            floatingLabelText="What's your name?"
-            onChange={this.onTextChanged}
-            multiLine={true}
-            rows={2}/>
-          <div style={{display: 'flex', flexDirection: 'row', alignItems: 'flex-end'}}>
-            <RaisedButton
-              disabled={this.state.name === ''}
-              onTouchTap={this.onStartPressed}
-              style={styles.button}
-              secondary={true}
-              label="Start" />
-          </div>
-        </div>
-      </VelocityTransitionGroup>
-    );
-  },
-
-  renderScaffoldingOptions() {
-    const {competencyGroupValue} = this.state;
+    const {isSolutionMode, name, competencyGroupValue, sessionLength, questions, shouldShowStudentCards, shouldShowSummary, helpType} = this.state;
     const competencyGroups = _.uniq(_.map(allQuestions, 'learningObjectiveId')).map((id) => {
       return _.find(learningObjectives, {id}).competencyGroup;
     });
     return (
-      <div>
-        <div style={styles.optionTitle}>Learning objectives to practice</div>
-        <RadioButtonGroup
-          name="competencyGroupValue"
-          valueSelected={competencyGroupValue}
-          onChange={this.onCompetencyGroupChanged}
-          style={_.merge({ padding: 20 }, styles.option)}>
-          <RadioButton
-            value={ALL_COMPETENCY_GROUPS}
-            label="All" />
-          {competencyGroups.map((competencyGroup) => {
-            return <RadioButton
-              key={competencyGroup}
-              value={competencyGroup}
-              label={competencyGroup} />;
-          })}
-        </RadioButtonGroup>
-        <Divider />
-        <div>
-          <div style={styles.optionTitle}>Session Length: {this.state.sessionLength} {this.state.sessionLength===1 ? "question" : "questions"}</div>
-          <Slider key={competencyGroupValue} value={this.state.sessionLength} min={1} max={this.state.questions.length} step={1} onChange={this.onSliderChange}/>
-        </div>
-        <Divider />
-        <div style={styles.optionTitle}>Scaffolding</div>
-        <div style={_.merge({ padding: 20 }, styles.option)}>
-          <Toggle
-            label="With student cards"
-            labelPosition="right"
-            toggled={this.state.shouldShowStudentCards}
-            onToggle={this.onStudentCardsToggled} />
-          <Toggle
-            label="Show summary after each question"
-            labelPosition="right"
-            toggled={this.state.shouldShowSummary}
-            onToggle={this.onSummaryToggled}/>
-          <div style={{margin: 10}}><Divider /></div>
-          <RadioButtonGroup name="helpOptions" valueSelected={this.state.helpType} onChange={this.onHelpToggled}>
-            <RadioButton
-              value="feedback"
-              label="With feedback and revision"
-              style={styles.radioButton}
-              />
-            <RadioButton
-              value="hints"
-              label="With hints available"
-              style={styles.radioButton}
-              />
-            <RadioButton
-              value="none"
-              label="With no help available"
-              style={styles.radioButton}
-              />
-          </RadioButtonGroup>
-        </div>
-        <Divider />
-      </div>
-    );
+      <InstructionsCard 
+        isSolutionMode={isSolutionMode}
+        onTextChanged={this.onTextChanged}
+        onStartPressed={this.onStartPressed}
+        name={name}
+        competencyGroupValue={competencyGroupValue}
+        competencyGroups={competencyGroups}
+        onCompetencyGroupChanged={this.onCompetencyGroupChanged}
+        sessionLength={sessionLength}
+        questions={questions}
+        onSliderChange={this.onSliderChange}
+        shouldShowStudentCards={shouldShowStudentCards}
+        onStudentCardsToggled={this.onStudentCardsToggled}
+        shouldShowSummary={shouldShowSummary}
+        onSummaryToggled={this.onSummaryToggled}
+        helpType={helpType}
+        onHelpToggled={this.onHelpToggled}
+        itemsToShow={this.props.query}
+        />);
   }
 });
 
 const styles = {
   done: {
-    padding: 20,
-    width: 360
-  },
-  instructions: {
     padding: 20,
     width: 360
   },
@@ -318,24 +236,6 @@ const styles = {
     width: 400,
     fontSize: 20,
     padding: 0
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    marginBottom: 20
-  },
-  paragraph: {
-    marginTop: 20,
-    marginBottom: 20
-  },
-  option: {
-    fontSize: 16
-  },
-  optionTitle: {
-    padding: 10,
-    fontSize: 16,
-    paddingTop: 20,
-    paddingBottom: 0
   },
   button: {
     marginTop: 20

--- a/ui/src/message_popup/instructions_card.jsx
+++ b/ui/src/message_popup/instructions_card.jsx
@@ -1,0 +1,106 @@
+import React from "react";
+import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
+import "velocity-animate/velocity.ui";
+import ScaffoldingCard from "./scaffolding_card.jsx";
+import RaisedButton from 'material-ui/RaisedButton';
+import Divider from 'material-ui/Divider';
+import TextField from 'material-ui/TextField';
+
+export default React.createClass({
+  displayName: "InstructionsCard",
+  
+  propTypes: {
+    isSolutionMode: React.PropTypes.bool.isRequired,
+    onTextChanged: React.PropTypes.func.isRequired,
+    onStartPressed: React.PropTypes.func.isRequired,
+    name: React.PropTypes.string.isRequired,
+    competencyGroupValue: React.PropTypes.string.isRequired,
+    competencyGroups: React.PropTypes.array.isRequired,
+    onCompetencyGroupChanged: React.PropTypes.func.isRequired,
+    sessionLength: React.PropTypes.number.isRequired,
+    questions: React.PropTypes.array.isRequired,
+    onSliderChange: React.PropTypes.func.isRequired,
+    shouldShowStudentCards: React.PropTypes.bool.isRequired,
+    onStudentCardsToggled: React.PropTypes.func.isRequired,
+    shouldShowSummary: React.PropTypes.bool.isRequired,
+    onSummaryToggled: React.PropTypes.func.isRequired,
+    helpType: React.PropTypes.string.isRequired,
+    onHelpToggled: React.PropTypes.func.isRequired,
+    itemsToShow: React.PropTypes.object.isRequired
+  },
+  
+  render(){
+    return (
+      <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
+        <div style ={_.merge(_.clone(styles.container), styles.instructions)}>
+          <div style={styles.title}>Message Popup</div>
+          {this.props.isSolutionMode &&
+            <p style={styles.paragraph}>Clear 15 minutes.  Your work is timed, so being able to focus is important.</p>
+          }
+          {!this.props.isSolutionMode && 
+            <p style={styles.paragraph}>This will feel uncomfortable at first, but better to get comfortable here than with real students.</p>
+          }
+          <p style={styles.paragraph}>You may be asked to write, sketch or say your responses aloud.</p>
+          <p style={styles.paragraph}>Each question is timed to simulate responding in the moment in the classroom.  You'll have 90 seconds to respond to each question.</p>
+          <Divider />
+          {!this.props.isSolutionMode && 
+            <ScaffoldingCard
+              competencyGroupValue={this.props.competencyGroupValue}
+              competencyGroups={this.props.competencyGroups}
+              onCompetencyGroupChanged={this.props.onCompetencyGroupChanged}
+              sessionLength={this.props.sessionLength}
+              questions={this.props.questions}
+              onSliderChange={this.props.onSliderChange}
+              shouldShowStudentCards={this.props.shouldShowStudentCards}
+              onStudentCardsToggled={this.props.onStudentCardsToggled}
+              shouldShowSummary={this.props.shouldShowSummary}
+              onSummaryToggled={this.props.onSummaryToggled}
+              helpType={this.props.helpType}
+              onHelpToggled={this.props.onHelpToggled}
+              itemsToShow={this.props.itemsToShow}
+              />}
+          <TextField
+            underlineShow={false}
+            floatingLabelText="What's your name?"
+            onChange={this.props.onTextChanged}
+            multiLine={true}
+            rows={2}/>
+          <div style={{display: 'flex', flexDirection: 'row', alignItems: 'flex-end'}}>
+            <RaisedButton
+              disabled={this.props.name === ''}
+              onTouchTap={this.props.onStartPressed}
+              style={styles.button}
+              secondary={true}
+              label="Start" />
+          </div>
+        </div>
+      </VelocityTransitionGroup>
+    );
+  }
+});
+
+const styles = {
+  instructions: {
+    padding: 20,
+    width: 360
+  },
+  container: {
+    border: '1px solid #ccc',
+    margin: 20,
+    width: 400,
+    fontSize: 20,
+    padding: 0
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20
+  },
+  paragraph: {
+    marginTop: 20,
+    marginBottom: 20
+  },
+  button: {
+    marginTop: 20
+  }
+};

--- a/ui/src/message_popup/instructions_card.jsx
+++ b/ui/src/message_popup/instructions_card.jsx
@@ -5,70 +5,144 @@ import ScaffoldingCard from "./scaffolding_card.jsx";
 import RaisedButton from 'material-ui/RaisedButton';
 import Divider from 'material-ui/Divider';
 import TextField from 'material-ui/TextField';
+import TextChangeEvent from '../types/dom_types.js';
+import {allStudents} from '../data/virtual_school.js';
+import {learningObjectives} from '../data/learning_objectives.js';
+import {allQuestions} from './questions.js';
+
+const ALL_COMPETENCY_GROUPS = 'ALL_COMPETENCY_GROUPS';
 
 export default React.createClass({
   displayName: "InstructionsCard",
   
   propTypes: {
-    isSolutionMode: React.PropTypes.bool.isRequired,
-    onTextChanged: React.PropTypes.func.isRequired,
     onStartPressed: React.PropTypes.func.isRequired,
-    name: React.PropTypes.string.isRequired,
-    competencyGroupValue: React.PropTypes.string.isRequired,
-    competencyGroups: React.PropTypes.array.isRequired,
-    onCompetencyGroupChanged: React.PropTypes.func.isRequired,
-    sessionLength: React.PropTypes.number.isRequired,
-    questions: React.PropTypes.array.isRequired,
-    onSliderChange: React.PropTypes.func.isRequired,
-    shouldShowStudentCards: React.PropTypes.bool.isRequired,
-    onStudentCardsToggled: React.PropTypes.func.isRequired,
-    shouldShowSummary: React.PropTypes.bool.isRequired,
-    onSummaryToggled: React.PropTypes.func.isRequired,
-    helpType: React.PropTypes.string.isRequired,
-    onHelpToggled: React.PropTypes.func.isRequired,
     itemsToShow: React.PropTypes.object.isRequired
   },
   
+  getInitialState(){
+    return ({
+      isSolutionMode: _.has(this.props.itemsToShow, "solution"),
+      name: '',
+      sessionLength: 20,
+      questions: allQuestions,
+      competencyGroupValue: ALL_COMPETENCY_GROUPS,
+      shouldShowStudentCard: true,
+      shouldShowSummary: true,
+      helpType: 'feedback',
+    });
+  },
+  
+  onTextChanged({target:{value}}:TextChangeEvent) {
+    this.setState({ name: value });
+  },
+  
+  onConfigurationSet(){
+    const {name, sessionLength, shouldShowStudentCard, shouldShowSummary, helpType} = this.state;
+    const questions = this.getQuestions(this.state.competencyGroupValue);
+    this.props.onStartPressed(name, sessionLength, questions, shouldShowStudentCard ,shouldShowSummary, helpType);
+  },
+  
+  onCompetencyGroupChanged(event, competencyGroupValue){
+    const questions = this.getQuestions(competencyGroupValue);
+    const newLength = questions.length;
+    var sessionLength = this.state.sessionLength
+    if(sessionLength > newLength){
+      sessionLength = newLength;
+    }
+    this.setState({questions, competencyGroupValue, sessionLength});
+  },
+  
+  onSliderChange(event, value){
+    this.setState({ sessionLength: value})
+  },
+  
+  onStudentCardsToggled(){
+    this.setState({ shouldShowStudentCard: !this.state.shouldShowStudentCard });
+  },
+  
+  onSummaryToggled(){ 
+    this.setState({ shouldShowSummary: !this.state.shouldShowSummary });
+  },
+  
+  onHelpToggled(event, value){
+    this.setState({ helpType: value});
+  },
+  
+  getQuestions(competencyGroup=""){
+    var {competencyGroupValue, isSolutionMode} = this.state;
+    if(competencyGroup !== ""){
+      competencyGroupValue = competencyGroup;
+    }
+    const questions = (isSolutionMode || competencyGroupValue === ALL_COMPETENCY_GROUPS)
+      ? _.shuffle(this.withStudents(allQuestions))
+      : this.questionsForCompetencies(competencyGroupValue);
+    return questions;
+  },
+  
+  withStudents(questions) {
+    return questions.map((question) => {
+      const student = _.find(allStudents, {id: question.studentId });
+      return _.extend({student}, question);
+    });
+  },
+  
+  questionsForCompetencies(competencyGroup) {
+    const withCompetencyGroups = _.compact(allQuestions.map((question) => {
+      const learningObjective = _.find(learningObjectives, { id: question.learningObjectiveId });
+      if (learningObjective.competencyGroup !== competencyGroup) return null;
+      return {
+        ...question,
+        competencyGroup: learningObjective.competencyGroup
+      };
+    }));
+    return _.shuffle(this.withStudents(withCompetencyGroups));
+  },
+  
   render(){
+    const{isSolutionMode, name, sessionLength, questions, competencyGroupValue, shouldShowStudentCard, shouldShowSummary, helpType} = this.state;
+    const competencyGroups = _.uniq(_.map(allQuestions, 'learningObjectiveId')).map((id) => {
+      return _.find(learningObjectives, {id}).competencyGroup;
+    });
     return (
       <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
         <div style ={_.merge(_.clone(styles.container), styles.instructions)}>
           <div style={styles.title}>Message Popup</div>
-          {this.props.isSolutionMode &&
+          {isSolutionMode &&
             <p style={styles.paragraph}>Clear 15 minutes.  Your work is timed, so being able to focus is important.</p>
           }
-          {!this.props.isSolutionMode && 
+          {!isSolutionMode && 
             <p style={styles.paragraph}>This will feel uncomfortable at first, but better to get comfortable here than with real students.</p>
           }
           <p style={styles.paragraph}>You may be asked to write, sketch or say your responses aloud.</p>
           <p style={styles.paragraph}>Each question is timed to simulate responding in the moment in the classroom.  You'll have 90 seconds to respond to each question.</p>
           <Divider />
-          {!this.props.isSolutionMode && 
+          {!isSolutionMode &&
             <ScaffoldingCard
-              competencyGroupValue={this.props.competencyGroupValue}
-              competencyGroups={this.props.competencyGroups}
-              onCompetencyGroupChanged={this.props.onCompetencyGroupChanged}
-              sessionLength={this.props.sessionLength}
-              questions={this.props.questions}
-              onSliderChange={this.props.onSliderChange}
-              shouldShowStudentCards={this.props.shouldShowStudentCards}
-              onStudentCardsToggled={this.props.onStudentCardsToggled}
-              shouldShowSummary={this.props.shouldShowSummary}
-              onSummaryToggled={this.props.onSummaryToggled}
-              helpType={this.props.helpType}
-              onHelpToggled={this.props.onHelpToggled}
+              competencyGroupValue={competencyGroupValue}
+              competencyGroups={competencyGroups}
+              onCompetencyGroupChanged={this.onCompetencyGroupChanged}
+              sessionLength={sessionLength}
+              questions={questions}
+              onSliderChange={this.onSliderChange}
+              shouldShowStudentCard={shouldShowStudentCard}
+              onStudentCardsToggled={this.onStudentCardsToggled}
+              shouldShowSummary={shouldShowSummary}
+              onSummaryToggled={this.onSummaryToggled}
+              helpType={helpType}
+              onHelpToggled={this.onHelpToggled}
               itemsToShow={this.props.itemsToShow}
               />}
           <TextField
             underlineShow={false}
             floatingLabelText="What's your name?"
-            onChange={this.props.onTextChanged}
+            onChange={this.onTextChanged}
             multiLine={true}
             rows={2}/>
           <div style={{display: 'flex', flexDirection: 'row', alignItems: 'flex-end'}}>
             <RaisedButton
-              disabled={this.props.name === ''}
-              onTouchTap={this.props.onStartPressed}
+              disabled={this.state.name === ''}
+              onTouchTap={this.onConfigurationSet}
               style={styles.button}
               secondary={true}
               label="Start" />

--- a/ui/src/message_popup/scaffolding_card.jsx
+++ b/ui/src/message_popup/scaffolding_card.jsx
@@ -18,7 +18,7 @@ export default React.createClass({
     sessionLength: React.PropTypes.number.isRequired,
     questions: React.PropTypes.array.isRequired,
     onSliderChange: React.PropTypes.func.isRequired,
-    shouldShowStudentCards: React.PropTypes.bool.isRequired,
+    shouldShowStudentCard: React.PropTypes.bool.isRequired,
     onStudentCardsToggled: React.PropTypes.func.isRequired,
     shouldShowSummary: React.PropTypes.bool.isRequired,
     onSummaryToggled: React.PropTypes.func.isRequired,
@@ -26,6 +26,8 @@ export default React.createClass({
     onHelpToggled: React.PropTypes.func.isRequired,
     itemsToShow: React.PropTypes.object.isRequired
   },
+  
+  
   
   onHelpToggled(){
     if(this.props.helpType === 'feedback'){
@@ -36,10 +38,10 @@ export default React.createClass({
   },
   
   render(){
-    const {competencyGroupValue, competencyGroups, onCompetencyGroupChanged, sessionLength, questions, onSliderChange, shouldShowStudentCards, onStudentCardsToggled, shouldShowSummary, onSummaryToggled, helpType, onHelpToggled, itemsToShow} = this.props;
+    const {competencyGroupValue, competencyGroups, onCompetencyGroupChanged, sessionLength, questions, onSliderChange, shouldShowStudentCard, onStudentCardsToggled, shouldShowSummary, onSummaryToggled, helpType, onHelpToggled, itemsToShow} = this.props;
     
-    var showLearningObjectives = _.has(itemsToShow, 'all') || _.has(itemsToShow, 'objectives') || _.has(itemsToShow, 'basic');
-    var showSlider = _.has(itemsToShow, 'all') || _.has(itemsToShow, 'slider') || _.has(itemsToShow, 'basic');
+    var showLearningObjectives = true;
+    var showSlider = true;
     var showStudentCardsToggle = _.has(itemsToShow, 'all') || _.has(itemsToShow, 'cards') || _.has(itemsToShow, 'basic');
     var showSummaryToggle = _.has(itemsToShow, 'all') || _.has(itemsToShow, 'summary');
     var showHelpToggle = _.has(itemsToShow, 'all') || _.has(itemsToShow, 'feedback') || _.has(itemsToShow, 'basic');
@@ -87,7 +89,7 @@ export default React.createClass({
               <Toggle
               label="With student cards"
               labelPosition="right"
-              toggled={shouldShowStudentCards}
+              toggled={shouldShowStudentCard}
               onToggle={onStudentCardsToggled} />
               }
               {showSummaryToggle &&

--- a/ui/src/message_popup/scaffolding_card.jsx
+++ b/ui/src/message_popup/scaffolding_card.jsx
@@ -1,0 +1,160 @@
+import React from "react";
+import Toggle from 'material-ui/Toggle';
+import Divider from 'material-ui/Divider';
+import {RadioButton, RadioButtonGroup} from 'material-ui/RadioButton';
+import Slider from 'material-ui/Slider';
+import _ from 'lodash';
+
+
+const ALL_COMPETENCY_GROUPS = 'ALL_COMPETENCY_GROUPS';
+
+export default React.createClass({
+  displayName: "ScaffoldingCard",
+  
+  propTypes: {
+    competencyGroupValue: React.PropTypes.string.isRequired,
+    competencyGroups: React.PropTypes.array.isRequired,
+    onCompetencyGroupChanged: React.PropTypes.func.isRequired,
+    sessionLength: React.PropTypes.number.isRequired,
+    questions: React.PropTypes.array.isRequired,
+    onSliderChange: React.PropTypes.func.isRequired,
+    shouldShowStudentCards: React.PropTypes.bool.isRequired,
+    onStudentCardsToggled: React.PropTypes.func.isRequired,
+    shouldShowSummary: React.PropTypes.bool.isRequired,
+    onSummaryToggled: React.PropTypes.func.isRequired,
+    helpType: React.PropTypes.string.isRequired,
+    onHelpToggled: React.PropTypes.func.isRequired,
+    itemsToShow: React.PropTypes.object.isRequired
+  },
+  
+  onHelpToggled(){
+    if(this.props.helpType === 'feedback'){
+      this.props.onHelpToggled(null, 'none');
+    }else{
+      this.props.onHelpToggled(null, 'feedback');
+    }
+  },
+  
+  render(){
+    const {competencyGroupValue, competencyGroups, onCompetencyGroupChanged, sessionLength, questions, onSliderChange, shouldShowStudentCards, onStudentCardsToggled, shouldShowSummary, onSummaryToggled, helpType, onHelpToggled, itemsToShow} = this.props;
+    
+    var showLearningObjectives = _.has(itemsToShow, 'all') || _.has(itemsToShow, 'objectives') || _.has(itemsToShow, 'basic');
+    var showSlider = _.has(itemsToShow, 'all') || _.has(itemsToShow, 'slider') || _.has(itemsToShow, 'basic');
+    var showStudentCardsToggle = _.has(itemsToShow, 'all') || _.has(itemsToShow, 'cards') || _.has(itemsToShow, 'basic');
+    var showSummaryToggle = _.has(itemsToShow, 'all') || _.has(itemsToShow, 'summary');
+    var showHelpToggle = _.has(itemsToShow, 'all') || _.has(itemsToShow, 'feedback') || _.has(itemsToShow, 'basic');
+    var showOriginalHelp = _.has(itemsToShow, 'all') || _.has(itemsToShow, 'originalHelp');
+    
+    return (
+      <div>
+        {showLearningObjectives &&
+          <div>
+            <div style={styles.optionTitle}>Learning objectives to practice</div>
+            <RadioButtonGroup
+              name="competencyGroupValue"
+              valueSelected={competencyGroupValue}
+              onChange={onCompetencyGroupChanged}
+              style={_.merge({padding:20},styles.option)} >
+              <RadioButton 
+                value={ALL_COMPETENCY_GROUPS}
+                label="All" />
+              {competencyGroups.map((competencyGroup) => {
+                return <RadioButton
+                         key={competencyGroup}
+                         value={competencyGroup}
+                         label={competencyGroup} />;
+              })}
+            </RadioButtonGroup>
+          </div>
+        }
+        
+        <Divider />
+        
+        {showSlider &&
+          <div>
+            <div style={styles.optionTitle}>Session Length: {sessionLength} {sessionLength===1 ? "question" : "questions"}</div>
+            <Slider key={competencyGroupValue} value={sessionLength} min={1} max={questions.length} step={1} onChange={onSliderChange}/>
+          </div>
+        }
+        
+        <Divider />
+        
+        {(showStudentCardsToggle || showHelpToggle || showSummaryToggle || showOriginalHelp) &&
+          <div>
+            <div style={styles.optionTitle}>Scaffolding</div>
+            <div style={_.merge({ padding: 20 }, styles.option)}>
+              {showStudentCardsToggle &&
+              <Toggle
+              label="With student cards"
+              labelPosition="right"
+              toggled={shouldShowStudentCards}
+              onToggle={onStudentCardsToggled} />
+              }
+              {showSummaryToggle &&
+              <Toggle
+              label="Show summary after each question"
+              labelPosition="right"
+              toggled={shouldShowSummary}
+              onToggle={onSummaryToggled}/>
+              }
+              {showHelpToggle &&
+              <Toggle
+              label="With feedback and revision"
+              labelPosition="right"
+              toggled={helpType==='feedback'}
+              onToggle={this.onHelpToggled} />
+              }
+              {(showStudentCardsToggle || showSummaryToggle || showHelpToggle) && showOriginalHelp &&
+              <div style={{margin: 10}}><Divider /></div>
+              }
+              {showOriginalHelp &&
+              <RadioButtonGroup name="helpOptions" valueSelected={helpType} onChange={onHelpToggled}>
+                <RadioButton
+                  value="feedback"
+                  label="With feedback and revision"
+                  />
+                <RadioButton
+                  value="hints"
+                  label="With hints available"
+                  />
+                <RadioButton
+                  value="none"
+                  label="With no help available"
+                  />
+              </RadioButtonGroup>
+              }
+            </div>
+          </div>
+        }
+        
+        <Divider />
+            
+      </div>
+    );
+  }
+});
+
+const styles = {
+  option: {
+    fontSize: 16,
+  },
+  optionTitle: {
+    padding: 10,
+    fontSize: 16,
+    paddingTop: 20,
+    paddingBottom: 0
+  },
+  objective: {
+    fontSize: 16,
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between'
+  },
+  objectiveSlider: {
+    width: 80
+  },
+  objectiveText: {
+    width: 240,
+    padding: 'auto'
+  }
+};

--- a/ui/src/message_popup/student_card.jsx
+++ b/ui/src/message_popup/student_card.jsx
@@ -38,7 +38,6 @@ export default React.createClass({
       familyBackground,
       ses
     } = this.props.student;
-
     return (
       <div style={containerStyle}>
         <div style={styles.name}>{name}</div>


### PR DESCRIPTION
I moved the Instructions and option scaffolding to separate components in separate files. Also, I started on making the practice page look less cluttered. This can be done by using query strings to designate which options should be shown. Having no query string will not show any options at the moment but all the default options are still selected. The purpose of this was so that we can discuss and decide on which ones should be always shown. 

For now, I have an example of that with the query string `basic` which shows the following options:

![](https://i.gyazo.com/e744c2d3e0c3db16c872c0ff630305c8.png)

I experimented with using sliders on the side of the learning objectives for a little but I thought it looked a bit cluttered so I will experiment more with it tomorrow and see if I can make it look better with that.