### PR TITLE
Show indicators instead of competency groups when starting session

### DIFF
--- a/ui/src/message_popup/transformations.jsx
+++ b/ui/src/message_popup/transformations.jsx
@@ -23,15 +23,16 @@ export function withLearningObjectiveAndIndicator(question) {
   };
 }
 
-export function questionsForCompetencies(competencyGroup) {
-  const withCompetencyGroups = _.compact(allQuestions.map((question) => {
-    const learningObjective = _.find(learningObjectives, { id: question.learningObjectiveId });
-    if (learningObjective.competencyGroup !== competencyGroup) return null;
+export function questionsForIndicator(indicatorId) {
+  const withIndicators = _.compact(allQuestions.map((question) => {
+    if (question.indicatorId !== indicatorId) return null;
+    
+    const indicator = _.find(indicators, { id: question.indicatorId });
     return {
       ...question,
-      competencyGroup: learningObjective.competencyGroup
+      indicator
     };
   }));
 
-  return _.shuffle(withStudents(withCompetencyGroups));
+  return _.shuffle(withStudents(withIndicators));
 }


### PR DESCRIPTION
This said "learning objectives" before when actually showing competency groups, so this clarifies and uses the indicator as the grain size shown to the player:

Before:
<img width="342" alt="screen shot 2016-07-21 at 3 49 01 pm" src="https://cloud.githubusercontent.com/assets/1056957/17036546/baaf2354-4f5a-11e6-99d6-51aca6e47813.png">


After:
<img width="370" alt="screen shot 2016-07-21 at 3 47 33 pm" src="https://cloud.githubusercontent.com/assets/1056957/17036498/8a26091e-4f5a-11e6-90cd-4f717622cf93.png">
