### PR TITLE
Add minimal UI for looking at logs, evaluations and indicators

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -114,7 +114,7 @@ function tellSlack(text) {
 }
 
 
-app.get('/server/query', facultyAuth, function(request, response) {
+app.get('/server/evidence', facultyAuth, function(request, response) {
   if (process.env.NODE_ENV === 'development' && process.env.READ_LOCAL_EVIDENCE) {
     return readFile('../../tmp/query.json')(request, response);
   }

--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -14,6 +14,7 @@ import HomePage from './home/home_page.jsx';
 import SlatePage from './slate/slate_page.jsx';
 import CSSTankPage from './csstank/csstank_page.jsx';
 import VirtualSchoolPage from './virtual_school/virtual_school_page.jsx';
+import RawPage from './ecd/raw_page.jsx';
 import * as MessagePopup from './message_popup/index.js';
 import {
   challenges,
@@ -35,6 +36,7 @@ export default React.createClass({
     '/message_popup': 'messagePopup',
     '/message_popup/exploration': 'messagePopupExploration',
     '/message_popup/scoring': 'messagePopupScoring',
+    '/ecd/raw': 'ecdRaw',
     '/slate/:id': 'slate',
     '/csstank': 'cssTank',
   },
@@ -101,5 +103,9 @@ export default React.createClass({
 
   virtualSchool(query = {}) {
     return <VirtualSchoolPage query={query} />;
+  },
+
+  ecdRaw(query = {}) {
+    return <RawPage query={query} />;
   }
 });

--- a/ui/src/ecd/raw_page.jsx
+++ b/ui/src/ecd/raw_page.jsx
@@ -1,9 +1,11 @@
 /* @flow weak */
+import _ from 'lodash';
 import React from 'react';
 
 import {Card, CardHeader, CardText} from 'material-ui/Card';
 import * as Colors from 'material-ui/styles/colors';
 import TextField from 'material-ui/TextField';
+import FlatButton from 'material-ui/FlatButton';
 
 import SetIntervalMixin from '../helpers/set_interval_mixin.js';
 import * as Api from '../helpers/api.js';
@@ -58,6 +60,10 @@ export default React.createClass({
     this.setState({ searchText: e.target.value });
   },
 
+  onTapEmail(email) {
+    this.setState({ searchText: email });
+  },
+
   filterRaw(items) {
     const {searchText} = this.state;
 
@@ -75,21 +81,55 @@ export default React.createClass({
         {!isLoaded && <div key="loading">Loading...</div>}
         {isLoaded &&
           <div>
-            <div>
-              <TextField
-                name="searchText"
-                onChange={this.onSearchTextChanged}
-                value={this.state.searchText}
-                fullWidth={true}
-                hintText="Search..."
-              />
-            </div>
+            <div>{this.renderSearch()}</div>
             <div>{this.renderLogs(logs)}</div>
             <div>{this.renderEvaluations(evaluations)}</div>
             <div>{this.renderIndicators(indicators)}</div>
           </div>
         }
       </div>
+    );
+  },
+
+  renderSearch() {
+    const {logs, evaluations} = this.state;
+    const emails = _.uniq(_.compact([].concat(
+      evaluations.map(evaluation => evaluation.json && evaluation.json.email),
+      logs.map(log => log.json && log.json.email)
+    )));
+    
+    return (
+      <Card
+        initiallyExpanded={true}>
+        <CardHeader
+          titleStyle={styles.cardTitleHeader}
+          title="Filter" />
+        <CardText>
+          <div>
+            <TextField
+              name="searchText"
+              onChange={this.onSearchTextChanged}
+              value={this.state.searchText}
+              fullWidth={true}
+              hintText="Search..."
+            />
+          </div>
+          <div>
+            <FlatButton
+              label="Clear"
+              primary={true}
+              onTouchTap={this.onTapEmail.bind(this, '')}
+            />
+            {emails.map(email => {
+              return <FlatButton
+                key={email}
+                label={email}
+                onTouchTap={this.onTapEmail.bind(this, email)}
+              />;
+            })}
+          </div>
+        </CardText>
+      </Card>
     );
   },
 

--- a/ui/src/ecd/raw_page.jsx
+++ b/ui/src/ecd/raw_page.jsx
@@ -1,0 +1,165 @@
+/* @flow weak */
+import React from 'react';
+
+import {Card, CardHeader, CardText} from 'material-ui/Card';
+import * as Colors from 'material-ui/styles/colors';
+import TextField from 'material-ui/TextField';
+
+import SetIntervalMixin from '../helpers/set_interval_mixin.js';
+import * as Api from '../helpers/api.js';
+import {indicators} from '../data/indicators.js';
+
+
+
+export default React.createClass({
+  displayName: 'RawPage',
+  mixins: [SetIntervalMixin],
+
+  propTypes: {
+    refreshIntervalMs: React.PropTypes.number.isRequired
+  },
+
+  getDefaultProps() {
+    return {
+      refreshIntervalMs: 5000
+    };
+  },
+
+  getInitialState() {
+    return {
+      indicators,
+      logs: null,
+      evaluations: null,
+      searchText: ''
+    };
+  },
+
+  componentDidMount(props, state) {
+    this.doReload();
+    this.setInterval(this.doReload, this.props.refreshIntervalMs);
+  },
+
+  doReload() {
+    Api.evidenceQuery().end(this.onDataReceived);
+    Api.evaluationsQuery().end(this.onEvaluationsReceived);
+  },
+
+  onDataReceived(err, response) {
+    const logs = JSON.parse(response.text).rows;
+    this.setState({logs});
+  },
+
+  onEvaluationsReceived(err, response) {
+    const evaluations = JSON.parse(response.text).rows;
+    this.setState({evaluations});
+  },
+
+  onSearchTextChanged(e) {
+    this.setState({ searchText: e.target.value });
+  },
+
+  filterRaw(items) {
+    const {searchText} = this.state;
+
+    return items.filter((item) => {
+      return JSON.stringify(item).indexOf(searchText) !== -1;
+    });
+  },
+
+  render() {
+    const {logs, evaluations, indicators} = this.state;
+    const isLoaded = logs && evaluations && indicators;
+
+    return (
+      <div style={styles.pageContainer}>
+        {!isLoaded && <div key="loading">Loading...</div>}
+        {isLoaded &&
+          <div>
+            <div>
+              <TextField
+                name="searchText"
+                onChange={this.onSearchTextChanged}
+                value={this.state.searchText}
+                fullWidth={true}
+                hintText="Search..."
+              />
+            </div>
+            <div>{this.renderLogs(logs)}</div>
+            <div>{this.renderEvaluations(evaluations)}</div>
+            <div>{this.renderIndicators(indicators)}</div>
+          </div>
+        }
+      </div>
+    );
+  },
+
+  renderLogs(logs) {
+    return (
+      <Card
+        style={{backgroundColor: Colors.amber700}}
+        initiallyExpanded={false}>
+        <CardHeader
+          titleStyle={styles.cardTitleHeader}
+          title="Logs"
+          actAsExpander={true}
+          showExpandableButton={true} />
+        <CardText expandable={true}>
+          {this.filterRaw(logs).map((log) => {
+            return <pre key={log.id} style={styles.line}>{JSON.stringify(log)}</pre>;
+          })}
+        </CardText>
+      </Card>
+    );
+  },
+
+  renderEvaluations(evaluations) {
+    return (
+      <Card
+        style={{backgroundColor: Colors.lightBlue200}}
+        initiallyExpanded={false}>
+        <CardHeader
+          titleStyle={styles.cardTitleHeader}
+          title="Evaluations"
+          actAsExpander={true}
+          showExpandableButton={true} />
+        <CardText expandable={true}>
+          {this.filterRaw(evaluations).map((evaluation) => {
+            return <pre key={evaluation.id} style={styles.line}>{JSON.stringify(evaluation)}</pre>;
+          })}
+        </CardText>
+      </Card>
+    );
+  },
+
+  renderIndicators(indicators) {
+    return (
+      <Card
+        style={{backgroundColor: Colors.deepPurple100}}
+        initiallyExpanded={false}>
+        <CardHeader
+          titleStyle={styles.cardTitleHeader}
+          title="Indicators"
+          actAsExpander={true}
+          showExpandableButton={true} />
+        <CardText expandable={true}>
+          {this.filterRaw(indicators).map((indicator) => {
+            return <pre key={indicator.id} style={styles.line}>{JSON.stringify(indicator)}</pre>;
+          })}
+        </CardText>
+      </Card>
+    );
+  }
+});
+
+const styles = {
+  cardTitleHeader: {
+    fontSize: 24
+  },
+  pageContainer: {
+    padding: 10
+  },
+  line: {
+    padding: 0,
+    margin: 0
+  }
+};

--- a/ui/src/helpers/anonymizer.js
+++ b/ui/src/helpers/anonymizer.js
@@ -1,0 +1,13 @@
+import fakeNames from '../data/fake_names.js';
+import d3 from 'd3';
+
+
+// Make this a consistent hash from the value
+export function create() {
+  const nameScale = d3.scale.ordinal()
+    .range(fakeNames);
+  
+  return {
+    name: (d) => nameScale(d.json.name)
+  };     
+}

--- a/ui/src/helpers/api.js
+++ b/ui/src/helpers/api.js
@@ -41,7 +41,7 @@ export function logEvidence(type, record) {
 
 export function evidenceQuery() {
   return request
-    .get('/server/query')
+    .get('/server/evidence')
     .set('Content-Type', 'application/json');
 }
 

--- a/ui/src/message_popup/exploration_page.jsx
+++ b/ui/src/message_popup/exploration_page.jsx
@@ -1,22 +1,14 @@
 import _ from 'lodash';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-import fakeNames from '../data/fake_names.js';
-import request from 'superagent';
 import d3 from 'd3';
 import dc from 'dc';
 import crossfilter from 'crossfilter';
 import dateFns from 'date-fns';
 
-// Make this a consistent hash from the value
-function createAnonymizer() {
-  const nameScale = d3.scale.ordinal()
-    .range(fakeNames);
-  
-  return {
-    name: (d) => nameScale(d.json.name)
-  };     
-}
+import * as Api from '../helpers/api.js';
+import * as Anonymizer from '../helpers/anonymizer.js';
+
 
 /*
 UI for exploring Message PopUp responses, not used for scoring.
@@ -45,17 +37,13 @@ export default React.createClass({
   },
 
   componentDidMount(props, state) {
-    this.anonymizer = createAnonymizer();
+    this.anonymizer = Anonymizer.create();
     document.addEventListener('keydown', (e) => {
       if (e.keyCode === 27) this.onResetClicked();
     });
 
     this.doInjectStyles();
-
-    request
-      .get('/server/query')
-      .set('Content-Type', 'application/json')
-      .end(this.onDataReceived);
+    Api.evidenceQuery().end(this.onDataReceived);
   },
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
This adds a minimal UI for searching logs, evaluations and indicators.  It polls to request more data, so can help monitor the playtest.

It also factors out the anonymizer function from the explorations page, but doesn't use it yet.

![screen shot 2016-07-12 at 11 32 57 am](https://cloud.githubusercontent.com/assets/1056957/16773039/67ab9bac-4824-11e6-92fb-34f8bf71fca4.png)
