### PR TITLE
Factoring out audio recorder from React component shim, clarifying when microphone is needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.4.8",
+    "babel-plugin-transform-class-properties": "^6.11.5",
     "basic-auth": "^1.0.4",
     "body-parser": "^1.15.1",
     "date-fns": "^1.3.0",

--- a/ui/.babelrc
+++ b/ui/.babelrc
@@ -4,6 +4,7 @@
     "development": {
       "plugins": [
         ["transform-flow-strip-types"],
+        ["transform-class-properties"],
         ["react-transform", {
           "transforms": [{
             "transform": "livereactload/babel-transform",


### PR DESCRIPTION
This is a refactor to accomplish a small product improvement.  Previously, `AudioCapture` could be used as a controlled component to record audio blobs.  But the way it was implemented, it would add in the AuO component immediately, which prompted the user to use the audio and indicated that audio was being captured even when it wasn't actually yet.  This is because AuO captures the stream for visualization separately from recording.

We should investigate replacing this altogether, but this at least defers the "audio is recording" browser UI indication until the user clicks "record."