### PR TITLE
Improve scrolling with animated transition in scoring UI

### DIFF
--- a/ui/src/message_popup/instructions_card.jsx
+++ b/ui/src/message_popup/instructions_card.jsx
@@ -7,7 +7,6 @@ import ScaffoldingCard from "./scaffolding_card.jsx";
 import RaisedButton from 'material-ui/RaisedButton';
 import Divider from 'material-ui/Divider';
 import TextField from 'material-ui/TextField';
-import AppBar from 'material-ui/AppBar';
 import TextChangeEvent from '../types/dom_types.js';
 import {allStudents} from '../data/virtual_school.js';
 import {learningObjectives} from '../data/learning_objectives.js';

--- a/ui/src/message_popup/mobile_prototype_card.jsx
+++ b/ui/src/message_popup/mobile_prototype_card.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import _ from 'lodash';
 
-import {withStudents} from './transformations.jsx';
-
 //Material-UI imports
 import AppBar from 'material-ui/AppBar';
 import Paper from 'material-ui/Paper';

--- a/ui/src/message_popup/scoring_page.jsx
+++ b/ui/src/message_popup/scoring_page.jsx
@@ -49,7 +49,6 @@ export default React.createClass({
 
   onTransitionDone() {
     window.scrollTo(0, 0);
-    console.log("scroll")
   },
 
   onLogsReceived(err, response) {

--- a/ui/src/message_popup/scoring_page.jsx
+++ b/ui/src/message_popup/scoring_page.jsx
@@ -24,7 +24,14 @@ export default React.createClass({
   displayName: 'MessagePopupScoringPage',
 
   propTypes: {
-    query: React.PropTypes.object.isRequired
+    query: React.PropTypes.object.isRequired,
+    transitionMs: React.PropTypes.number
+  },
+
+  getDefaultProps() {
+    return {
+      transitionMs: 150
+    };
   },
 
   getInitialState() {
@@ -38,6 +45,11 @@ export default React.createClass({
   componentWillMount() {
     Api.evidenceQuery().end(this.onLogsReceived);
     Api.evaluationsQuery().end(this.onEvaluationsReceived);
+  },
+
+  onTransitionDone() {
+    window.scrollTo(0, 0);
+    console.log("scroll")
   },
 
   onLogsReceived(err, response) {
@@ -89,8 +101,8 @@ export default React.createClass({
       <div>
         {!logs && <div key="loading">Loading...</div>}
         <VelocityTransitionGroup
-          leave={{animation: "transition.slideLeftOut", duration: 150}}
-          enter={{animation: "transition.slideLeftIn", duration: 150}}
+          leave={{animation: "transition.slideLeftOut", duration: this.props.transitionMs, complete: this.onTransitionDone}}
+          enter={{animation: "transition.slideLeftIn", duration: this.props.transitionMs, complete: this.onTransitionDone}}
         >
           {logs && !selectedQuestion && this.renderQuestions(logs)}
         </VelocityTransitionGroup>

--- a/ui/src/message_popup/scoring_swipe.jsx
+++ b/ui/src/message_popup/scoring_swipe.jsx
@@ -1,6 +1,5 @@
 /* @flow weak */
 import React from 'react';
-import ReactDOM from 'react-dom';
 import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
 import 'velocity-animate/velocity.ui';
 import SwipeableViews from 'react-swipeable-views';

--- a/ui/src/message_popup/scoring_swipe.jsx
+++ b/ui/src/message_popup/scoring_swipe.jsx
@@ -1,5 +1,6 @@
 /* @flow weak */
 import React from 'react';
+import ReactDOM from 'react-dom';
 import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
 import 'velocity-animate/velocity.ui';
 import SwipeableViews from 'react-swipeable-views';


### PR DESCRIPTION
This is a small improvement to set the scroll position to the top of the window when navigating between the scoring screens.  It runs after the Velocity transition animation finishes.

This also has some unrelated eslint cleanup :)