### PR TITLE
Created GET endpoint for message popup questions

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -190,7 +190,8 @@ app.get('/server/questions', facultyAuth, function(request, response){
     const {rows} = result;
     console.log(rows);
     response.status(200);
-    return response.json({rows});
+    if(rows.length === 0) return response.json({});
+    return response.json({row: rows[0]});
   });
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -174,6 +174,26 @@ app.get('/server/evaluations', facultyAuth, function(request, response) {
   });
 });
 
+
+
+app.get('/server/questions', facultyAuth, function(request, response){
+  if (process.env.NODE_ENV === 'development') {
+    return response.json({});
+  }
+
+  queryDatabase('SELECT * FROM message_popup_questions ORDER BY timestamp DESC LIMIT 1', [], function(err, result){
+    if (err) {
+      console.log({ error: err });
+      return response.status(500);
+    }
+
+    const {rows} = result;
+    console.log(rows);
+    response.status(200);
+    return response.json({rows});
+  });
+});
+
 // serve static HTML
 function readFile(filename) {
   return function(request, response) {

--- a/ui/src/helpers/api.js
+++ b/ui/src/helpers/api.js
@@ -70,3 +70,10 @@ function joinEvaluationsWithEvidence([evaluationsResponse, evidenceResponse]) {
     return {...evaluation, log};
   });
 }
+
+//Query for questions
+export function questionsQuery() {
+  return request
+    .get('/server/questions')
+    .set('Content-Type', 'application/json');
+}


### PR DESCRIPTION
I set up the endpoint for querying the database for questions.

My thought for how the questions will be formatted is a parameter like the following in the questions section of the database row:
```
{currentQuestions: [ ... ], archivedQuestions: [ ... ]}
```

I believe to access this we would use `Api.questionsQuery().end(callback)` and `callback` would look like the following: 
```
function(err, response) {
  //... some checks here to make sure it actually exists ...
  const allQuestions = JSON.parse(response.text).rows[0]; //only 1 item
  const {currentQuestions, archivedQuestions} = allQuestions;
  //... setting the questions somewhere in state ...
}
```

For now, this pull request is just to see how it would work on the actual heroku server with actual access to the database.