### PR TITLE
Do scoring on separate domain with isolated problems responses

### DIFF
--- a/ui/playtest.html
+++ b/ui/playtest.html
@@ -51,7 +51,7 @@
 
       <ol class="list">
       <li>If you're an <b>experienced science teacher</b>, we'd love if you could share your feedback on how some undergraduates have responded to these scenarios.
-      <a href="/message_popup/scoring">Give feedback</a>
+      <a href="https://threeflows-playtest-20160712.herokuapp.com/message_popup/scoring">Give feedback</a>
       </li>
 
       <li>If you're an <b>intermediate or beginning science teacher</b>, we'd like you to try out these practice scenarios without any additional scaffolding.


### PR DESCRIPTION
I stood up a separate domain for scoring, so that the items that folks are scoring during the playtest are controlled past responses.  Responses from folks playing are kept separate and not visible to other players.