### PR TITLE
Add lint rule for React method ordering, and update code to match

### DIFF
--- a/ui/.eslintrc
+++ b/ui/.eslintrc
@@ -21,10 +21,28 @@
     "indent": ["error", 2],
     "semi": ["error", "always"],
     "comma-dangle": ["error", "only-multiline"],
-
+    "no-unused-vars": ["error", {
+      "args": "none"
+    }],
+    "no-use-before-define": "off",
+    "eol-last": "off",
     "react/prefer-stateless-function": "off",
     "react/prefer-es6-class": "off",
-    "no-use-before-define": "off",
-    "eol-last": "off"
+    "react/sort-comp": ["error", {
+      order: [
+        'static-methods',
+        'mixins',
+        'lifecycle',
+        'everything-else',
+        '/^on.+$/',
+        'rendering'
+      ],
+      groups: {
+        rendering: [
+          'render',
+          '/^render.+$/'
+        ]
+      }
+    }]
   }
 }

--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -30,21 +30,6 @@ export default React.createClass({
   displayName: 'App',
 
   mixins: [RouterMixin],
-  routes: {
-    '/': 'home',
-    '/virtual_school': 'virtualSchool',
-    
-    '/challenge/:id': 'challenge',
-    '/message_popup': 'messagePopup',
-    '/message_popup/exploration': 'messagePopupExploration',
-    '/message_popup/evaluations/:id': 'messagePopupEvaluation',
-    '/message_popup/scoring': 'messagePopupScoring',
-    '/ecd/raw': 'ecdRaw',
-    '/ecd/candidate': 'ecdCandidate',
-    '/ecd/evaluator': 'ecdEvaluator',
-    '/slate/:id': 'slate',
-    '/csstank': 'cssTank',
-  },
 
   propTypes: {
     challenges: React.PropTypes.arrayOf(PropTypes.Challenge),
@@ -62,6 +47,23 @@ export default React.createClass({
     injectTapEventPlugin(); // material-ui, see https://github.com/zilverline/react-tap-event-plugin
   },
 
+  routes: {
+    '/': 'home',
+    '/virtual_school': 'virtualSchool',
+    
+    '/challenge/:id': 'challenge',
+    '/message_popup': 'messagePopup',
+    '/message_popup/exploration': 'messagePopupExploration',
+    '/message_popup/evaluations/:id': 'messagePopupEvaluation',
+    '/message_popup/scoring': 'messagePopupScoring',
+    '/ecd/raw': 'ecdRaw',
+    '/ecd/candidate': 'ecdCandidate',
+    '/ecd/evaluator': 'ecdEvaluator',
+    '/slate/:id': 'slate',
+    '/csstank': 'cssTank',
+  },
+
+  /*eslint-disable react/sort-comp */
   render(){
     return (
       <MuiThemeProvider muiTheme={this.props.muiTheme}>
@@ -127,4 +129,5 @@ export default React.createClass({
   ecdEvaluator(query = {}) {
     return <EvaluatorPage evaluatorEmail={query.email} />;
   }
+  /*eslint-enable react/sort-comp */
 });

--- a/ui/src/auth_container.jsx
+++ b/ui/src/auth_container.jsx
@@ -23,6 +23,13 @@ export default React.createClass({
     localStorageKey: React.PropTypes.string
   },
 
+  childContextTypes: {
+    auth: React.PropTypes.shape({
+      userProfile: React.PropTypes.object,
+      doLogout: React.PropTypes.func
+    }).isRequired
+  },
+
   getDefaultProps() {
     return {
       localStorageKey: 'threeflows_email_registration'
@@ -37,13 +44,6 @@ export default React.createClass({
     };
   },
 
-  childContextTypes: {
-    auth: React.PropTypes.shape({
-      userProfile: React.PropTypes.object,
-      doLogout: React.PropTypes.func
-    }).isRequired
-  },
-
   getChildContext() {
     const userProfile = (this.state.hasConfirmedEmail) ? {
       email: this.state.userEmail
@@ -55,14 +55,6 @@ export default React.createClass({
         doLogout: this.doLogout
       }
     };
-  },
-
-  doLogout() {
-    window.localStorage.removeItem(this.props.localStorageKey);
-    this.setState({
-      hasConfirmedEmail: false,
-      userEmail: ''
-    });
   },
 
   componentWillMount() {
@@ -83,6 +75,14 @@ export default React.createClass({
     if (hasConfirmedEmail && userEmail) {
       window.localStorage.setItem(this.props.localStorageKey, JSON.stringify({userEmail, hasConfirmedEmail}));
     }
+  },
+
+  doLogout() {
+    window.localStorage.removeItem(this.props.localStorageKey);
+    this.setState({
+      hasConfirmedEmail: false,
+      userEmail: ''
+    });
   },
 
   validateEmail(email) {

--- a/ui/src/components/navigation_app_bar.jsx
+++ b/ui/src/components/navigation_app_bar.jsx
@@ -36,6 +36,10 @@ export default React.createClass({
     };
   },
 
+  doCloseDrawer() {
+    this.setState({ isOpen: false });
+  },
+
   onToggled() {
     this.setState({isOpen: !this.state.isOpen});
   },
@@ -43,10 +47,6 @@ export default React.createClass({
   onNavigationTapped(url) {
     Routes.navigate(url);
     this.doCloseDrawer();
-  },
-
-  doCloseDrawer() {
-    this.setState({ isOpen: false });
   },
 
   render() {

--- a/ui/src/ecd/candidate_page.jsx
+++ b/ui/src/ecd/candidate_page.jsx
@@ -36,11 +36,6 @@ export default React.createClass({
     Api.evaluationsWithEvidenceQuery().then(this.onDataReceived);
   },
 
-  onDataReceived(evaluations) {
-    const candidateEvaluations = this.filteredByCandidate(evaluations, this.props.candidateEmail);
-    this.setState({candidateEvaluations});
-  },
-
   // Also filters out evaluations without links back to indicators.
   filteredByCandidate(evaluations, candidateEmail) {
     return evaluations.filter(evaluation => {
@@ -58,6 +53,11 @@ export default React.createClass({
       const indicator = _.find(indicators, indicator => indicator.id.toString() === indicatorId);
       return {indicator, evaluations};
     });
+  },
+
+  onDataReceived(evaluations) {
+    const candidateEvaluations = this.filteredByCandidate(evaluations, this.props.candidateEmail);
+    this.setState({candidateEvaluations});
   },
 
   render() {

--- a/ui/src/ecd/evaluator_page.jsx
+++ b/ui/src/ecd/evaluator_page.jsx
@@ -35,12 +35,6 @@ export default React.createClass({
     Api.evaluationsQuery().end(this.onEvaluationsReceived);
   },
 
-  onEvaluationsReceived(err, response) {
-    const evaluations = JSON.parse(response.text).rows;
-    const evaluatorEvaluations = this.filteredByEmail(evaluations, this.props.evaluatorEmail);
-    this.setState({evaluatorEvaluations});
-  },
-
   // Also filters out evaluations without links back to indicators.
   filteredByEmail(evaluations, email) {
     return evaluations.filter(evaluation => {
@@ -56,6 +50,12 @@ export default React.createClass({
       const indicator = _.find(indicators, indicator => indicator.id.toString() === indicatorId);
       return {indicator, evaluations};
     });
+  },
+
+  onEvaluationsReceived(err, response) {
+    const evaluations = JSON.parse(response.text).rows;
+    const evaluatorEvaluations = this.filteredByEmail(evaluations, this.props.evaluatorEmail);
+    this.setState({evaluatorEvaluations});
   },
 
   render() {

--- a/ui/src/ecd/raw_page.jsx
+++ b/ui/src/ecd/raw_page.jsx
@@ -45,6 +45,14 @@ export default React.createClass({
     this.setInterval(this.doReload, this.props.refreshIntervalMs);
   },
 
+  filterRaw(items) {
+    const {searchText} = this.state;
+
+    return items.filter((item) => {
+      return JSON.stringify(item).indexOf(searchText) !== -1;
+    });
+  },
+
   doReload() {
     Api.evidenceQuery().end(this.onDataReceived);
     Api.evaluationsQuery().end(this.onEvaluationsReceived);
@@ -66,14 +74,6 @@ export default React.createClass({
 
   onTapEmail(email) {
     this.setState({ searchText: email });
-  },
-
-  filterRaw(items) {
-    const {searchText} = this.state;
-
-    return items.filter((item) => {
-      return JSON.stringify(item).indexOf(searchText) !== -1;
-    });
   },
 
   render() {

--- a/ui/src/message_popup/experience_page.jsx
+++ b/ui/src/message_popup/experience_page.jsx
@@ -71,6 +71,10 @@ export default React.createClass({
     this.setState({ gameSession });
   },
 
+  resetExperience(){
+    this.setState(this.getInitialState());
+  },
+
   onLog(type, response:Response) {
     Api.logEvidence(type, {
       ...response,
@@ -93,10 +97,6 @@ export default React.createClass({
     Routes.navigate(Routes.Home);
   },
   
-  resetExperience(){
-    this.setState(this.getInitialState());
-  },
-
   onSaveScaffoldingAndSession(scaffolding, email, questions){
     this.setState({
       scaffolding,

--- a/ui/src/message_popup/exploration_page.jsx
+++ b/ui/src/message_popup/exploration_page.jsx
@@ -27,8 +27,10 @@ export default React.createClass({
     };
   },
 
-  anonymizer: null,
+  /* eslint-disable react/sort-comp */
+  anonymizer: null,  
   chartsMap: {},
+  /* eslint-enable react/sort-comp */
 
   getInitialState() {
     return {

--- a/ui/src/message_popup/feedback_card.jsx
+++ b/ui/src/message_popup/feedback_card.jsx
@@ -12,7 +12,14 @@ This shows a feedback card after the user first presses save
 export default React.createClass({
   displayName: 'FeedbackCard',
 
-  getInitialState: function(){
+  propTypes: {
+    initialResponseText: React.PropTypes.string.isRequired,
+    onRevised: React.PropTypes.func.isRequired,
+    onPassed: React.PropTypes.func.isRequired,
+    examples: React.PropTypes.array.isRequired
+  },
+
+  getInitialState(){
     var example = _.shuffle(this.props.examples)[0];
     const initialResponseText = this.props.initialResponseText;
     return ({
@@ -21,20 +28,12 @@ export default React.createClass({
     });
   },
   
-  propTypes: {
-    initialResponseText: React.PropTypes.string.isRequired,
-    onRevised: React.PropTypes.func.isRequired,
-    onPassed: React.PropTypes.func.isRequired,
-    examples: React.PropTypes.array.isRequired
-  },
-  
   onTextChanged({target:{value}}:TextChangeEvent){
     this.setState({ finalResponseText: value });
   },
   
   onRevise(){
     this.props.onRevised(this.state.finalResponseText);
-    
   },
   
   onPass(){

--- a/ui/src/message_popup/hint_card.jsx
+++ b/ui/src/message_popup/hint_card.jsx
@@ -9,8 +9,13 @@ This shows a hint in the form of a toggleable good or bad example response
 */
 export default React.createClass({
   displayName: 'HintCard',
+  
+  propTypes: {
+    examples: React.PropTypes.array.isRequired,
+    nonExamples: React.PropTypes.array.isRequired
+  },
 
-  getInitialState: function(){
+  getInitialState() {
     var goodExamples = _.map(this.props.examples, function(example){return {type: 'Good', text: example};});
     var badExamples = _.map(this.props.nonExamples, function(example){return {type: 'Bad', text: example};});
     var allExamples = _.shuffle(goodExamples.concat(badExamples));
@@ -20,11 +25,6 @@ export default React.createClass({
       allExamples: allExamples,
       originalAll: originalAll
     });
-  },
-  
-  propTypes: {
-    examples: React.PropTypes.array.isRequired,
-    nonExamples: React.PropTypes.array.isRequired
   },
   
   onNextExample(){

--- a/ui/src/message_popup/popup_question.jsx
+++ b/ui/src/message_popup/popup_question.jsx
@@ -67,6 +67,33 @@ export default React.createClass({
     }
   },
 
+  logResponse() {
+    this.logData('message_popup_response');
+  },
+  
+  logRevision(finalText) {
+    this.logData('message_popup_revision', {finalResponseText: finalText});
+  },
+  
+  logRevisionDeclined(){
+    this.logData('message_popup_revision_declined');
+  },
+  
+  logData(type, params = {}) {
+    const {elapsedMs, initialResponseText} = this.state;
+    const {question, scaffolding} = this.props;
+    const {finalResponseText} = params;
+    const response:Response = {
+      question,
+      shouldShowStudentCard: scaffolding.shouldShowStudentCard,
+      helpType: scaffolding.helpType,
+      elapsedMs,
+      initialResponseText,
+      finalResponseText
+    };
+    this.props.onLog(type, response);
+  },
+  
   onTextChanged({target:{value}}:TextChangeEvent) {
     this.setState({ initialResponseText: value });
   },
@@ -113,33 +140,6 @@ export default React.createClass({
   onRequestClose() {
     //This empty function is meant to cancel out the closing of the toast without having to use
     //an extremely large autoHideDuration
-  },
-  
-  logResponse() {
-    this.logData('message_popup_response');
-  },
-  
-  logRevision(finalText) {
-    this.logData('message_popup_revision', {finalResponseText: finalText});
-  },
-  
-  logRevisionDeclined(){
-    this.logData('message_popup_revision_declined');
-  },
-  
-  logData(type, params = {}) {
-    const {elapsedMs, initialResponseText} = this.state;
-    const {question, scaffolding} = this.props;
-    const {finalResponseText} = params;
-    const response:Response = {
-      question,
-      shouldShowStudentCard: scaffolding.shouldShowStudentCard,
-      helpType: scaffolding.helpType,
-      elapsedMs,
-      initialResponseText,
-      finalResponseText
-    };
-    this.props.onLog(type, response);
   },
 
   render() {

--- a/ui/src/message_popup/scoring_page.jsx
+++ b/ui/src/message_popup/scoring_page.jsx
@@ -47,6 +47,26 @@ export default React.createClass({
     Api.evaluationsQuery().end(this.onEvaluationsReceived);
   },
 
+  computeRelevantLogs() {
+    const {logs, evaluations} = this.state;
+    if (logs === null) return [];
+    if (evaluations === null) return [];
+
+    // Show only solution mode responses, and those that haven't been translated to evidence
+    // or dismissed.
+    const logIds = evaluations.map(evaluation => evaluation.json.logId);
+    return logs.filter((log) => {
+      if (log.type !== 'message_popup_response') return false;
+      if (log.json.helpType === 'none') return false;
+      if (logIds.indexOf(log.id) !== -1) return false;
+      return true;
+    });
+  },
+
+  computeSelectedLogs(logs, selectedQuestion) {
+    return logs.filter(log => log.json.question.text === selectedQuestion.text);
+  },
+
   onTransitionDone() {
     window.scrollTo(0, 0);
   },
@@ -69,26 +89,6 @@ export default React.createClass({
     const evaluation = Api.logEvaluation('message_popup_response_scored', evaluationRecord);
     const evaluations = this.state.evaluations.concat(evaluation);
     this.setState({evaluations});
-  },
-
-  computeRelevantLogs() {
-    const {logs, evaluations} = this.state;
-    if (logs === null) return [];
-    if (evaluations === null) return [];
-
-    // Show only solution mode responses, and those that haven't been translated to evidence
-    // or dismissed.
-    const logIds = evaluations.map(evaluation => evaluation.json.logId);
-    return logs.filter((log) => {
-      if (log.type !== 'message_popup_response') return false;
-      if (log.json.helpType === 'none') return false;
-      if (logIds.indexOf(log.id) !== -1) return false;
-      return true;
-    });
-  },
-
-  computeSelectedLogs(logs, selectedQuestion) {
-    return logs.filter(log => log.json.question.text === selectedQuestion.text);
   },
 
   render() {

--- a/ui/src/message_popup/scoring_swipe.jsx
+++ b/ui/src/message_popup/scoring_swipe.jsx
@@ -40,14 +40,14 @@ export default React.createClass({
     limitIncrement: React.PropTypes.number
   },
 
+  contextTypes: {
+    auth: React.PropTypes.object.isRequired
+  },
+
   getDefaultProps() {
     return {
       limitIncrement: 20
     };
-  },
-
-  contextTypes: {
-    auth: React.PropTypes.object.isRequired
   },
 
   getInitialState() {


### PR DESCRIPTION
This adds a new eslint rule for the order of React methods.  It's roughly:

```
lifecycle
(anything else, eg., computing values from state or performing effects like navigating pages)
event handlers, prefixed with on
render
other rendering methods
```