### PR TITLE
Add MessagePopUp-specific evaluation data in raw assessment page

### DIFF
--- a/ui/src/ecd/raw_page.jsx
+++ b/ui/src/ecd/raw_page.jsx
@@ -11,6 +11,8 @@ import SetIntervalMixin from '../helpers/set_interval_mixin.js';
 import * as Api from '../helpers/api.js';
 import {indicators} from '../data/indicators.js';
 
+// app-specific
+import MessageEvaluationCard from '../message_popup/message_evaluation_card.jsx';
 
 
 export default React.createClass({
@@ -136,7 +138,6 @@ export default React.createClass({
   renderLogs(logs) {
     return (
       <Card
-        style={{backgroundColor: Colors.amber700}}
         initiallyExpanded={false}>
         <CardHeader
           titleStyle={styles.cardTitleHeader}
@@ -155,7 +156,6 @@ export default React.createClass({
   renderEvaluations(evaluations) {
     return (
       <Card
-        style={{backgroundColor: Colors.lightBlue200}}
         initiallyExpanded={false}>
         <CardHeader
           titleStyle={styles.cardTitleHeader}
@@ -164,6 +164,7 @@ export default React.createClass({
           showExpandableButton={true} />
         <CardText expandable={true}>
           {this.filterRaw(evaluations).map((evaluation) => {
+            if (evaluation.type === 'message_popup_response_scored') return <MessageEvaluationCard evaluation={evaluation} />;
             return <pre key={evaluation.id} style={styles.line}>{JSON.stringify(evaluation)}</pre>;
           })}
         </CardText>
@@ -174,7 +175,6 @@ export default React.createClass({
   renderIndicators(indicators) {
     return (
       <Card
-        style={{backgroundColor: Colors.deepPurple100}}
         initiallyExpanded={false}>
         <CardHeader
           titleStyle={styles.cardTitleHeader}

--- a/ui/src/message_popup/evaluation_viewer_page.jsx
+++ b/ui/src/message_popup/evaluation_viewer_page.jsx
@@ -8,6 +8,8 @@ import * as Colors from 'material-ui/styles/colors';
 import * as Api from '../helpers/api.js';
 import ScoringQuestionContext from './scoring_question_context.jsx';
 import MessageResponseCard from './message_response_card.jsx';
+import MessageEvaluationCard from './message_evaluation_card.jsx';
+
 
 
 /*
@@ -61,10 +63,6 @@ export default React.createClass({
   },
 
   renderEvaluation(evaluation, log) {
-    const scoreColor = (evaluation.json.scoreValue === 0)
-      ? Colors.orange500
-      : Colors.green500;
-
     return (
       <div>
         <ScoringQuestionContext
@@ -73,11 +71,7 @@ export default React.createClass({
           learningObjective={evaluation.json.learningObjective}
         />
         <MessageResponseCard log={log} />
-        <div style={{backgroundColor: scoreColor, padding: 10}}>
-          <div>Scored by: {evaluation.json.email}</div>
-          <div>Score: {evaluation.json.scoreValue}</div>
-          <div>Comment: {evaluation.json.scoreComment}</div>
-        </div>
+        <MessageEvaluationCard evaluation={evaluation} />
         <pre style={{color: Colors.grey300}}>{JSON.stringify({evaluation, log}, null, 2)}</pre>
       </div>
     );

--- a/ui/src/message_popup/message_evaluation_card.jsx
+++ b/ui/src/message_popup/message_evaluation_card.jsx
@@ -1,0 +1,31 @@
+/* @flow weak */
+import React from 'react';
+
+import * as Colors from 'material-ui/styles/colors';
+
+
+/*
+Pure UI component showing an evaluation for a question.
+*/
+export default React.createClass({
+  displayName: 'MessageEvaluationCard',
+
+  propTypes: {
+    evaluation: React.PropTypes.object.isRequired
+  },
+
+  render() {
+    const {evaluation} = this.props;
+    const scoreColor = (evaluation.json.scoreValue === 0)
+      ? Colors.orange500
+      : Colors.green500;
+
+    return (
+      <div style={{backgroundColor: scoreColor, padding: 10}}>
+        <div>Scored by: {evaluation.json.email}</div>
+        <div>Score: {evaluation.json.scoreValue}</div>
+        <div>Comment: {evaluation.json.scoreComment}</div>
+      </div>
+    );
+  }
+});


### PR DESCRIPTION
For easier reviewing of evaluations done during playtest.  Not attached to this as a direction, but it's useful for reviewing data right now.

![screen shot 2016-07-18 at 10 32 04 am](https://cloud.githubusercontent.com/assets/1056957/16918285/f0ef5388-4cd2-11e6-9630-654ff6c9f48a.png)
