### PR TITLE
Add eslint and Flow to build process

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "build": "cp *.html build && browserify -t [babelify] src/main.jsx -o build/bundle.js",
     "watch": "npm run build && watchify -t [babelify] -p livereactload src/main.jsx -o build/bundle.js",
-    "flow": "flow; test $? -eq 0 -o $? -eq 2",
+    "flow-quiet": "flow; test $? -eq 0 -o $? -eq 2",
     "lint-quiet": "eslint --fix --ext jsx --ext js -c .eslintrc src; exit 0",
-    "test": "echo No tests yet"
+    "lint": "eslint --ext jsx --ext js -c .eslintrc src",
+    "test": "npm run lint && flow"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This adds in eslint and Flow to the `npm test` command, which will also cause it to be run as part of the Travis build process.  The checks are run sequentially and a failure in either will break the build.