### PR TITLE
Update API functions to return Promises

### DIFF
--- a/ui/.eslintrc
+++ b/ui/.eslintrc
@@ -1,6 +1,7 @@
 {
   "env": {
-    "browser": true
+    "browser": true,
+    "es6": true
   },
   "parser": "babel-eslint",
   "parserOptions": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,6 +43,7 @@
     "reactify": "^1.1.1",
     "rollbar-browser": "^1.9.1",
     "superagent": "^2.0.0",
+    "superagent-promise": "^1.1.0",
     "velocity-animate": "^1.2.3",
     "velocity-react": "^1.1.5",
     "watchify": "3.7.0"

--- a/ui/src/helpers/api.js
+++ b/ui/src/helpers/api.js
@@ -1,6 +1,8 @@
 /* @flow weak */
-import request from 'superagent';
+import superagent from 'superagent';
 import * as Routes from '../routes.js';
+import SuperagentPromise from 'superagent-promise';
+const request = SuperagentPromise(superagent, Promise);
 
 
 export function logEvaluation(type, record) {


### PR DESCRIPTION
In order to use `Promise.all` to join separate server requests, this PR:
- adds in `superagent-promise`
- updates `api.js` so that all requests return promises while still supporting existing callback usage
- updates the eslint config to allow ES6 globals like `Promise`