### PR TITLE
Add two minimal views for evaluations of candidate competencies, with refactors

### DIFF
--- a/ui/.eslintrc
+++ b/ui/.eslintrc
@@ -1,6 +1,7 @@
 {
   "env": {
-    "browser": true
+    "browser": true,
+    "es6": true
   },
   "parser": "babel-eslint",
   "parserOptions": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,6 +43,7 @@
     "reactify": "^1.1.1",
     "rollbar-browser": "^1.9.1",
     "superagent": "^2.0.0",
+    "superagent-promise": "^1.1.0",
     "velocity-animate": "^1.2.3",
     "velocity-react": "^1.1.5",
     "watchify": "3.7.0"

--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -15,6 +15,7 @@ import SlatePage from './slate/slate_page.jsx';
 import CSSTankPage from './csstank/csstank_page.jsx';
 import VirtualSchoolPage from './virtual_school/virtual_school_page.jsx';
 import RawPage from './ecd/raw_page.jsx';
+import CandidatePage from './ecd/candidate_page.jsx';
 import * as MessagePopup from './message_popup/index.js';
 import {
   challenges,
@@ -35,8 +36,10 @@ export default React.createClass({
     '/challenge/:id': 'challenge',
     '/message_popup': 'messagePopup',
     '/message_popup/exploration': 'messagePopupExploration',
+    '/message_popup/evaluations/:id': 'messagePopupEvaluation',
     '/message_popup/scoring': 'messagePopupScoring',
     '/ecd/raw': 'ecdRaw',
+    '/ecd/candidate': 'ecdCandidate',
     '/slate/:id': 'slate',
     '/csstank': 'cssTank',
   },
@@ -91,6 +94,10 @@ export default React.createClass({
   messagePopupScoring(query = {}) {
     return <MessagePopup.ScoringPage query={query} />;
   },
+
+  messagePopupEvaluation(evaluationId, query = {}) {
+    return <MessagePopup.EvaluationViewerPage evaluationId={evaluationId} />;
+  },
   
   cssTank(query = {}) {
     return <CSSTankPage query={query} />;
@@ -107,5 +114,9 @@ export default React.createClass({
 
   ecdRaw(query = {}) {
     return <RawPage query={query} />;
-  }
+  },
+
+  ecdCandidate(query = {}) {
+    return <CandidatePage candidateEmail={query.email} />;
+  },
 });

--- a/ui/src/ecd/candidate_page.jsx
+++ b/ui/src/ecd/candidate_page.jsx
@@ -1,0 +1,155 @@
+/* @flow weak */
+import _ from 'lodash';
+import React from 'react';
+import dateFns from 'date-fns';
+
+import {Card, CardHeader, CardText} from 'material-ui/Card';
+import * as Colors from 'material-ui/styles/colors';
+
+import * as Routes from '../routes.js';
+import * as Api from '../helpers/api.js';
+import * as EvaluationConstants from '../helpers/evaluation_constants';
+import {indicators} from '../data/indicators.js';
+
+
+/*
+A page showing all evaluations against indicators for a particular
+candidate.
+*/
+export default React.createClass({
+  displayName: 'CandidatePage',
+
+  propTypes: {
+    candidateEmail: React.PropTypes.string.isRequired
+  },
+
+  getInitialState() {
+    return {
+      indicators,
+      candidateEvaluations: null
+    };
+  },
+
+  componentDidMount(props, state) {
+    Api.evaluationsQuery().end(this.onEvaluationsReceived);
+  },
+
+  onEvaluationsReceived(err, response) {
+    const evaluations = JSON.parse(response.text).rows;
+    const candidateEvaluations = this.filteredByEmail(evaluations, this.props.candidateEmail);
+    this.setState({candidateEvaluations});
+  },
+
+  // Also filters out evaluations without links back to indicators.
+  filteredByEmail(evaluations, email) {
+    return evaluations.filter(evaluation => {
+      return evaluation.json && evaluation.json.email === email && evaluation.json.indicator;
+    });
+  },
+
+  computeGroupedIndicators(candidateEvaluations) {
+    const indicatorEvaluationsMap = _.groupBy(candidateEvaluations, (evaluation) => {
+      return evaluation.json && evaluation.json.indicator && evaluation.json.indicator.id;
+    });
+    return _.zipWith(_.toPairs(indicatorEvaluationsMap), ([indicatorId, evaluations]) => {
+      const indicator = _.find(indicators, indicator => indicator.id.toString() === indicatorId);
+      return {indicator, evaluations};
+    });
+  },
+
+  render() {
+    const {candidateEmail} = this.props;
+    const {candidateEvaluations, indicators} = this.state;
+    const isLoaded = candidateEvaluations && indicators;
+
+    return (
+      <div style={styles.pageContainer}>
+        <h2>{candidateEmail}</h2>
+        {!isLoaded && <div key="loading">Loading...</div>}
+        {isLoaded &&
+          <div>
+            <div>{this.renderIndicatorsTable()}</div>
+          </div>
+        }
+      </div>
+    );
+  },
+
+  renderIndicatorsTable() {
+    const {candidateEvaluations} = this.state;
+    const groupedIndicators = this.computeGroupedIndicators(candidateEvaluations);
+
+    return (
+      <Card
+        style={{backgroundColor: Colors.deepPurple100}}
+        initiallyExpanded={true}>
+        <CardHeader
+          titleStyle={styles.cardTitleHeader}
+          title="Indicators"
+          actAsExpander={true}
+          showExpandableButton={true} />
+        <CardText expandable={true}>
+          {groupedIndicators.map(({indicator, evaluations}) => {
+            return (
+              <div key={indicator.id} style={styles.line}>
+                <div style={styles.leftColumn}>{indicator.text}</div>
+                <div style={styles.rightColumn}>
+                  {evaluations.map(this.renderEvaluation, this)}
+                </div>
+              </div>
+            );
+          })}
+        </CardText>
+      </Card>
+    );
+  },
+
+  renderEvaluation(evaluation) {
+    const evaluationUrl = Routes.messagePopupEvaluationUrl(evaluation.id);
+    const dateText = dateFns.format(new Date(evaluation.timestamp), 'M/D');
+    const backgroundColor = EvaluationConstants.colorFor(evaluation.json.scoreValue);
+
+    return (
+      <a key={evaluation.id} href={evaluationUrl} style={{...styles.evaluationBox, backgroundColor, ...styles.boxLink}}>
+        <div title={evaluation.json.scoreComment}>{dateText}</div>
+      </a>
+    );
+  }
+});
+
+const styles = {
+  cardTitleHeader: {
+    fontSize: 24
+  },
+  pageContainer: {
+    padding: 10
+  },
+  line: {
+    padding: 0,
+    margin: 0,
+    display: 'flex',
+    alignItems: 'flex-start',
+    height: '5em',
+    justifyContent: 'flex-start'
+  },
+  evaluationBox: {
+    width: '3em',
+    height: '3em',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    border: '1px solid #666'
+  },
+  boxLink: {
+    color: 'black',
+    textDecoration: 'none'
+  },
+  leftColumn: {
+    flex: 6,
+    display: 'flex'
+  },
+  rightColumn: {
+    flex: 4,
+    display: 'flex'
+  }
+};

--- a/ui/src/helpers/api.js
+++ b/ui/src/helpers/api.js
@@ -1,6 +1,8 @@
 /* @flow weak */
-import request from 'superagent';
+import superagent from 'superagent';
 import * as Routes from '../routes.js';
+import SuperagentPromise from 'superagent-promise';
+const request = SuperagentPromise(superagent, Promise);
 
 
 export function logEvaluation(type, record) {

--- a/ui/src/helpers/evaluation_constants.js
+++ b/ui/src/helpers/evaluation_constants.js
@@ -1,0 +1,15 @@
+/* @flow */
+import * as MaterialColors from 'material-ui/styles/colors';
+
+/*
+Constants about evaluations.
+*/
+export const DEMONSTRATED_COMPETENCY = 1;
+export const NOT_YET_COMPETENCY = 0;
+export function colorFor(scoreValue:number) {
+  return Colors[scoreValue] || 'black';
+}
+export const Colors = {
+  [DEMONSTRATED_COMPETENCY]: MaterialColors.green500,
+  [NOT_YET_COMPETENCY]: MaterialColors.orange500
+};

--- a/ui/src/message_popup/evaluation_viewer_page.jsx
+++ b/ui/src/message_popup/evaluation_viewer_page.jsx
@@ -1,0 +1,85 @@
+/* @flow weak */
+import _ from 'lodash';
+import React from 'react';
+
+import AppBar from 'material-ui/AppBar';
+import * as Colors from 'material-ui/styles/colors';
+
+import * as Api from '../helpers/api.js';
+import ScoringQuestionContext from './scoring_question_context.jsx';
+import MessageResponseCard from './message_response_card.jsx';
+
+
+/*
+UI for viewing Message PopUp evaluations that have been completed previously.
+*/
+export default React.createClass({
+  displayName: 'MessagePopup.EvaluationViewerPage',
+
+  propTypes: {
+    evaluationId: React.PropTypes.string.isRequired
+  },
+
+  getInitialState() {
+    return {
+      evaluation: null,
+      log: null
+    };
+  },
+  
+  componentWillMount() {
+    Promise.all([
+      Api.evaluationsQuery(),
+      Api.evidenceQuery()
+    ]).then(this.onDataReceived);
+  },
+
+  // This is over-fetching to get all evidence and evaluations, and filtering
+  // down to a specific evaluation and the log it refers to.
+  onDataReceived([evaluationsResponse, evidenceResponse]) {
+    const {evaluationId} = this.props;
+    const evaluations = JSON.parse(evaluationsResponse.text).rows;
+    const evaluation = _.find(evaluations, evaluation => evaluation.id.toString() === evaluationId);
+    const logs = JSON.parse(evidenceResponse.text).rows;
+    const log = _.find(logs, log => log.id.toString() === evaluation.json.logId.toString());
+
+    this.setState({evaluation, log});
+  },
+
+  render() {
+    const {evaluation, log} = this.state;
+    const hasLoaded = evaluation && log;
+
+    return (
+      <div>
+        <AppBar title="Evaluation" />
+        {hasLoaded
+          ? this.renderEvaluation(evaluation, log)
+          : <div key="loading">Loading...</div>}
+      </div>
+    );
+  },
+
+  renderEvaluation(evaluation, log) {
+    const scoreColor = (evaluation.json.scoreValue === 0)
+      ? Colors.orange500
+      : Colors.green500;
+
+    return (
+      <div>
+        <ScoringQuestionContext
+          question={evaluation.json.question}
+          indicator={evaluation.json.indicator}
+          learningObjective={evaluation.json.learningObjective}
+        />
+        <MessageResponseCard log={log} />
+        <div style={{backgroundColor: scoreColor, padding: 10}}>
+          <div>Scored by: {evaluation.json.email}</div>
+          <div>Score: {evaluation.json.scoreValue}</div>
+          <div>Comment: {evaluation.json.scoreComment}</div>
+        </div>
+        <pre style={{color: Colors.grey300}}>{JSON.stringify({evaluation, log}, null, 2)}</pre>
+      </div>
+    );
+  }
+});

--- a/ui/src/message_popup/index.js
+++ b/ui/src/message_popup/index.js
@@ -2,5 +2,6 @@
 import ExperiencePage from './experience_page.jsx';
 import ExplorationPage from './exploration_page.jsx';
 import ScoringPage from './scoring_page.jsx';
+import EvaluationViewerPage from './evaluation_viewer_page.jsx';
 
-export {ExperiencePage, ExplorationPage, ScoringPage};
+export {ExperiencePage, ExplorationPage, ScoringPage, EvaluationViewerPage};

--- a/ui/src/message_popup/message_response_card.jsx
+++ b/ui/src/message_popup/message_response_card.jsx
@@ -1,0 +1,45 @@
+/* @flow weak */
+import React from 'react';
+
+import * as Colors from 'material-ui/styles/colors';
+import {Card, CardText} from 'material-ui/Card';
+
+
+/*
+Pure UI component showing a response to a question.
+*/
+export default React.createClass({
+  displayName: 'MessageResponseCard',
+
+  propTypes: {
+    log: React.PropTypes.object.isRequired,
+    extendStyle: React.PropTypes.object
+  },
+
+  render() {
+    const {log, extendStyle} = this.props;
+    const style = {...styles.itemCard, ...extendStyle};
+
+    return (
+      <Card key="competency" style={style}>
+        <CardText style={{fontSize: 16}}>
+          <div>
+            <div>{log.json.initialResponseText}</div>
+            <div style={styles.responseLatency}>{`${Math.round(log.json.elapsedMs/1000)} seconds`}</div>
+          </div>
+        </CardText>
+      </Card>
+    );
+  }
+});
+
+const styles = {
+  itemCard: {
+    borderBottom: '1px solid #eee',
+    margin: 0
+  },
+  responseLatency: {
+    marginTop: 10,
+    color: Colors.grey500
+  }
+};

--- a/ui/src/message_popup/scoring_question_context.jsx
+++ b/ui/src/message_popup/scoring_question_context.jsx
@@ -1,0 +1,74 @@
+/* @flow weak */
+import React from 'react';
+
+import {Card, CardHeader, CardText} from 'material-ui/Card';
+
+import StudentCard from './student_card.jsx';
+import ExamplesCard from './examples_card.jsx';
+import {questionId} from './questions.js';
+
+
+/*
+This shows the full context of a Message Popup question, for use in scoring
+or evaluating responses to it.
+*/
+export default React.createClass({
+  displayName: 'MessagePopUp.ScoringQuestionContext',
+
+  propTypes: {
+    question: React.PropTypes.object.isRequired,
+    learningObjective: React.PropTypes.object.isRequired,
+    indicator: React.PropTypes.object.isRequired
+  },
+
+  render() {
+    const {question, indicator, learningObjective} = this.props;
+    
+    return (
+      <div>
+        <Card
+          key="question"
+          zDepth={2}
+          initiallyExpanded={true}>
+          <CardHeader
+            title={`Question #${questionId(question)}`}
+            actAsExpander={true}
+            showExpandableButton={true}/>
+          <CardText
+            expandable={true}>
+              <div>
+                <div style={{paddingBottom: 20}}>{question.text}</div>
+                {question.student && <StudentCard useCardStyles={true} student={question.student} />}
+              </div>
+          </CardText>
+        </Card>
+        <Card key="learningObjective" zDepth={2}>
+          <CardHeader
+            title="Learning Objective"
+            actAsExpander={true}
+            showExpandableButton={true} />
+          <CardText
+            expandable={true}>{learningObjective.text}</CardText>
+        </Card>
+        <Card key="indicator" zDepth={2}>
+          <CardHeader
+            title="Indicator"
+            actAsExpander={true}
+            showExpandableButton={true} />
+          <CardText
+            expandable={true}>{indicator.text}</CardText>
+        </Card>
+        {question.examples.length > 0 &&
+          <ExamplesCard
+            key="examples"
+            titleText="Examples"
+            examples={question.examples} />}
+        {question.nonExamples.length > 0 &&
+          <ExamplesCard
+            key="non-examples"
+            titleText="Non-examples"
+            examples={question.nonExamples} />}
+      </div>
+    );
+  }
+});

--- a/ui/src/message_popup/scoring_swipe.jsx
+++ b/ui/src/message_popup/scoring_swipe.jsx
@@ -10,22 +10,18 @@ import RaisedButton from 'material-ui/RaisedButton';
 import DoneIcon from 'material-ui/svg-icons/action/done';
 import BackIcon from 'material-ui/svg-icons/navigation/arrow-back';
 import FeedbackIcon from 'material-ui/svg-icons/action/feedback';
-import * as Colors from 'material-ui/styles/colors';
-import {Card, CardHeader, CardText} from 'material-ui/Card';
+import {Card, CardText} from 'material-ui/Card';
 import LinearProgress from 'material-ui/LinearProgress';
 import IconButton from 'material-ui/IconButton';
 
-import StudentCard from './student_card.jsx';
-import ExamplesCard from './examples_card.jsx';
-import {questionId} from './questions.js';
-
+import ScoringQuestionContext from './scoring_question_context.jsx';
+import MessageResponseCard from './message_response_card.jsx';
+import * as EvaluationConstants from '../helpers/evaluation_constants';
+const {DEMONSTRATED_COMPETENCY, NOT_YET_COMPETENCY} = EvaluationConstants;
 
 const SWIPE_LEFT_INDEX = 0;
 const NO_SWIPE_INDEX = 1;
 const SWIPE_RIGHT_INDEX = 2;
-
-const DEMONSTRATED_COMPETENCY = 1;
-const NOT_YET_COMPETENCY = 0;
 
 
 /*
@@ -171,55 +167,13 @@ export default React.createClass({
 
   renderContext(logs) {
     const {question, indicator, learningObjective} = this.props;
-    
     return (
       <div>
-        <Card
-          key="question"
-          style={styles.contextCard}
-          zDepth={2}
-          initiallyExpanded={true}>
-          <CardHeader
-            title={`Question #${questionId(question)}`}
-            actAsExpander={true}
-            showExpandableButton={true}/>
-          <CardText
-            expandable={true}
-            style={styles.competencyText}>
-              <div>
-                <div style={{paddingBottom: 20}}>{question.text}</div>
-                {question.student && <StudentCard useCardStyles={true} student={question.student} />}
-              </div>
-          </CardText>
-        </Card>
-        <Card key="learningObjective" style={styles.contextCard} zDepth={2}>
-          <CardHeader
-            title="Learning Objective"
-            actAsExpander={true}
-            showExpandableButton={true} />
-          <CardText
-            expandable={true}
-            style={styles.competencyText}>{learningObjective.text}</CardText>
-        </Card>
-        <Card key="indicator" style={styles.contextCard} zDepth={2}>
-          <CardHeader
-            title="Indicator"
-            actAsExpander={true}
-            showExpandableButton={true} />
-          <CardText
-            expandable={true}
-            style={styles.competencyText}>{indicator.text}</CardText>
-        </Card>
-        {question.examples.length > 0 &&
-          <ExamplesCard
-            key="examples"
-            titleText="Examples"
-            examples={question.examples} />}
-        {question.nonExamples.length > 0 &&
-          <ExamplesCard
-            key="non-examples"
-            titleText="Non-examples"
-            examples={question.nonExamples} />}
+        <ScoringQuestionContext
+          question={question}
+          indicator={indicator}
+          learningObjective={learningObjective}
+        />
         <Card key="progress" style={styles.contextCard} zDepth={2}>
           <CardText>
             {logs.length > 0 && 
@@ -243,16 +197,7 @@ export default React.createClass({
   },
 
   renderItem(log) {
-    return (
-      <Card key="competency" style={{...styles.itemHeight, ...styles.itemCard}}>
-        <CardText style={{fontSize: 16}}>
-          <div>
-            <div>{log.json.initialResponseText}</div>
-            <div style={styles.responseLatency}>{`${Math.round(log.json.elapsedMs/1000)} seconds`}</div>
-          </div>
-        </CardText>
-      </Card>
-    );
+    return <MessageResponseCard log={log} extendStyle={styles.itemHeight} />;
   },
 
   renderFeedback(log) {
@@ -288,13 +233,8 @@ const styles = {
   listContainer: {
     paddingTop: 5
   },
-  contextCard: {},
   itemHeight: {
     minHeight: 150
-  },
-  itemCard: {
-    borderBottom: '1px solid #eee',
-    margin: 0
   },
   swipe: {
     color: 'white',
@@ -305,11 +245,11 @@ const styles = {
     height: '100%'
   },
   doneSwipe: {
-    backgroundColor: Colors.green500,
+    backgroundColor: EvaluationConstants.Colors[DEMONSTRATED_COMPETENCY],
     justifyContent: 'flex-end',
   },
   notYetSwipe: {
-    backgroundColor: Colors.orange500,
+    backgroundColor: EvaluationConstants.Colors[NOT_YET_COMPETENCY],
     justifyContent: 'flex-start'
   },
   textField: {},
@@ -321,9 +261,5 @@ const styles = {
   },
   showMoreButton: {
     margin: 20
-  },
-  responseLatency: {
-    marginTop: 10,
-    color: Colors.grey500
   }
 };

--- a/ui/src/routes.js
+++ b/ui/src/routes.js
@@ -25,6 +25,10 @@ export function messagePopupSolutionPath() {
   return "/message_popup?solution";
 }
 
+export function messagePopupEvaluationUrl(evaluationId:number) {
+  return `/message_popup/evaluations/${evaluationId}`;
+}
+
 
 /* Services */
 type EvidencePathT = {app:string, type:string, version:number};


### PR DESCRIPTION
This adds two minimal views, more for the immediate purpose of exploring data from the playtest than for sketching faculty-facing workflows.  This branch is on top of https://github.com/mit-teaching-systems-lab/threeflows/pull/84, which updates the API request methods to return Promises.

#### Evaluations against indicators for a candidate
This is for viewing all evaluations against all indicators for a candidate.  There's no way to navigate now, it's only accessible via query string (eg., `http://localhost:5000/ecd/candidate?email=kevin.robinson.0@gmail.com`).

It shows the set of indicators and any evaluations against those.  They're color coded by score and show the date.
![screen shot 2016-07-13 at 11 40 53 am](https://cloud.githubusercontent.com/assets/1056957/16809576/d1d6ee9e-48ee-11e6-9a9f-32e9ea799237.png)


#### Evaluation viewer
The other view is for viewing evaluations that faculty have made.  This can be navigated to from the candidate page.  Making this involved factoring out pieces of the UI from the scoring page.

![screen shot 2016-07-13 at 11 19 32 am](https://cloud.githubusercontent.com/assets/1056957/16809700/409e4f70-48ef-11e6-8599-d98b937260e8.png)
![screen shot 2016-07-13 at 11 19 37 am](https://cloud.githubusercontent.com/assets/1056957/16809701/409ebeba-48ef-11e6-9a0c-5134a0838fc1.png)