### PR TITLE
Fix bug in feedback mode with showing examples when question has none

### DIFF
--- a/ui/src/message_popup/popup_question.jsx
+++ b/ui/src/message_popup/popup_question.jsx
@@ -89,11 +89,13 @@ export default React.createClass({
   },
 
   onSavePressed() {
-    const {helpType} = this.props;
     this.logResponse();
-    if(helpType === 'feedback'){
-      this.setState({isRevising:true});
-    }else{
+    
+    const {helpType} = this.props;
+    const {examples} = this.props.question;
+    if(helpType === 'feedback' && examples.length > 0) {
+      this.setState({ isRevising: true });
+    } else{
       this.onDonePressed();
     }
   },


### PR DESCRIPTION
I noticed this trying some new questions without examples yet.  This adds another check so that the "revision" prompt is only shown if we're in feedback mode and there are actual examples to show.

The bug:
![screen shot 2016-07-15 at 4 51 02 pm](https://cloud.githubusercontent.com/assets/1056957/16888192/73b77990-4aac-11e6-9d2b-ab4d608b8ebd.png)
