### PR TITLE
Make MessagePopUp evaluation clickable in raw gradebook view

### DIFF
--- a/ui/src/ecd/raw_page.jsx
+++ b/ui/src/ecd/raw_page.jsx
@@ -8,6 +8,7 @@ import FlatButton from 'material-ui/FlatButton';
 import * as Colors from 'material-ui/styles/colors';
 
 import SetIntervalMixin from '../helpers/set_interval_mixin.js';
+import * as Routes from '../routes.js';
 import * as Api from '../helpers/api.js';
 import {indicators} from '../data/indicators.js';
 import NavigationAppBar from '../components/navigation_app_bar.jsx';
@@ -171,8 +172,8 @@ export default React.createClass({
             return (
               <div key={evaluation.id}>
                 {evaluation.type === 'message_popup_response_scored'
-                  ? <MessageEvaluationCard evaluation={evaluation} />
-                  : <pre key={evaluation.id} style={styles.line}>{JSON.stringify(evaluation)}</pre>}
+                  ? this.renderMessagePopupEvaluation(evaluation)
+                  : <pre style={styles.line}>{JSON.stringify(evaluation)}</pre>}
               </div>
             );
           })}
@@ -196,6 +197,14 @@ export default React.createClass({
           })}
         </CardText>
       </Card>
+    );
+  },
+
+  renderMessagePopupEvaluation(evaluation) {
+    return (
+      <a style={{textDecoration: 'none', color: 'black'}} href={Routes.messagePopupEvaluationUrl(evaluation.id)}>
+        <MessageEvaluationCard evaluation={evaluation} />
+      </a>
     );
   }
 });


### PR DESCRIPTION
For easier navigation and exploration of playtest evaluations, these items are clickable:

![screen shot 2016-07-18 at 11 10 50 am](https://cloud.githubusercontent.com/assets/1056957/16919634/89f05cee-4cd8-11e6-934b-d830f908f893.png)
