### PR TITLE
Add Rollbar to report JS errors

### DIFF
--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -2,7 +2,26 @@
 import App from './app.jsx';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import Rollbar from 'rollbar-browser';
+
 
 document.addEventListener('DOMContentLoaded', () => {
+  startRollbar();
   ReactDOM.render(<App history={true}/>, document.getElementById('app-main'));
 });
+
+
+function startRollbar() {
+  const {hostname, protocol, port} = window.location;
+  const portString = port === '' ? '' : `:${port}`;
+  const environment = `${protocol}//${hostname}${portString}`;
+
+  window.rollbar = Rollbar.init({
+    accessToken: "de42c0395e924afba679510bd16908a6",
+    captureUncaught: true,
+    captureUnhandledRejections: false,
+    payload: {
+      environment: environment
+    }
+  });
+}


### PR DESCRIPTION
So we have visibility into browser-side JS errors.  The environment var here is set based on the deployment so that we can collect all the things for now.  We can adjust this or turn off local errors if we find this bothersome.