### PR TITLE
Read AWS credentials for audio as single env variable

### DIFF
--- a/server/s3_client.js
+++ b/server/s3_client.js
@@ -4,11 +4,6 @@ var AWS = require('aws-sdk');
 module.exports = function createS3Client() {
   const awsConfig = (process.env.NODE_ENV === 'development')
     ? JSON.parse(fs.readFileSync('./tmp/aws_message_popup.json'))
-    : {
-        accessKeyId: process.env.MESSAGE_POPUP_S3_ACCESS_KEY_ID,
-        secretAccessKey: process.env.MESSAGE_POPUP_S3_SECRET_ACCESS_KEY,
-        region: process.env.MESSAGE_POPUP_S3_REGION,
-        bucket: process.env.MESSAGE_POPUP_S3_BUCKET
-      };
+    : JSON.parse(process.env.MESSAGE_POPUP_S3_CONFIG_JSON);
   return new AWS.S3(awsConfig); 
 }


### PR DESCRIPTION
This is a revision to https://github.com/mit-teaching-systems-lab/threeflows/pull/100, to keep the format in local dev and production the same (just values are different).