### PR TITLE
Make no-unused-vars lint rule stricter

### DIFF
--- a/ui/.eslintrc
+++ b/ui/.eslintrc
@@ -21,9 +21,6 @@
     "indent": ["error", 2],
     "semi": ["error", "always"],
     "comma-dangle": ["error", "only-multiline"],
-    "no-unused-vars": ["error", {
-      "args": "none"
-    }],
 
     "react/prefer-stateless-function": "off",
     "react/prefer-es6-class": "off",

--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -58,7 +58,7 @@ export default React.createClass({
     };
   },
 
-  componentWillMount(props, state) {
+  componentWillMount() {
     injectTapEventPlugin(); // material-ui, see https://github.com/zilverline/react-tap-event-plugin
   },
 
@@ -72,15 +72,15 @@ export default React.createClass({
     );
   },
 
-  notFound(path, query = {}) {
-    return <div>Could not find path...</div>;
+  notFound(path) {
+    return <div>Could not find {path}...</div>;
   },
 
-  home(query = {}) {
+  home() {
     return <HomePage challenges={this.props.challenges} />;
   },
 
-  challenge(id, query = {}) {
+  challenge(id) {
     const challenge = _.find(this.props.challenges, (challenge) => challenge.id === _.toInteger(id));
     return <ChallengePage challenge={challenge} user={this.state.user} />;
   },
@@ -99,7 +99,7 @@ export default React.createClass({
     return <MessagePopup.ScoringPage query={query} />;
   },
 
-  messagePopupEvaluation(evaluationId, query = {}) {
+  messagePopupEvaluation(evaluationId) {
     return <MessagePopup.EvaluationViewerPage evaluationId={evaluationId} />;
   },
   

--- a/ui/src/auth_container.jsx
+++ b/ui/src/auth_container.jsx
@@ -65,7 +65,7 @@ export default React.createClass({
     });
   },
 
-  componentWillMount(prevProps, prevState) {
+  componentWillMount() {
     // Check local storage cache
     const storedValues = window.localStorage.getItem(this.props.localStorageKey);
     if (!storedValues) return;
@@ -78,7 +78,7 @@ export default React.createClass({
     });
   },
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate() {
     const {userEmail, hasConfirmedEmail} = this.state;
     if (hasConfirmedEmail && userEmail) {
       window.localStorage.setItem(this.props.localStorageKey, JSON.stringify({userEmail, hasConfirmedEmail}));
@@ -95,11 +95,11 @@ export default React.createClass({
     this.setState({userEmail});
   },
 
-  onDoneEmail(e) {
+  onDoneEmail() {
     this.setState({ hasConfirmedEmail: true });
   },
 
-  onDecline(e) {
+  onDecline() {
     this.setState({ isNavigatingAway: true });
     window.location = 'http://tsl.mit.edu/';
   },

--- a/ui/src/ecd/candidate_page.jsx
+++ b/ui/src/ecd/candidate_page.jsx
@@ -32,7 +32,7 @@ export default React.createClass({
     };
   },
 
-  componentDidMount(props, state) {
+  componentDidMount() {
     Api.evaluationsWithEvidenceQuery().then(this.onDataReceived);
   },
 

--- a/ui/src/ecd/evaluator_page.jsx
+++ b/ui/src/ecd/evaluator_page.jsx
@@ -31,7 +31,7 @@ export default React.createClass({
     };
   },
 
-  componentDidMount(props, state) {
+  componentDidMount() {
     Api.evaluationsQuery().end(this.onEvaluationsReceived);
   },
 

--- a/ui/src/ecd/raw_page.jsx
+++ b/ui/src/ecd/raw_page.jsx
@@ -40,7 +40,7 @@ export default React.createClass({
     };
   },
 
-  componentDidMount(props, state) {
+  componentDidMount() {
     this.doReload();
     this.setInterval(this.doReload, this.props.refreshIntervalMs);
   },

--- a/ui/src/message_popup/exploration_page.jsx
+++ b/ui/src/message_popup/exploration_page.jsx
@@ -36,7 +36,7 @@ export default React.createClass({
     };
   },
 
-  componentDidMount(props, state) {
+  componentDidMount() {
     this.anonymizer = Anonymizer.create();
     document.addEventListener('keydown', (e) => {
       if (e.keyCode === 27) this.onResetClicked();
@@ -46,7 +46,7 @@ export default React.createClass({
     Api.evidenceQuery().end(this.onDataReceived);
   },
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate() {
     this.doDraw(this.state.logs);
   },
 
@@ -103,7 +103,7 @@ export default React.createClass({
     const typeDim = ndx.dimension(d => d.type);
     this.chartsMap.type = dc.rowChart('.chart-type')
       .dimension(typeDim)
-      .group(typeDim.group().reduceSum(d => 1))
+      .group(typeDim.group().reduceSum(() => 1))
       .elasticX(true)
       .width(styles.chart.width)
       .height(styles.chart.height)
@@ -113,7 +113,7 @@ export default React.createClass({
     const helpTypeDim = ndx.dimension(d => d.json.helpType);
     this.chartsMap.helpType = dc.rowChart('.chart-help-type')
       .dimension(helpTypeDim)
-      .group(helpTypeDim.group().reduceSum(d => 1))
+      .group(helpTypeDim.group().reduceSum(() => 1))
       .elasticX(true)
       .width(styles.chart.width)
       .height(styles.chart.height)
@@ -123,7 +123,7 @@ export default React.createClass({
     const studentDim = ndx.dimension(d => d.json.question.student && d.json.question.student.name);
     this.chartsMap.student = dc.rowChart('.chart-student')
       .dimension(studentDim)
-      .group(studentDim.group().reduceSum(d => 1))
+      .group(studentDim.group().reduceSum(() => 1))
       .elasticX(true)
       .width(styles.chart.width)
       .height(styles.chart.height)
@@ -133,7 +133,7 @@ export default React.createClass({
     const userDim = ndx.dimension(anonymizer.name);
     this.chartsMap.user = dc.rowChart('.chart-name')
       .dimension(userDim)
-      .group(userDim.group().reduceSum(d => 1))
+      .group(userDim.group().reduceSum(() => 1))
       .elasticX(true)
       .width(styles.chart.width)
       .height(styles.chart.height)
@@ -144,7 +144,7 @@ export default React.createClass({
     const latencyDim = ndx.dimension(latency);
     this.chartsMap.latency = dc.barChart('.chart-elapsed')
       .dimension(latencyDim)
-      .group(latencyDim.group().reduceSum(d => 1))
+      .group(latencyDim.group().reduceSum(() => 1))
       .x(d3.scale.linear().domain([0,d3.max(logs, latency)]))
       .controlsUseVisibility(true)
       .width(styles.chart.width)

--- a/ui/src/message_popup/popup_question.jsx
+++ b/ui/src/message_popup/popup_question.jsx
@@ -109,6 +109,11 @@ export default React.createClass({
     this.logRevisionDeclined();
     this.onDonePressed();
   },
+
+  onRequestClose() {
+    //This empty function is meant to cancel out the closing of the toast without having to use
+    //an extremely large autoHideDuration
+  },
   
   logResponse() {
     this.logData('message_popup_response');
@@ -203,10 +208,7 @@ export default React.createClass({
         <Snackbar
           open={seconds >= (this.props.limitMs/1000)}
           message="Remember, these are supposed to be quick responses."
-          onRequestClose={function(reason){
-            //This empty function is meant to cancel out the closing of the toast without having to use
-            //an extremely large autoHideDuration
-          }}
+          onRequestClose={this.onRequestClose}
           />
       </div>
     );

--- a/ui/src/message_popup/scoring_swipe.jsx
+++ b/ui/src/message_popup/scoring_swipe.jsx
@@ -83,7 +83,7 @@ export default React.createClass({
     });
   },
 
-  onSwiped(log, index, fromIndex) {
+  onSwiped(log, index) {
     if (index === SWIPE_LEFT_INDEX) return this.doScore(log.id, DEMONSTRATED_COMPETENCY);
     if (index === SWIPE_RIGHT_INDEX) {
       this.setState({


### PR DESCRIPTION
So that any unused vars in function arguments are lint errors.  In some places, functions were specifying what values they would be called with, which is helpful but then the linter can't warn against arguments that are never used in the function body.