### PR TITLE
Add in Rollbar dependency

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -41,6 +41,7 @@
     "react-swipeable-views": "^0.6.3",
     "react-tap-event-plugin": "^1.0.0",
     "reactify": "^1.1.1",
+    "rollbar-browser": "^1.9.1",
     "superagent": "^2.0.0",
     "velocity-animate": "^1.2.3",
     "velocity-react": "^1.1.5",


### PR DESCRIPTION
Fixing https://travis-ci.org/mit-teaching-systems-lab/threeflows/builds/144224728, I must have only installed this locally earlier.