### PR TITLE
Adding auth0 for UI-side authentication, no server checks yet

### DIFF
--- a/ui/.flowconfig
+++ b/ui/.flowconfig
@@ -3,3 +3,4 @@
 .*/node_modules/config-chain/test/broken.json
 .*/node_modules/npmconf/test/.*
 .*/node_modules/react-motion/.*
+.*/node_modules/reqwest/.*

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/mit-teaching-systems-lab/threeflows#readme",
   "dependencies": {
+    "auth0-lock": "^9.2.1",
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",

--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -1,8 +1,14 @@
 /* @flow weak */
 import React from 'react';
 import _ from 'lodash';
-import * as PropTypes from './prop_types.js';
 import {RouterMixin} from 'react-mini-router';
+
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import injectTapEventPlugin from 'react-tap-event-plugin';
+
+import * as PropTypes from './prop_types.js';
+import AuthContainer from './auth_container.jsx';
 import ChallengePage from './challenge/challenge_page.jsx';
 import HomePage from './home/home_page.jsx';
 import SlatePage from './slate/slate_page.jsx';
@@ -14,9 +20,6 @@ import {
   slates,
   withLearningObjectives
 } from './data/challenges.js';
-import getMuiTheme from 'material-ui/styles/getMuiTheme';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
-import injectTapEventPlugin from 'react-tap-event-plugin';
 
 
 
@@ -48,31 +51,16 @@ export default React.createClass({
     };
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object.isRequired
-  },
-
-  getChildContext() {
-    return { muiTheme: this.props.muiTheme };
-  },
-
-  getInitialState() {
-    return {
-      user: {
-        driveFolderId: '0B1DHMN8NDLMVNnZGaVJjSjRTbDg'
-      }
-    };
-  },
-
-  componentWillMount(props, state) {
-    // material-ui, see https://github.com/zilverline/react-tap-event-plugin
-    injectTapEventPlugin();
+  componentDidMount(props, state) {
+    injectTapEventPlugin(); // material-ui, see https://github.com/zilverline/react-tap-event-plugin
   },
 
   render(){
     return (
       <MuiThemeProvider muiTheme={this.props.muiTheme}>
-        {this.renderCurrentRoute()}
+        <AuthContainer>
+          {this.renderCurrentRoute()}
+        </AuthContainer>
       </MuiThemeProvider>
     );
   },

--- a/ui/src/auth0_config.js
+++ b/ui/src/auth0_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  AUTH0_CLIENT_ID: 'OTmWVAoIbNjpdy5oiQbtUPSs75ogTt4R',
+  AUTH0_DOMAIN: 'flows.auth0.com'
+};

--- a/ui/src/auth_container.jsx
+++ b/ui/src/auth_container.jsx
@@ -1,0 +1,133 @@
+/* @flow weak */
+import React from 'react';
+import Auth0Lock from 'auth0-lock';
+import Auth0Variables from './auth0_config.js';
+
+// Injects Auth0 login screen, bounces over to OAuth provider for login,
+// saves userTokens in localStorage afterward.
+//
+// Provides auth state as context to children components.
+export default React.createClass({
+  displayName: 'AuthContainer',
+
+  propTypes: {
+    children: React.PropTypes.element.isRequired,
+    localStorageKey: React.PropTypes.string
+  },
+
+  getDefaultProps() {
+    return {
+      localStorageKey: 'threeflows_auth_container'
+    };
+  },
+
+  lock: null,
+
+  getInitialState() {
+    return {
+      loginError: null,
+      userToken: null,
+      accessToken: null,
+      authHash: null,
+      userProfile: null
+    };
+  },
+
+  childContextTypes: {
+    auth: React.PropTypes.shape({
+      loginError: React.PropTypes.object,
+      userToken: React.PropTypes.string,
+      accessToken: React.PropTypes.string,
+      userProfile: React.PropTypes.object,
+      authHash: React.PropTypes.object,
+      doLogout: React.PropTypes.func
+    }).isRequired
+  },
+
+  getChildContext() {
+    return {
+      auth: {
+        loginError: this.state.loginError,
+        userToken: this.state.userToken,
+        accessToken: this.state.accessToken,
+        authHash: this.state.authHash,
+        userProfile: this.state.userProfile,
+        doLogout: this.doLogout
+      }
+    };
+  },
+
+  componentDidMount(props, state) {
+    this.lock = new Auth0Lock(Auth0Variables.AUTH0_CLIENT_ID, Auth0Variables.AUTH0_DOMAIN);
+    this.setProfileOrShowLogin();
+  },
+
+  doLogout() {
+    window.localStorage.removeItem(this.props.localStorageKey);
+    window.location.reload();
+  },
+
+  setProfileOrShowLogin() {
+    const {lock} = this;
+
+    // Check hash from redirect
+    const authHash = lock && lock.parseHash(window.location.hash);
+    if (authHash) {
+      window.history.replaceState({}, document.title, '/');
+      
+      const {error} = authHash;
+      const idToken = authHash.id_token;
+      const accessToken = authHash.access_token;
+      if (error) return this.setState({ loginError: error });
+      if (idToken && lock) {
+        return lock.getProfile(idToken, this.onSignInDone.bind(this, {
+          authHash,
+          accessToken,
+          userToken: idToken
+        }));
+      }
+    }
+
+    // Check local storage cache
+    const storedValues = window.localStorage.getItem(this.props.localStorageKey);
+    if (storedValues) {
+      const {userToken, userProfile} = JSON.parse(storedValues);
+      if (userToken && userProfile) return this.setState({userToken, userProfile});
+    }
+
+    // Do a new login
+    return this.showLogin();
+  },
+
+  showLogin() {
+    this.lock && this.lock.show({
+      connections: ['google-oauth2'],
+      socialBigButtons: true,
+      icon: 'http://ram.raritanassets.com/images/global/why-power-icon_airflow.png',
+      closable: false,
+      popup: false,
+      responseType: 'token',
+      callbackOnLocationHash: true
+    });
+  },
+
+  componentDidUpdate(prevProps, prevState) {
+    const {userToken, userProfile} = this.state;
+    if (userToken !== prevState.userToken || userProfile !== prevState.userProfile) {
+      window.localStorage.setItem(this.props.localStorageKey, JSON.stringify({userToken, userProfile}));
+    }
+  },
+
+  onSignInDone({authHash, accessToken, userToken}, loginError, userProfile) {
+    this.setState({authHash, accessToken, userToken, loginError, userProfile});
+  },
+
+  render() {
+    const {loginError, userProfile} = this.state;
+
+    return <div>
+      {loginError && <div>There was an error logging in.</div>}
+      {userProfile && this.props.children}
+    </div>;
+  }
+});

--- a/ui/src/challenge/challenge_page.jsx
+++ b/ui/src/challenge/challenge_page.jsx
@@ -15,7 +15,6 @@ export default React.createClass({
   displayName: 'ChallengePage',
 
   propTypes: {
-    user: PropTypes.User.isRequired,
     challenge: PropTypes.Challenge.isRequired
   },
 

--- a/ui/src/home/home_page.jsx
+++ b/ui/src/home/home_page.jsx
@@ -11,6 +11,10 @@ export default React.createClass({
     challenges: React.PropTypes.arrayOf(PropTypes.Challenge).isRequired
   },
 
+  contextTypes: {
+    auth: React.PropTypes.object.isRequired
+  },
+
   render() {
     return (
       <div>
@@ -18,6 +22,22 @@ export default React.createClass({
         {this.props.challenges.map((challenge) => {
           return <ChallengeCard key="{challenge.name}" {...challenge} />;
         })}
+        {this.renderProfile()}
+      </div>
+    );
+  },
+
+  renderProfile() {
+    const {userProfile, authHash} = this.context.auth;
+
+    return (
+      <div style={{marginTop: 50, border: '1px solid #eee'}}>
+        <div><img src={userProfile.picture} width="64" height="64"/></div>
+        <div>{userProfile.name}</div>
+        <div>{userProfile.email}</div>
+        <pre>{JSON.stringify(userProfile, null, 2)}</pre>
+        <pre>{JSON.stringify(authHash, null, 2)}</pre>
+        <div><a href="#" onClick={this.context.auth.doLogout}>Logout</a></div>
       </div>
     );
   }

--- a/ui/src/message_popup/experience_page.jsx
+++ b/ui/src/message_popup/experience_page.jsx
@@ -1,21 +1,20 @@
 /* @flow weak */
 import _ from 'lodash';
 import React from 'react';
-import * as Routes from '../routes';
-import type {Response} from './popup_question.jsx';
-import RaisedButton from 'material-ui/RaisedButton';
-import Divider from 'material-ui/Divider';
-import PopupQuestion from './popup_question.jsx';
-import LinearProgress from 'material-ui/LinearProgress';
-import Snackbar from 'material-ui/Snackbar';
-import TextChangeEvent from '../types/dom_types.js';
-import {learningObjectives} from '../data/learning_objectives.js';
-import {allQuestions} from './questions.js';
 import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
-import {withStudents, questionsForCompetencies} from './transformations.jsx';
-import * as Api from '../helpers/api.js';
 import 'velocity-animate/velocity.ui';
 import uuid from 'node-uuid';
+
+import RaisedButton from 'material-ui/RaisedButton';
+import Divider from 'material-ui/Divider';
+import LinearProgress from 'material-ui/LinearProgress';
+import Snackbar from 'material-ui/Snackbar';
+
+import PopupQuestion from './popup_question.jsx';
+import * as Routes from '../routes';
+import type {Response} from './popup_question.jsx';
+import {allQuestions} from './questions.js';
+import * as Api from '../helpers/api.js';
 import FinalSummaryCard from './final_summary_card.jsx';
 import InstructionsCard from './instructions_card.jsx';
 
@@ -29,6 +28,10 @@ export default React.createClass({
 
   propTypes: {
     query: React.PropTypes.object.isRequired
+  },
+
+  contextTypes: {
+    auth: React.PropTypes.object.isRequired
   },
 
   getInitialState: function() {
@@ -45,7 +48,7 @@ export default React.createClass({
       sessionId,
       competencyGroupValue: ALL_COMPETENCY_GROUPS,
       questions: allQuestions,
-      name: '',
+      name: this.context.auth.userProfile.name,
       hasStarted: false,
       questionsAnswered: 0,
       sessionLength: 20,
@@ -162,6 +165,7 @@ export default React.createClass({
     return (
       <InstructionsCard 
         onStartPressed={this.onStartPressed}
+        name={this.state.name}
         itemsToShow={this.props.query}
         />);
   }

--- a/ui/src/message_popup/instructions_card.jsx
+++ b/ui/src/message_popup/instructions_card.jsx
@@ -1,6 +1,8 @@
-import React from "react";
-import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
-import "velocity-animate/velocity.ui";
+/* @flow weak */
+import React from 'react';
+import _ from 'lodash';
+import VelocityTransitionGroup from 'velocity-react/velocity-transition-group';
+import 'velocity-animate/velocity.ui';
 import ScaffoldingCard from "./scaffolding_card.jsx";
 import RaisedButton from 'material-ui/RaisedButton';
 import Divider from 'material-ui/Divider';
@@ -17,13 +19,14 @@ export default React.createClass({
   
   propTypes: {
     onStartPressed: React.PropTypes.func.isRequired,
-    itemsToShow: React.PropTypes.object.isRequired
+    itemsToShow: React.PropTypes.object.isRequired,
+    name: React.PropTypes.string
   },
   
   getInitialState(){
     return ({
       isSolutionMode: _.has(this.props.itemsToShow, "solution"),
-      name: '',
+      name: this.props.name,
       sessionLength: 20,
       questions: allQuestions,
       competencyGroupValue: ALL_COMPETENCY_GROUPS,
@@ -46,7 +49,7 @@ export default React.createClass({
   onCompetencyGroupChanged(event, competencyGroupValue){
     const questions = this.getQuestions(competencyGroupValue);
     const newLength = questions.length;
-    var sessionLength = this.state.sessionLength
+    var sessionLength = this.state.sessionLength;
     if(sessionLength > newLength){
       sessionLength = newLength;
     }
@@ -54,7 +57,7 @@ export default React.createClass({
   },
   
   onSliderChange(event, value){
-    this.setState({ sessionLength: value})
+    this.setState({ sessionLength: value});
   },
   
   onStudentCardsToggled(){
@@ -100,7 +103,7 @@ export default React.createClass({
   },
   
   render(){
-    const{isSolutionMode, name, sessionLength, questions, competencyGroupValue, shouldShowStudentCard, shouldShowSummary, helpType} = this.state;
+    const{isSolutionMode, sessionLength, questions, competencyGroupValue, shouldShowStudentCard, shouldShowSummary, helpType} = this.state;
     const competencyGroups = _.uniq(_.map(allQuestions, 'learningObjectiveId')).map((id) => {
       return _.find(learningObjectives, {id}).competencyGroup;
     });
@@ -136,6 +139,7 @@ export default React.createClass({
           <TextField
             underlineShow={false}
             floatingLabelText="What's your name?"
+            value={this.state.name}
             onChange={this.onTextChanged}
             multiLine={true}
             rows={2}/>

--- a/ui/src/message_popup/scoring_page.jsx
+++ b/ui/src/message_popup/scoring_page.jsx
@@ -34,7 +34,7 @@ export default React.createClass({
       selectedQuestion: null
     };
   },
-
+  
   componentWillMount() {
     Api.evidenceQuery().end(this.onLogsReceived);
     Api.evaluationsQuery().end(this.onEvaluationsReceived);

--- a/ui/src/message_popup/scoring_swipe.jsx
+++ b/ui/src/message_popup/scoring_swipe.jsx
@@ -49,6 +49,10 @@ export default React.createClass({
     };
   },
 
+  contextTypes: {
+    auth: React.PropTypes.object.isRequired
+  },
+
   getInitialState() {
     return {
       limit: this.props.limitIncrement,
@@ -73,7 +77,8 @@ export default React.createClass({
       logId,
       scoreComment,
       learningObjective,
-      question
+      question,
+      email: this.context.auth.userProfile.email
     });
   },
 


### PR DESCRIPTION
This uses the https://auth0.com/ service for authenticating the user's email address through Google.  This is mostly handled in the `AuthContainer` component, which then provides authorization information to child components via React context.

This is used to pre-fill the MessagePopUp experience with the user's name, and to record the email address of anyone scoring responses.

This is only enforced in the browser; although it does send a redirect through the server the server isn't looking at, guarding or checking any of this information (the existing basic auth is still there).  The auth0 setup here is using tokens that are client-side, so experimenting with passing them through and validating on the server that would be a next step (or switching directions to capture the OAuth tokens on the server and store them in a session).