### PR TITLE
Adds support for multiple students

### DIFF
--- a/ui/src/message_popup/popup_question.jsx
+++ b/ui/src/message_popup/popup_question.jsx
@@ -39,7 +39,7 @@ export default React.createClass({
       text: React.PropTypes.string.isRequired,
       examples: React.PropTypes.array.isRequired,
       nonExamples: React.PropTypes.array.isRequired,
-      student: React.PropTypes.object
+      students: React.PropTypes.array
     }).isRequired,
     onLog: React.PropTypes.func.isRequired,
     onDone: React.PropTypes.func.isRequired,
@@ -156,8 +156,9 @@ export default React.createClass({
   renderQuestion(){
     const {elapsedMs} = this.state;
     const {scaffolding} = this.props;
-    const {text, student, examples, nonExamples} = this.props.question;
+    const {text, students, examples, nonExamples} = this.props.question;
     const seconds = Math.round(elapsedMs / 1000);
+    const student = students[0];
     
     return (
       <div>

--- a/ui/src/message_popup/popup_question.jsx
+++ b/ui/src/message_popup/popup_question.jsx
@@ -158,7 +158,7 @@ export default React.createClass({
     const {scaffolding} = this.props;
     const {text, students, examples, nonExamples} = this.props.question;
     const seconds = Math.round(elapsedMs / 1000);
-    const student = students[0];
+    const student = students === undefined ? undefined : students[0];
     
     return (
       <div>

--- a/ui/src/message_popup/popup_question.jsx
+++ b/ui/src/message_popup/popup_question.jsx
@@ -39,7 +39,7 @@ export default React.createClass({
       text: React.PropTypes.string.isRequired,
       examples: React.PropTypes.array.isRequired,
       nonExamples: React.PropTypes.array.isRequired,
-      students: React.PropTypes.array
+      students: React.PropTypes.array.isRequired
     }).isRequired,
     onLog: React.PropTypes.func.isRequired,
     onDone: React.PropTypes.func.isRequired,
@@ -158,7 +158,7 @@ export default React.createClass({
     const {scaffolding} = this.props;
     const {text, students, examples, nonExamples} = this.props.question;
     const seconds = Math.round(elapsedMs / 1000);
-    const student = students === undefined ? undefined : students[0];
+    const student = students[0];
     
     return (
       <div>

--- a/ui/src/message_popup/questions.js
+++ b/ui/src/message_popup/questions.js
@@ -23,7 +23,7 @@ function forIndicator(indicatorId) {
 }
 
 export type Question = {
-  studentId?: number,
+  studentIds?: [number],
   id: number,
   text: string,
   examples: [string],
@@ -31,7 +31,7 @@ export type Question = {
 };
 export const inquiryQuestions:[Question] = [
   { 
-    studentId: 4, 
+    studentIds: [4], 
     id: 101,
     text: `At the conclusion of your lesson plan for this challenge, you seed a group discussion by asking "What are you curious about related to photosynthesis?"  Hayin says "Why are plants green?"  What do you do?`,
     examples: [
@@ -48,7 +48,7 @@ export const inquiryQuestions:[Question] = [
     ]
   },  
   {
-    studentId: 10, 
+    studentIds: [10], 
     id: 102,
     text: `Imagine a new student, Sasha, joins your classroom during the lesson plan you developed for this challenge.  As part of helping her feel comfortable, you give her a quick overview of what's happening.  She asks "what is photosynthesis again?"  How can you give a brief direct answer to her question?`,
     examples: [
@@ -64,7 +64,7 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   { 
-    studentId: 2, 
+    studentIds: [2], 
     id: 103,
     text: `In the context of the lesson plan you developed for this challenge, Floyd says "why are we even doing this?"  Respond in way that engages his natural curiosity and tendency towards asking questions`,
     examples: [
@@ -80,7 +80,7 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 8,
+    studentIds: [8],
     id: 104,
     text: `Imagine in the context of the lesson plan you developed for this challenge, there is an activity where students are coming up with questions to investigate.  Ada says "How many questions should I write and what do you want me to include in them?"  Respond in a way that draws out the student's curiosity and pushes them towards asking questions that are meaningful to them.`,
     examples: [
@@ -100,7 +100,7 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 10,
+    studentIds: [10],
     id: 105,
     text: `Imagine a new student, Sasha, joins your classroom during the lesson plan you developed for this challenge.  As part of helping her feel comfortable, you pull her aside and give her a quick overview of what's happening at the beginning of the class.  She interrupts and asks, "I do better with visuals, can you draw me a picture of photosynthesis?"  Describe what you could quickly sketch to directly answer her question.`,
     examples: [
@@ -112,7 +112,7 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 3,
+    studentIds: [3],
     id: 106,
     text: `Imagine in the context of the lesson plan you developed for this challenge, you pause and ask the whole class if they have anything they want to check their understanding on or clarify.  Maia asks "How can plants be breathing, you don't see them inhaling and exhaling, and you don't see their breath in the cold?"`,
     examples: [
@@ -125,7 +125,7 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 5,
+    studentIds: [5],
     id: 107,
     text: `Imagine in the context of the lesson plan you developed for this challenge, you provide a summarizing explanation of photosynthesis to the whole class.  Mike asks, "I'm still a little confused, can you explain it again in a different way?"`,
     examples: [
@@ -139,7 +139,7 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 2,
+    studentIds: [2],
     id: 108,
     text: `Imagine in the context of the lesson plan you developed for this challenge, you provide a summarizing explanation of photosynthesis to the whole class.  Floyd asks, "But how can plants take in sunlight, do they like grab it?"`,
     examples: [
@@ -153,7 +153,7 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 9,
+    studentIds: [9],
     id: 109,
     text: 'You challenge Steve and ask, "What is another hypothesis you could test?" He asks, "why don\'t you just tell me what the right answer is?"',
     examples: [
@@ -181,9 +181,9 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 1,
+    studentIds: [1],
     id: 111,
-    text: 'You set up an experiment that tests how light intensity affects photosynthesis over time and recorded the data. Kevin says, “Plant A probably grew more because it a genetically modified by Home Depot,” and the whole class laughs. Prompt the student to clarify and use evidence.',
+    text: 'You set up an experiment that tests how light intensity affects photosynthesis over time and recorded the data. Kevin says, "Plant A probably grew more because it was genetically modified by Home Depot," and the whole class laughs. Prompt the student to clarify and use evidence.',
     examples: [
       'Ask the student to make claims using evidence',
       `That's a great point! Genetically modified plants are going to be a part of our lives. I'm curious - do you think Home Depot would genetically modify a plant? Could you clarify your ideas a little more?`,
@@ -194,7 +194,7 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 6,
+    studentIds: [6],
     id: 112,
     text: `As you walk around, you see that Jasmine is missing some data in their data tables. What could you do to nudge her in the right direction?`,
     examples: [
@@ -208,9 +208,9 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 7,
+    studentIds: [7],
     id: 113,
-    text: 'Miquel finished generating questions (i.e. hypotheses) about photosynthesis, and some are not testable. How can you connect their responses with the idea of planning research?',
+    text: 'Miquel finished generating questions (i.e. hypotheses) about photosynthesis, and some are not testable. How can you connect his responses with the idea of planning research?',
     examples: [
       'Explain what a testable hypothesis is.'
     ],
@@ -219,7 +219,7 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
-    studentId: 5,
+    studentIds: [5],
     id: 114,
     text: `You set up a photosynthesis experiment for the class, and students report the data they\'ve collected. As it turns out, Mike has experimented with only two variables: hours of light and water.  Respond to this by connecting this with data collection planning.`,
     examples: [
@@ -234,7 +234,7 @@ export const inquiryQuestions:[Question] = [
 
 export const motivationQuestions:[Question] = [
   {
-    studentId: 8,
+    studentIds: [8],
     id: 115,
     text: 'Ada is frustrated that she cannot figure out how her data supports her initial hypothesis. She refuses to modify her question, instead saying, "I don\'t want to try again because I will just mess up again."',
     examples: [
@@ -244,9 +244,9 @@ export const motivationQuestions:[Question] = [
     nonExamples: []
   },
   {
-    studentId: 3,
+    studentIds: [3, 8],
     id: 116,
-    text: 'At the end of the photosynthesis unit, you introduce a list of topics that students choose for a project they want to do. Maia raises her hand and says, "I don\'t want to do any of these. Can I just come up with my own thing?" Even before you have a chance to respond to her, another student, another student, says, "I want to do my own topic too!"  Respond.',
+    text: 'At the end of the photosynthesis unit, you introduce a list of topics that students choose for a project they want to do. Maia raises her hand and says, "I don\'t want to do any of these. Can I just come up with my own thing?" Even before you have a chance to respond to her, another student says, "I want to do my own topic too!"  Respond.',
     examples: [
       'Try the principle: Interest-powered learning',
       'Try the principle: Encourage choice (Glasser)'
@@ -254,9 +254,9 @@ export const motivationQuestions:[Question] = [
     nonExamples: []
   },
   {
-    studentId: 8,
+    studentIds: [8, 5],
     id: 117,
-    text: 'Students are working individually on a worksheet. You notice that a student is distracted.  She lashes out, "I can\'t do this! And Mike gets it.  He just gets science and I don\'t. Why do I even need to try?"',
+    text: 'Students are working individually on a worksheet. You notice that a student is distracted.  She lashes out, "I can\'t do this! And Mike gets it. He just gets science and I don\'t. Why do I even need to try?"',
     examples: [
       'Try the principle: Everyone has the capacity to grow (Dweck)',
       'Try the principle: Persisting through challenges is how we grow (Duckworth)'
@@ -274,7 +274,7 @@ export const motivationQuestions:[Question] = [
     nonExamples: []
   },
   {
-    studentId: 10,
+    studentIds: [10],
     id: 119,
     text: 'You divide students into groups to perform a photosynthesis experiment. Students get to divide themselves into groups. A new student, Sasha, doesn\'t get picked until the last minute.  What would you do?',
     examples: [
@@ -284,7 +284,7 @@ export const motivationQuestions:[Question] = [
     nonExamples: []
   },
   {
-    studentId: 3,
+    studentIds: [3, 1],
     id: 120,
     text: 'You introduced a game related to photosynthesis, and have pairs of two working on a game. Maia is paired with Kevin, and she asks, "How are we getting graded on this?" You tell her that there will be no grade for either completion or participation. "Why are we doing this then?" she asks.',
     examples: [

--- a/ui/src/message_popup/questions.js
+++ b/ui/src/message_popup/questions.js
@@ -167,6 +167,7 @@ export const inquiryQuestions:[Question] = [
     ]
   },
   {
+    studentIds: [],
     id: 110,
     text: 'You ask the whole class, "how can you test if the amount of sunlight influences the amount of O2 generated as a result of photosynthesis?"  You wait a few seconds and nobody comes forward with an answer.  What would you do?',
     examples: [
@@ -264,6 +265,7 @@ export const motivationQuestions:[Question] = [
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 118,
     text: 'For the end of the photosynthesis unit, you arranged a field trip to a local farm so that students could present their findings on improving crop yield potential to professionals in the field. However, when you tell the class about the project, they don\'t seem to be excited.  What would you do to communicate the benefits of this field trip to your class?',
     examples: [
@@ -299,102 +301,119 @@ export const motivationQuestions:[Question] = [
 
 export const doSomethingQuestions:[Question] = [
   {
+    studentIds: [],
     id: 301,
     text: 'During afternoon homeroom, two students are playing a hand slap game which gets out of control after a few rounds when a student yells and is about to cry.',
     examples: [],
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 302,
     text: 'It is the first public share of student work.  Students are sharing their thinking maps in small groups.  One student clearly spent more time on his piece and added glitter and neon.  When he begins to share, the most volatile student lets out a laugh, "ohh my god that is sooo gay."',
     examples: [],
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 303,
     text: 'After lunch, you come back to the room and see someone took down the color chart or homework chart and threw it on the floor.  It is not clear who did this.',
     examples: [],
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 304,
     text: 'During a mini lesson you inadvertently say a phrase that clearly is taken as a sexual innuendo by a small group of students who start laughing out loud.  Others are in the dark or missed it.  You hear them ask, "what?.."',
     examples: [],
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 305,
     text: 'You are checking homework, and you notice Danny doesn\'t have his hw out and ready.  You write it down on your clipboard without interrupting his Do Now.  You ask his partner where her homework is.  Danny looks up and says loudly, "you didn\'t ask me for my homework--what, it\'s cause I\'m black!"',
     examples: [],
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 306,
     text: 'During a lesson on the rug, you are engaging the class in a Read Aloud, students are clearly engaged.  However, you soon notice that one student in the back of the room is writing all over her desk top seeming not to be paying attention.',
     examples: [],
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 307,
     text: 'Students are working in small groups of three or four. You scan and notice that in one group only one student is doing all the work while the other two are drawing and in another group one of the students keeps calling another student "stupid" and telling the student that his/her ideas, "suck".',
     examples: [],
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 308,
     text: 'You have started a well planned launch of a lesson where just about every word and idea is critical to the student entry into the problem solving part of the lesson. A student waves his/her hand and asks to go to the bathroom.',
     examples: [],
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 309,
     text: 'It is group work time, and students are working on a problem solving protocol on chart papers.  One group calls out, “who has a green marker?”  Across the room--the green marker flies, successfully, from one group to another.',
     examples: [],
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 310,
     text: 'It\'s rug time. You transition the class to the rug. One student refuses to leave his seat and starts yelling out negative comments, "I hate this class. The work we do is stupid."',
     examples: [],
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 311,
     text: 'The lesson is going along smoothly. You ask a question and calls on a student, as the student begins to respond, another student then yells out, "You NEVER call on me!" and rips their paper up.',
     examples: [],
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 313,
     text: 'The class is actively engaged in a discussion about a time they felt grown up, and as you scan the room, you notice a student has their head down and is staring into space.',
     examples: [],
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 314,
     text: 'Students have just returned to class from special and have started the routine of independent reading. You are passing out the snack for the day - bananas. As you reach one student, she asks, "What can we have if we don\'t like bananas?" You say, "Bananas are the only choice. It\'s bananas or you can wait until lunch." The student yells out "WHAT?! I don\'t like bananas," walks out of her seat, rolls up half the rug, and then starts slamming the door repeatedly.',
     examples: [],
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 315,
     text: 'The class is lining up for specials in line order. One of your students decides to cut in front of another student. You hear the other student ask her to kindly move but she refuses with a smirk on her face. You tell the student she needs to return to her line spot, but she continues to stand there silently. Your student who was cut starts to stomp her feet and yell "That\'s not fair that she gets to cut!"',
     examples: [],
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 316,
     text: 'It\'s the third day of school, a student walks in the middle of the mini lesson and yells, "Ms. I\'m in your class now!" The class bursts out in equal parts "ooooohhhh" and "oh nooooooo"  The newly entering student begins to answer back, "What?"',
     examples: [],
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 317,
     text: 'Students are getting ready for dismissal. There are few students out in the classroom getting their backpacks as you are monitoring the other students working at their desks. One student comes in and reports two students are fighting in the hallway. You walk out and see one student pinning the other student to the ground. Many students from the class have gotten out of their desks and are watching in the doorway.',
     examples: [],
     nonExamples: []
   },
   {
+    studentIds: [],
     id: 318,
     text: 'It is the second full week of school and during your silent do now, you hear a student\'s phone buzz.  The student starts texting.  You ask her to put the phone away and she says, loud enough for others to hear, "it\'s my mom..." and continues texting.',
     examples: [],

--- a/ui/src/message_popup/scaffolding_card.jsx
+++ b/ui/src/message_popup/scaffolding_card.jsx
@@ -119,7 +119,7 @@ export default React.createClass({
         {showSlider &&
           <div>
             <div style={styles.optionTitle}>Session Length: {sessionLength} {sessionLength===1 ? "question" : "questions"}</div>
-            <Slider value={sessionLength} min={1} max={questions.length} step={1} onChange={this.onSliderChange}/>
+            <Slider key={selectedIndicatorId} value={sessionLength} min={1} max={questions.length} step={1} onChange={this.onSliderChange}/>
           </div>
         }
         

--- a/ui/src/message_popup/scoring_question_context.jsx
+++ b/ui/src/message_popup/scoring_question_context.jsx
@@ -38,7 +38,7 @@ export default React.createClass({
             expandable={true}>
               <div>
                 <div style={{paddingBottom: 20}}>{question.text}</div>
-                {question.student && <StudentCard useCardStyles={true} student={question.student} />}
+                {question.students && question.students.map(student => <StudentCard useCardStyles={true} student={student} />)}
               </div>
           </CardText>
         </Card>

--- a/ui/src/message_popup/scoring_question_context.jsx
+++ b/ui/src/message_popup/scoring_question_context.jsx
@@ -38,7 +38,7 @@ export default React.createClass({
             expandable={true}>
               <div>
                 <div style={{paddingBottom: 20}}>{question.text}</div>
-                {question.students && question.students.map(student => <StudentCard useCardStyles={true} student={student} />)}
+                {question.students && question.students.map(student => <StudentCard useCardStyles={true} key={`student-${student.id}`} student={student} />)}
               </div>
           </CardText>
         </Card>

--- a/ui/src/message_popup/transformations.jsx
+++ b/ui/src/message_popup/transformations.jsx
@@ -8,8 +8,13 @@ import {allQuestions} from './questions.js';
 
 export function withStudents(questions) {
   return questions.map((question) => {
-    const student = _.find(allStudents, {id: question.studentId });
-    return _.extend({student}, question);
+    var students = [];
+    if(_.has(question, 'studentIds')){
+      for (var studentIdIndex = 0; studentIdIndex < question.studentIds.length; studentIdIndex++){
+        students.push(_.find((allStudents), {id: question.studentIds[studentIdIndex]}));
+      }
+    }
+    return _.extend({students}, question);
   });
 }
 

--- a/ui/src/message_popup/transformations.jsx
+++ b/ui/src/message_popup/transformations.jsx
@@ -8,12 +8,7 @@ import {allQuestions} from './questions.js';
 
 export function withStudents(questions) {
   return questions.map((question) => {
-    var students = [];
-    if(_.has(question, 'studentIds')){
-      for (var studentIdIndex = 0; studentIdIndex < question.studentIds.length; studentIdIndex++){
-        students.push(_.find((allStudents), {id: question.studentIds[studentIdIndex]}));
-      }
-    }
+    const students = question.studentIds.map(studentId => _.find(allStudents, {id: studentId}));
     return _.extend({students}, question);
   });
 }


### PR DESCRIPTION
I originally had this on the pull request for the texting interface but since it could be useful to start using this in other branches I have decided to pull it out and give it its own pull request. It changes `questions.js` by changing the `studentId` property to an array `studentIds`. It also updates `withStudents` from `transformations.jsx` to include the `students` array as a property instead of `student`. Currently, since multiple students is not an issue because the version of Message PopUp on master does not need it, if there are multiple students in the `studentIds` array, the first studentId is selected as the student for the question.