### PR TITLE
Swap evaluator and candidate pages, abstract querying to Api

### DIFF
--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -16,6 +16,7 @@ import CSSTankPage from './csstank/csstank_page.jsx';
 import VirtualSchoolPage from './virtual_school/virtual_school_page.jsx';
 import RawPage from './ecd/raw_page.jsx';
 import CandidatePage from './ecd/candidate_page.jsx';
+import EvaluatorPage from './ecd/evaluator_page.jsx';
 import DoSomethingPage from './do_something/do_something_page.jsx';
 import * as MessagePopup from './message_popup/index.js';
 import {
@@ -42,6 +43,7 @@ export default React.createClass({
     '/do_something': 'doSomething',
     '/ecd/raw': 'ecdRaw',
     '/ecd/candidate': 'ecdCandidate',
+    '/ecd/evaluator': 'ecdEvaluator',
     '/slate/:id': 'slate',
     '/csstank': 'cssTank',
   },
@@ -127,4 +129,8 @@ export default React.createClass({
   ecdCandidate(query = {}) {
     return <CandidatePage candidateEmail={query.email} />;
   },
+
+  ecdEvaluator(query = {}) {
+    return <EvaluatorPage evaluatorEmail={query.email} />;
+  }
 });

--- a/ui/src/helpers/api.js
+++ b/ui/src/helpers/api.js
@@ -1,4 +1,5 @@
 /* @flow weak */
+import _ from 'lodash';
 import superagent from 'superagent';
 import * as Routes from '../routes.js';
 import SuperagentPromise from 'superagent-promise';
@@ -51,4 +52,21 @@ export function evaluationsQuery() {
   return request
     .get('/server/evaluations')
     .set('Content-Type', 'application/json');
+}
+
+// Query both endpoints and join inefficently in the browser
+export function evaluationsWithEvidenceQuery() {
+  return Promise.all([
+    evaluationsQuery(),
+    evidenceQuery()
+  ]).then(joinEvaluationsWithEvidence);
+}
+
+function joinEvaluationsWithEvidence([evaluationsResponse, evidenceResponse]) {
+  const evaluations = JSON.parse(evaluationsResponse.text).rows;
+  const logs = JSON.parse(evidenceResponse.text).rows;
+  return evaluations.map((evaluation) => {
+    const log = _.find(logs, log => log.id.toString() === evaluation.json.logId.toString());
+    return {...evaluation, log};
+  });
 }

--- a/ui/src/message_popup/evaluation_viewer_page.jsx
+++ b/ui/src/message_popup/evaluation_viewer_page.jsx
@@ -30,20 +30,15 @@ export default React.createClass({
   },
   
   componentWillMount() {
-    Promise.all([
-      Api.evaluationsQuery(),
-      Api.evidenceQuery()
-    ]).then(this.onDataReceived);
+    Api.evaluationsWithEvidenceQuery().then(this.onDataReceived);
   },
 
   // This is over-fetching to get all evidence and evaluations, and filtering
   // down to a specific evaluation and the log it refers to.
-  onDataReceived([evaluationsResponse, evidenceResponse]) {
+  onDataReceived(evaluations) {
     const {evaluationId} = this.props;
-    const evaluations = JSON.parse(evaluationsResponse.text).rows;
     const evaluation = _.find(evaluations, evaluation => evaluation.id.toString() === evaluationId);
-    const logs = JSON.parse(evidenceResponse.text).rows;
-    const log = _.find(logs, log => log.id.toString() === evaluation.json.logId.toString());
+    const {log} = evaluation;
 
     this.setState({evaluation, log});
   },

--- a/ui/src/message_popup/experience_page.jsx
+++ b/ui/src/message_popup/experience_page.jsx
@@ -75,6 +75,7 @@ export default React.createClass({
     Api.logEvidence(type, {
       ...response,
       name: this.state.gameSession.email,
+      email: this.state.gameSession.email,
       sessionId: this.state.gameSession.sessionId,
       clientTimestampMs: new Date().getTime()
     });

--- a/ui/src/message_popup/index.js
+++ b/ui/src/message_popup/index.js
@@ -7,13 +7,19 @@ import ScoringPage from './scoring_page.jsx';
 import EvaluationViewerPage from './evaluation_viewer_page.jsx';
 import MessageEvaluationCard from './message_evaluation_card.jsx';
 
+
 // Returns a unique set of emails for people we have evidence for.
 // The check for @ is because of older logs that used names instead of email
 // addresses.
-function emailsFromLogs(logs:[ResponseLogT]) {
-  return _.uniq(_.compact(logs.map(log => log.json && log.json.name))).filter((name) => {
-    return name.indexOf('@') !== -1;
-  });
+export function candidateEmailFromLog(log:ResponseLogT) {
+  if (!log.json) return undefined;
+  if (log.json.email) return log.json.email;
+  if (log.json.name && log.json.name.indexOf('@') !== -1) return log.json.name;
+  return undefined;
+}
+
+export function emailsFromLogs(logs:[ResponseLogT]) {
+  return _.uniq(_.compact(logs.map(candidateEmailFromLog)));
 }
 
 export {
@@ -21,6 +27,5 @@ export {
   ExplorationPage,
   ScoringPage,
   EvaluationViewerPage,
-  MessageEvaluationCard,
-  emailsFromLogs
+  MessageEvaluationCard
 };

--- a/ui/src/message_popup/scoring_swipe.jsx
+++ b/ui/src/message_popup/scoring_swipe.jsx
@@ -78,7 +78,8 @@ export default React.createClass({
       learningObjective,
       indicator,
       question,
-      email
+      email,
+      scorerEmail: email
     });
   },
 


### PR DESCRIPTION
The initial candidate page was actually filtering by evaluator email, so this moves that to an evaluator page and adds a proper candidate page.

It also moves some querying and joining code into the `api` module, and renames the fields to be clearer on the write path.