### PR TITLE
Removed sessionLength from Slider key

### DIFF
--- a/ui/src/message_popup/scaffolding_card.jsx
+++ b/ui/src/message_popup/scaffolding_card.jsx
@@ -111,7 +111,7 @@ export default React.createClass({
     const showOriginalHelp = _.has(itemsToShow, 'all') || _.has(itemsToShow, 'originalHelp');
 
     // This is a workaround for a bug in Slider while we wait for https://github.com/callemall/material-ui/pull/4895 to land
-    const sliderKey = [sessionLength, questionsLength, selectedIndicatorId].join('-');
+    const sliderKey = [questionsLength, selectedIndicatorId].join('-');
     return (
       <div style={styles.container}>
         {this.renderIndicators()}


### PR DESCRIPTION
The Slider was having fun breaking again. This time around, I think what was happening is that every time the slider changed, the key updated because `sessionLength` was included. This meant that the slider would be replaced every time it changed which led to console errors and no actual sliding, just clicking.

For reference, these were the two errors:
```
Uncaught TypeError: Cannot read property 'getBoundingClientRect' of undefined
```
```
Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the undefined component.
```