### PR TITLE
Remove auth0 bounce, use self-identifying email form for playtest

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "main": "server/index.js",
   "scripts": {
+    "dev": "READ_LOCAL_EVIDENCE=true DATABASE_URL=http://localhost:5432 NODE_ENV=development npm run start",
     "start": "node server/index.js",
     "watch": "cd ui && npm run watch && cd ..",
     "heroku-prebuild": "cd ui && mkdir build && npm install",

--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -51,7 +51,7 @@ export default React.createClass({
     };
   },
 
-  componentDidMount(props, state) {
+  componentWillMount(props, state) {
     injectTapEventPlugin(); // material-ui, see https://github.com/zilverline/react-tap-event-plugin
   },
 

--- a/ui/src/auth_container.jsx
+++ b/ui/src/auth_container.jsx
@@ -25,7 +25,7 @@ export default React.createClass({
 
   getDefaultProps() {
     return {
-      localStorageKey: 'threeflow_email_registration'
+      localStorageKey: 'threeflows_email_registration'
     };
   },
 

--- a/ui/src/auth_container.jsx
+++ b/ui/src/auth_container.jsx
@@ -1,12 +1,20 @@
 /* @flow weak */
+import _ from 'lodash';
 import React from 'react';
-import Auth0Lock from 'auth0-lock';
-import Auth0Variables from './auth0_config.js';
 
-// Injects Auth0 login screen, bounces over to OAuth provider for login,
+import AppBar from 'material-ui/AppBar';
+import Paper from 'material-ui/Paper';
+import TextField from 'material-ui/TextField';
+import RaisedButton from 'material-ui/RaisedButton';
+import IconButton from 'material-ui/IconButton';
+import NavigationClose from 'material-ui/svg-icons/navigation/close';
+import * as Colors from 'material-ui/styles/Colors';
+
+
+// Injects form asking the user for their email address,
 // saves userTokens in localStorage afterward.
 //
-// Provides auth state as context to children components.
+// Provides userProfile.email as context to children components.
 export default React.createClass({
   displayName: 'AuthContainer',
 
@@ -17,7 +25,7 @@ export default React.createClass({
 
   getDefaultProps() {
     return {
-      localStorageKey: 'threeflows_auth_container'
+      localStorageKey: 'threeflow_email_registration'
     };
   },
 
@@ -25,109 +33,133 @@ export default React.createClass({
 
   getInitialState() {
     return {
-      loginError: null,
-      userToken: null,
-      accessToken: null,
-      authHash: null,
-      userProfile: null
+      userEmail: '',
+      hasConfirmedEmail: false,
+      isNavigatingAway: false
     };
   },
 
   childContextTypes: {
     auth: React.PropTypes.shape({
-      loginError: React.PropTypes.object,
-      userToken: React.PropTypes.string,
-      accessToken: React.PropTypes.string,
       userProfile: React.PropTypes.object,
-      authHash: React.PropTypes.object,
       doLogout: React.PropTypes.func
     }).isRequired
   },
 
   getChildContext() {
+    const userProfile = (this.state.hasConfirmedEmail) ? {
+      email: this.state.userEmail
+    } : null;
+
     return {
       auth: {
-        loginError: this.state.loginError,
-        userToken: this.state.userToken,
-        accessToken: this.state.accessToken,
-        authHash: this.state.authHash,
-        userProfile: this.state.userProfile,
+        userProfile,
         doLogout: this.doLogout
       }
     };
   },
 
-  componentDidMount(props, state) {
-    this.lock = new Auth0Lock(Auth0Variables.AUTH0_CLIENT_ID, Auth0Variables.AUTH0_DOMAIN);
-    this.setProfileOrShowLogin();
-  },
-
   doLogout() {
     window.localStorage.removeItem(this.props.localStorageKey);
-    window.location.reload();
+    this.setState({
+      hasConfirmedEmail: false,
+      userEmail: ''
+    });
   },
 
-  setProfileOrShowLogin() {
-    const {lock} = this;
-
-    // Check hash from redirect
-    const authHash = lock && lock.parseHash(window.location.hash);
-    if (authHash) {
-      window.history.replaceState({}, document.title, '/');
-      
-      const {error} = authHash;
-      const idToken = authHash.id_token;
-      const accessToken = authHash.access_token;
-      if (error) return this.setState({ loginError: error });
-      if (idToken && lock) {
-        return lock.getProfile(idToken, this.onSignInDone.bind(this, {
-          authHash,
-          accessToken,
-          userToken: idToken
-        }));
-      }
-    }
-
+  componentWillMount(prevProps, prevState) {
     // Check local storage cache
     const storedValues = window.localStorage.getItem(this.props.localStorageKey);
-    if (storedValues) {
-      const {userToken, userProfile} = JSON.parse(storedValues);
-      if (userToken && userProfile) return this.setState({userToken, userProfile});
-    }
+    if (!storedValues) return;
+    const {userEmail} = JSON.parse(storedValues);
+    if (!userEmail) return;
 
-    // Do a new login
-    return this.showLogin();
-  },
-
-  showLogin() {
-    this.lock && this.lock.show({
-      connections: ['google-oauth2'],
-      socialBigButtons: true,
-      icon: 'http://ram.raritanassets.com/images/global/why-power-icon_airflow.png',
-      closable: false,
-      popup: false,
-      responseType: 'token',
-      callbackOnLocationHash: true
+    this.setState({
+      userEmail,
+      hasConfirmedEmail: true
     });
   },
 
   componentDidUpdate(prevProps, prevState) {
-    const {userToken, userProfile} = this.state;
-    if (userToken !== prevState.userToken || userProfile !== prevState.userProfile) {
-      window.localStorage.setItem(this.props.localStorageKey, JSON.stringify({userToken, userProfile}));
+    const {userEmail, hasConfirmedEmail} = this.state;
+    if (hasConfirmedEmail && userEmail) {
+      window.localStorage.setItem(this.props.localStorageKey, JSON.stringify({userEmail, hasConfirmedEmail}));
     }
   },
 
-  onSignInDone({authHash, accessToken, userToken}, loginError, userProfile) {
-    this.setState({authHash, accessToken, userToken, loginError, userProfile});
+  validateEmail(email) {
+    var re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    return re.test(email);
+  },
+
+  onTextChanged(e) {
+    const userEmail = e.target.value;
+    this.setState({userEmail});
+  },
+
+  onDoneEmail(e) {
+    this.setState({ hasConfirmedEmail: true });
+  },
+
+  onDecline(e) {
+    this.setState({ isNavigatingAway: true });
+    window.location = 'http://tsl.mit.edu/';
   },
 
   render() {
-    const {loginError, userProfile} = this.state;
+    const {
+      userEmail,
+      hasConfirmedEmail,
+      isNavigatingAway
+    } = this.state;
 
-    return <div>
-      {loginError && <div>There was an error logging in.</div>}
-      {userProfile && this.props.children}
-    </div>;
+    if (isNavigatingAway) return <div style={{margin: 20}}>Loading...</div>;
+    return (
+      <div>
+        {hasConfirmedEmail && !_.isEmpty(userEmail)
+          ? this.props.children
+          : this.renderEmailForm()}
+      </div>
+    );
+  },
+
+  renderEmailForm() {
+    const {userEmail} = this.state;
+    const shouldShowWarning = userEmail.length > 10 && !this.validateEmail(userEmail);
+
+    return (
+      <div style={{height: '100%', position: 'fixed', backgroundColor: '#ccc'}}>
+        <AppBar
+          title="MIT Teaching Systems Lab"
+          iconElementLeft={
+            <IconButton onTouchTap={this.onDecline}>
+              <NavigationClose />
+            </IconButton>
+          }
+        />
+        <Paper style={{padding: 20}}>
+          <p>Please enter your email address.</p>
+          <p>It will only be used to identify your responses, and not shared or used in any other way.</p>
+          <div style={{marginBottom: 20}}>
+            <TextField
+              name="userEmail"
+              fullWidth={true}
+              hintText="Your email address"
+              errorText={shouldShowWarning && "Please enter a valid email address."}
+              errorStyle={{color: Colors.orange500}}
+              onChange={this.onTextChanged}
+            />
+          </div>
+          <div>
+            <RaisedButton
+              label="Start"
+              primary={true}
+              onTouchTap={this.onDoneEmail}
+              disabled={!this.validateEmail(userEmail)}
+            />
+          </div>
+        </Paper>
+      </div>
+    );
   }
 });

--- a/ui/src/home/home_page.jsx
+++ b/ui/src/home/home_page.jsx
@@ -28,16 +28,12 @@ export default React.createClass({
   },
 
   renderProfile() {
-    const {userProfile, authHash} = this.context.auth;
+    const {userProfile, doLogout} = this.context.auth;
 
     return (
       <div style={{marginTop: 50, border: '1px solid #eee'}}>
-        <div><img src={userProfile.picture} width="64" height="64"/></div>
-        <div>{userProfile.name}</div>
         <div>{userProfile.email}</div>
-        <pre>{JSON.stringify(userProfile, null, 2)}</pre>
-        <pre>{JSON.stringify(authHash, null, 2)}</pre>
-        <div><a href="#" onClick={this.context.auth.doLogout}>Logout</a></div>
+        <div><a href="#" onClick={doLogout}>Logout</a></div>
       </div>
     );
   }

--- a/ui/src/message_popup/experience_page.jsx
+++ b/ui/src/message_popup/experience_page.jsx
@@ -48,7 +48,7 @@ export default React.createClass({
       sessionId,
       competencyGroupValue: ALL_COMPETENCY_GROUPS,
       questions: allQuestions,
-      name: this.context.auth.userProfile.name,
+      email: this.context.auth.userProfile.email,
       hasStarted: false,
       questionsAnswered: 0,
       sessionLength: 20,
@@ -58,9 +58,9 @@ export default React.createClass({
     };
   },
 
-  onStartPressed(name, sessionLength, questions, shouldShowStudentCard,shouldShowSummary, helpType) {
+  onStartPressed(email, sessionLength, questions, shouldShowStudentCard,shouldShowSummary, helpType) {
     this.setState({
-      name,
+      email,
       sessionLength,
       questions,
       shouldShowStudentCard,
@@ -87,7 +87,7 @@ export default React.createClass({
   onLog(type, response:Response) {
     Api.logEvidence(type, {
       ...response,
-      name: this.state.name,
+      name: this.state.email,
       sessionId: this.state.sessionId,
       clientTimestampMs: new Date().getTime()
     });
@@ -165,7 +165,7 @@ export default React.createClass({
     return (
       <InstructionsCard 
         onStartPressed={this.onStartPressed}
-        name={this.state.name}
+        email={this.state.email}
         itemsToShow={this.props.query}
         />);
   }

--- a/ui/src/message_popup/instructions_card.jsx
+++ b/ui/src/message_popup/instructions_card.jsx
@@ -20,13 +20,13 @@ export default React.createClass({
   propTypes: {
     onStartPressed: React.PropTypes.func.isRequired,
     itemsToShow: React.PropTypes.object.isRequired,
-    name: React.PropTypes.string
+    email: React.PropTypes.string
   },
   
   getInitialState(){
     return ({
       isSolutionMode: _.has(this.props.itemsToShow, "solution"),
-      name: this.props.name,
+      email: this.props.email,
       sessionLength: 20,
       questions: allQuestions,
       competencyGroupValue: ALL_COMPETENCY_GROUPS,
@@ -37,13 +37,13 @@ export default React.createClass({
   },
   
   onTextChanged({target:{value}}:TextChangeEvent) {
-    this.setState({ name: value });
+    this.setState({ email: value });
   },
   
   onConfigurationSet(){
-    const {name, sessionLength, shouldShowStudentCard, shouldShowSummary, helpType} = this.state;
+    const {email, sessionLength, shouldShowStudentCard, shouldShowSummary, helpType} = this.state;
     const questions = this.getQuestions(this.state.competencyGroupValue);
-    this.props.onStartPressed(name, sessionLength, questions, shouldShowStudentCard ,shouldShowSummary, helpType);
+    this.props.onStartPressed(email, sessionLength, questions, shouldShowStudentCard ,shouldShowSummary, helpType);
   },
   
   onCompetencyGroupChanged(event, competencyGroupValue){
@@ -138,14 +138,14 @@ export default React.createClass({
               />}
           <TextField
             underlineShow={false}
-            floatingLabelText="What's your name?"
-            value={this.state.name}
+            floatingLabelText="What's your email address?"
+            value={this.state.email}
             onChange={this.onTextChanged}
             multiLine={true}
             rows={2}/>
           <div style={{display: 'flex', flexDirection: 'row', alignItems: 'flex-end'}}>
             <RaisedButton
-              disabled={this.state.name === ''}
+              disabled={this.state.email === ''}
               onTouchTap={this.onConfigurationSet}
               style={styles.button}
               secondary={true}


### PR DESCRIPTION
For the upcoming playtest, this removes the auth0 bounce to Google and instead just asks users to enter their email address.  There's no authentication of the address and there's no server-side checks.  It's stored in localStorage until the user "logs out" to clear it.

The experience page and scoring page are updated to use this email address.

#### Asking for email address
![screen shot 2016-07-06 at 11 08 24 am](https://cloud.githubusercontent.com/assets/1056957/16623125/b2446b30-436a-11e6-9d7f-46d04f68da03.png)

#### Updates to the experience page
![screen shot 2016-07-06 at 11 10 00 am](https://cloud.githubusercontent.com/assets/1056957/16623126/b46702ba-436a-11e6-9c15-3490d9f15d44.png)
