### PR TITLE
Beginning to make the mobile interface of message popup

### DIFF
--- a/ui/src/message_popup/experience_page.jsx
+++ b/ui/src/message_popup/experience_page.jsx
@@ -20,7 +20,7 @@ import ArrowBackIcon from 'material-ui/svg-icons/navigation/arrow-back';
 import RefreshIcon from 'material-ui/svg-icons/navigation/refresh';
 import MenuIcon from 'material-ui/svg-icons/navigation/menu';
 import {allQuestions} from './questions.js';
-import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
+
 import {withStudents} from './transformations.jsx';
 import * as Api from '../helpers/api.js';
 import FinalSummaryCard from './final_summary_card.jsx';

--- a/ui/src/message_popup/instructions_card.jsx
+++ b/ui/src/message_popup/instructions_card.jsx
@@ -1,12 +1,13 @@
 /* @flow weak */
-import React from 'react';
-import _ from 'lodash';
-import VelocityTransitionGroup from 'velocity-react/velocity-transition-group';
-import 'velocity-animate/velocity.ui';
+import React from "react";
+import _ from "lodash";
+import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
+import "velocity-animate/velocity.ui";
 import ScaffoldingCard from "./scaffolding_card.jsx";
 import RaisedButton from 'material-ui/RaisedButton';
 import Divider from 'material-ui/Divider';
 import TextField from 'material-ui/TextField';
+import AppBar from 'material-ui/AppBar';
 import TextChangeEvent from '../types/dom_types.js';
 import {allStudents} from '../data/virtual_school.js';
 import {learningObjectives} from '../data/learning_objectives.js';
@@ -108,64 +109,63 @@ export default React.createClass({
       return _.find(learningObjectives, {id}).competencyGroup;
     });
     return (
-      <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
-        <div style ={_.merge(_.clone(styles.container), styles.instructions)}>
-          <div style={styles.title}>Message Popup</div>
-          {isSolutionMode &&
-            <p style={styles.paragraph}>Clear 15 minutes.  Your work is timed, so being able to focus is important.</p>
-          }
-          {!isSolutionMode && 
-            <p style={styles.paragraph}>This will feel uncomfortable at first, but better to get comfortable here than with real students.</p>
-          }
-          <p style={styles.paragraph}>You may be asked to write, sketch or say your responses aloud.</p>
-          <p style={styles.paragraph}>Each question is timed to simulate responding in the moment in the classroom.  You'll have 90 seconds to respond to each question.</p>
-          <Divider />
-          {!isSolutionMode &&
-            <ScaffoldingCard
-              competencyGroupValue={competencyGroupValue}
-              competencyGroups={competencyGroups}
-              onCompetencyGroupChanged={this.onCompetencyGroupChanged}
-              sessionLength={sessionLength}
-              questions={questions}
-              onSliderChange={this.onSliderChange}
-              shouldShowStudentCard={shouldShowStudentCard}
-              onStudentCardsToggled={this.onStudentCardsToggled}
-              shouldShowSummary={shouldShowSummary}
-              onSummaryToggled={this.onSummaryToggled}
-              helpType={helpType}
-              onHelpToggled={this.onHelpToggled}
-              itemsToShow={this.props.itemsToShow}
-              />}
-          <TextField
-            underlineShow={false}
-            floatingLabelText="What's your email address?"
-            value={this.state.email}
-            onChange={this.onTextChanged}
-            multiLine={true}
-            rows={2}/>
-          <div style={{display: 'flex', flexDirection: 'row', alignItems: 'flex-end'}}>
-            <RaisedButton
-              disabled={this.state.email === ''}
-              onTouchTap={this.onConfigurationSet}
-              style={styles.button}
-              secondary={true}
-              label="Start" />
+      <div>        
+        <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
+          <div style ={_.merge(_.clone(styles.container), styles.instructions)}>
+            {isSolutionMode &&
+              <p style={styles.paragraph}>Clear 15 minutes.  Your work is timed, so being able to focus is important.</p>
+            }
+            {!isSolutionMode && 
+              <p style={styles.paragraph}>This will feel uncomfortable at first, but better to get comfortable here than with real students.</p>
+            }
+            <p style={styles.paragraph}>You may be asked to write, sketch or say your responses aloud.</p>
+            <p style={styles.paragraph}>Each question is timed to simulate responding in the moment in the classroom.  You'll have 90 seconds to respond to each question.</p>
+            <Divider />
+            {!isSolutionMode &&
+              <ScaffoldingCard
+                competencyGroupValue={competencyGroupValue}
+                competencyGroups={competencyGroups}
+                onCompetencyGroupChanged={this.onCompetencyGroupChanged}
+                sessionLength={sessionLength}
+                questions={questions}
+                onSliderChange={this.onSliderChange}
+                shouldShowStudentCard={shouldShowStudentCard}
+                onStudentCardsToggled={this.onStudentCardsToggled}
+                shouldShowSummary={shouldShowSummary}
+                onSummaryToggled={this.onSummaryToggled}
+                helpType={helpType}
+                onHelpToggled={this.onHelpToggled}
+                itemsToShow={this.props.itemsToShow}
+                />}
+            <TextField
+              style={{width: '100%'}}
+              underlineShow={false}
+              floatingLabelText="What's your email address?"
+              value={this.state.email}
+              onChange={this.onTextChanged}
+              multiLine={true}
+              rows={2}/>
+            <div style={{display: 'flex', flexDirection: 'row', alignItems: 'flex-end'}}>
+              <RaisedButton
+                disabled={this.state.email === ''}
+                onTouchTap={this.onConfigurationSet}
+                style={styles.button}
+                secondary={true}
+                label="Start" />
+            </div>
           </div>
-        </div>
-      </VelocityTransitionGroup>
+        </VelocityTransitionGroup>
+      </div>
     );
   }
 });
 
 const styles = {
   instructions: {
-    padding: 20,
-    width: 360
+    padding: 20
   },
   container: {
-    border: '1px solid #ccc',
-    margin: 20,
-    width: 400,
+    margin: 0,
     fontSize: 20,
     padding: 0
   },

--- a/ui/src/message_popup/mobile_prototype_card.jsx
+++ b/ui/src/message_popup/mobile_prototype_card.jsx
@@ -1,0 +1,239 @@
+import React from 'react';
+import ReactDom from 'react-dom';
+import _ from 'lodash';
+
+import {withStudents} from './transformations.jsx';
+
+//Material-UI imports
+import AppBar from 'material-ui/AppBar';
+import Paper from 'material-ui/Paper';
+import Dialog from 'material-ui/Dialog';
+import FlatButton from 'material-ui/FlatButton';
+import IconButton from 'material-ui/IconButton';
+import Divider from 'material-ui/Divider';
+import TextField from 'material-ui/TextField';
+import RaisedButton from 'material-ui/RaisedButton';
+
+//Icons
+import FaceIcon from 'material-ui/svg-icons/action/face';
+import InfoOutlineIcon from 'material-ui/svg-icons/action/info-outline';
+
+
+export default React.createClass({
+  displayName: 'MobilePrototypeCard',
+  
+  propTypes: {
+    question: React.PropTypes.object.isRequired
+  },
+  
+  getInitialState(){
+    return ({
+      question: this.props.question,
+      currentStudent: undefined,
+      responses: [],
+      currentResponse: ''
+    });
+  },
+  
+  openStudentDialog(){
+    this.setState({currentStudent: this.state.question.student});
+  },
+  
+  
+  closeStudentDialog(){
+    this.setState({currentStudent: undefined});
+  },
+  
+  sendMessage(){
+    this.setState({responses: _.clone(this.state.responses).concat(this.state.currentResponse)});
+  },
+  
+  next(){
+    
+  },
+  
+  onTextChange(event, value){
+    this.setState({currentResponse: value});
+  },
+  
+  render(){
+    const {
+      name,
+      grade,
+      gender,
+      race,
+      behavior,
+      ell,
+      learningDisabilities,
+      academicPerformance,
+      interests,
+      familyBackground,
+      ses
+    } = this.state.question.student;
+      
+    const studentDialogActions = [
+      <FlatButton
+        label="Close"
+        primary={true}
+        onTouchTap={this.closeStudentDialog}
+      />
+      
+    ];
+    
+    return (
+      <div>
+        <div>
+          <AppBar 
+            title='Message PopUp Practice'/>
+        </div>
+        <div style={styles.questionContainer}>
+          {<Message text={this.state.question.text} question={this.state.question} type='student' openStudentDialog={this.openStudentDialog} />}
+          {_.map(this.state.responses, (response) => {
+            return (
+              <Message text={response} question={this.state.question} type='user' />
+            );
+          })}
+        </div>
+        <div style={styles.responseContainer}>
+          <Divider />
+          <div style={styles.responseTextBox}>
+            <TextField
+              id="responseTextField"
+              multiLine={true}
+              hintText="Type something you would say"
+              textareaStyle={styles.responseTextAreaInner}
+              rows={2}
+              underlineShow={false}
+              rowsMax={2}
+              disabled={this.state.responses.length > 10}
+              value={this.state.currentResponse}
+              onChange={this.onTextChange}
+              style={{width: '100%', paddingLeft: 20, paddingRight: 20}}
+            />
+          </div>
+          <div style={styles.responseButtonRow}>
+            <RaisedButton 
+              label={this.state.responses.length > 10 ? 'Next' : 'Send'}
+              secondary={true}
+              onTouchTap={this.state.responses.length > 10 ? this.next : this.sendMessage}
+            />
+          </div>
+        </div>
+        
+        <Dialog
+          title="Student Information"
+          actions={studentDialogActions}
+          modal={false}
+          open={this.state.currentStudent !== undefined}
+          style={{backgroundColor: 'rgba(0, 0, 0, 0.1)'}}
+          onRequestClose={this.closeStudentDialog}
+        >
+          <div style={styles.studentName}>{name}</div>
+          <div style={styles.studentAttribute}>{`${grade} ${gender}, ${race}`}</div>
+          {behavior && <div style={styles.studentAttribute}>{behavior}</div>}
+          {ell && <div style={styles.studentAttribute}>{ell}</div>}
+          {learningDisabilities && <div style={styles.studentAttribute}>{learningDisabilities}</div>}
+          {academicPerformance && <div style={styles.studentAttribute}>{academicPerformance}</div>}
+          {interests && <div style={styles.studentAttribute}>{interests}</div>}
+          {familyBackground && <div style={styles.studentAttribute}>{familyBackground}</div>}
+          {ses && <div style={styles.studentAttribute}>{ses}</div>}
+        </Dialog>
+        
+      </div>
+    );
+  },
+});
+
+const Message = React.createClass({
+  propTypes: {
+    text: React.PropTypes.string.isRequired,
+    question: React.PropTypes.object.isRequired,
+    type: React.PropTypes.string.isRequired,
+    openStudentDialog: React.PropTypes.func
+  },
+  
+  componentDidUpdate(){ 
+    ReactDom.findDOMNode(this).scrollIntoView(); 
+  },
+  
+  render(){
+    const questionStyle = this.props.type==='user' ? _.merge({justifyContent: 'flex-end'}, styles.question) : _.merge({justifyContent: 'flex-start'}, styles.question);
+    
+    const questionTextStyle = this.props.type==='user' ? _.merge({backgroundColor: '#e6f9ff'}, styles.questionText) : styles.questionText;
+    
+    return (
+      <div>
+        <div style={questionStyle}>
+          { this.props.type === 'student' && <IconButton touch={true} onTouchTap={this.props.openStudentDialog} style={styles.questionIconButton} iconStyle={styles.questionIcon} ><FaceIcon /></IconButton> }
+          { this.props.type === 'info' && <InfoOutlineIcon  style={styles.questionIcon}/> }
+          <Paper style={questionTextStyle}>{this.props.text}</Paper>
+          { this.props.type === 'user' && <FaceIcon  style={styles.questionIcon}/> }
+        </div>
+      </div>
+    );
+  }
+});
+
+
+const styles = {
+  questionContainer: {
+    overflowY: 'scroll',
+    position: 'absolute',
+    top: 64,
+    bottom: 144,
+    width: '100%'
+  },
+  question: {
+    display: 'flex',
+    padding: 5
+  },
+  questionIconButton:{
+    margin: 0,
+    padding: 0
+  },
+  questionIcon: {
+    width: 30,
+    height: 30,
+    flexGrow: 0,
+    flexShrink: 0,
+    flexBasis: 30,
+    padding: 0,
+    margin: 5
+  },
+  questionText: {
+    padding: 10,
+    margin: 5,
+    whiteSpace: 'pre-wrap',
+    wordWrap: 'break-word',
+    wordBreak: 'break-word',
+    flexGrow: 0,
+    flexShrink: 1
+  },
+  studentName: {
+    fontWeight: 'bold',
+    marginBottom: 10
+  },
+  studentAttribute: {
+    fontSize: 12,
+    marginTop: 2
+  },
+  responseContainer: {
+    position: 'absolute',
+    bottom: 0,
+    width: '100%',
+    backgroundColor: '#ffffff',
+    paddingBottom: 15
+  },
+  responseTextBox: {
+    display: 'flex',
+    justifyContent: 'space-around'
+  },
+  responseTextAreaInner: {
+    border: '1px solid #eee',
+    marginBottom: 0
+  },
+  responseButtonRow:{
+    marginTop: 20,
+    marginLeft: 20,
+  }
+};


### PR DESCRIPTION
I added in a mobile version that gets displayed when you use the `mobile` query string. It only currently adds the `AppBar` to the top of all the questions/pages for Message PopUp.

Here are two examples:
![](https://i.gyazo.com/c4a037b49a165b6b1580c613158732ec.png)
and...
![](https://i.gyazo.com/f76e9687f108029781be6f13e3950d2e.png)

I was also experimenting with a different type of interface we could use. From my understanding, Message PopUp could originally be thought of as responding quickly to text messages. So I wondered how that would look and decided to make a prototype version of it to see it in action. It is accessible by using a `mobilePrototype` query string. I based it off of a texting interface and below are a few screenshots/design ideas for displaying the different previously added features.

First, you would be presented with a "text message" describing the situation. If a student is involved, the sender shows a face icon or possibly later on, a face we create for the individual student. If there is no specific student associated with the question, the sender icon will be an [Info Outline Icon](https://design.google.com/icons/#ic_info_outline).
![](https://i.gyazo.com/c565b3d66b45bed4bb8add3c611922c0.png)

You can respond by typing in a message and pressing send. I think with this format, the concept that you are responding to a student is more apparent. After sending a message, it would look like this.
![](https://i.gyazo.com/cf4558b09c87cab64d9e4b99e018c604.png)

By pressing on the student's icon, you are shown with a `Dialog` the student's information like below.
![](https://i.gyazo.com/4970472eb5514e2056efdc373ae473d6.png)

Other features like showing examples or allowing revisions could be added in by simply showing an info icon "send a message" of what a good example looks like and allowing the user to send another message or pass. The summary screen could still be shown afterwards and we could change the interface away from a texting one just for the summary or we could have the summary also act like a message that was sent, or we could just use another `Dialog` just like with the student's information.

This was just and idea I had that we could decide to pursue if you think it would help the experience.

As for just doing a mobile interface in general, how do we want to go about displaying one? Should we try to handle mobile browser detection, should certain versions of message popup just be accessible from different links, or should they all just display the mobile version?