### PR TITLE
Fix bug with threading helpType through to instructions page

### DIFF
--- a/ui/src/message_popup/experience_page.jsx
+++ b/ui/src/message_popup/experience_page.jsx
@@ -173,6 +173,7 @@ export default React.createClass({
         onStartPressed={this.onStartPressed}
         email={this.state.email}
         itemsToShow={this.props.query}
+        helpType={this.state.helpType}
         />);
   },
   

--- a/ui/src/message_popup/instructions_card.jsx
+++ b/ui/src/message_popup/instructions_card.jsx
@@ -32,7 +32,7 @@ export default React.createClass({
       competencyGroupValue: ALL_COMPETENCY_GROUPS,
       shouldShowStudentCard: true,
       shouldShowSummary: true,
-      helpType: 'feedback',
+      helpType: this.props.helpType
     });
   },
   


### PR DESCRIPTION
The `helpType` read from the URL in `experience_page` isn't passed into the `instructions_card`, so it essentially has no effect on the experience.  

@david-rosales this is also likely related to the refactoring like https://github.com/mit-teaching-systems-lab/threeflows/pull/67#issuecomment-230902000