### PR TITLE
Fixing shrinking icons

### DIFF
--- a/ui/src/message_popup/mobile_prototype/message_components.jsx
+++ b/ui/src/message_popup/mobile_prototype/message_components.jsx
@@ -43,7 +43,7 @@ const Message = React.createClass({
           <Paper style={messageTextStyle}>{this.props.text}</Paper>
           
         </div>
-        {this.props.rightIcon}
+        <div>{this.props.rightIcon}</div>
       </div>
     );
   }
@@ -71,7 +71,7 @@ export const StudentMessage = React.createClass({
           leftIcon={
             <IconButton 
               onTouchTap={this.props.onOpenStudentDialog} 
-              style={styles.messageIconButton} 
+              style={styles.messageIconContainer} 
               iconStyle={styles.messageIcon}>
               <FaceIcon/>
             </IconButton>
@@ -102,7 +102,9 @@ export const UserMessage = React.createClass({
           messageStyle={messageStyle}
           messageTextStyle={messageTextStyle}
           rightIcon={
-            <FaceIcon  style={{marginTop: 8, ...styles.messageIcon}}/> 
+            <div style={styles.messageIconContainer}>
+              <FaceIcon  style={{marginTop: 8, ...styles.messageIcon}}/>
+            </div>
           }
           />
       </div>
@@ -130,7 +132,7 @@ export const InfoMessage = React.createClass({
           leftIcon={
             <IconButton 
               onTouchTap={this.props.onOpenInfoDialog}
-              style={styles.messageIconButton}
+              style={styles.messageIconContainer}
               iconStyle={styles.messageIcon}>
               <InfoOutlineIcon/>
             </IconButton>
@@ -146,18 +148,15 @@ const styles = {
     display: 'flex',
     padding: 5
   },
-  messageIconButton: {
+  messageIconContainer: {
     margin: 0,
     padding: 0,
     width: '100%',
-    height: 0
   },
   messageIcon: {
     width: 30,
     height: 30,
     padding: 0,
-    marginTop: 5,
-    flexShrink: 0
   },
   messageTextSection: {
     margin: 5,

--- a/ui/src/message_popup/mobile_prototype/message_components.jsx
+++ b/ui/src/message_popup/mobile_prototype/message_components.jsx
@@ -149,12 +149,15 @@ const styles = {
   messageIconButton: {
     margin: 0,
     padding: 0,
-    width: '100%'
+    width: '100%',
+    height: 0
   },
   messageIcon: {
     width: 30,
     height: 30,
-    padding: 0
+    padding: 0,
+    marginTop: 5,
+    flexShrink: 0
   },
   messageTextSection: {
     margin: 5,


### PR DESCRIPTION
I noticed that the icon on the right (user icon) was now shrinking after we simplified some of the flexbox properties.

<div style="display: flex;">
<img width="290" alt="screen shot 2016-08-04 at 3 23 28 pm" src="https://cloud.githubusercontent.com/assets/1490352/17415670/cde0cb7c-5a58-11e6-966a-d3f1e772467d.png">
<img width="290" alt="screen shot 2016-08-04 at 3 26 16 pm" src="https://cloud.githubusercontent.com/assets/1490352/17415633/ab74dc36-5a58-11e6-9cfe-3e7251d646e4.png">
</div>

I added in `flexShrink: 0` to `styles.messageIcon` to prevent any icons from shrinking. I also set  `height: 0` in `styles.messageIconButton` to get rid of the additional padding created by the `IconButton`. Lastly, `marginTop: 5` was also added to `styles.messageIcon` in order to align both the left and right icons in terms of how high next to the message bubble they appeared. Before, the left icons were slightly shorter than the right icons.

<img width="388" alt="screen shot 2016-08-04 at 3 32 07 pm" src="https://cloud.githubusercontent.com/assets/1490352/17415830/664960e0-5a59-11e6-92f9-f3cbaa2e530d.png">
