### PR TITLE
Add querystring showing UI to allow forcing modes

### DIFF
--- a/ui/src/message_popup/experience_page.jsx
+++ b/ui/src/message_popup/experience_page.jsx
@@ -151,7 +151,7 @@ export default React.createClass({
 
   renderDone() {
     return (
-      <div>
+      <div className="done">
         <VelocityTransitionGroup enter={{animation: "slideDown"}} leave={{animation: "slideUp"}} runOnMount={true}>
           <div style={_.merge(_.clone(styles.container), styles.done)}>
             <div style={styles.doneTitle}>You finished!</div>
@@ -176,7 +176,7 @@ export default React.createClass({
 
     return (
       <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
-        <div>
+        <div className="instructions">
           <InstructionsCard 
            itemsToShow={query}
            />
@@ -199,7 +199,7 @@ export default React.createClass({
     const question = questions[questionsAnswered];
 
     return (
-      <div style={styles.container}>        
+      <div className="question" style={styles.container}>        
         <LinearProgress color="#EC407A" mode="determinate" value={questionsAnswered} max={sessionLength} />
         <VelocityTransitionGroup enter={{animation: "slideDown"}} leave={{animation: "slideUp"}} runOnMount={true}>
           <PopupQuestion
@@ -228,7 +228,7 @@ export default React.createClass({
     const sessionLength = questions.length;
     const question = withStudents(questions)[questionsAnswered];
     return ( 
-      <div>
+      <div className="prototype">
         <LinearProgress color="#EC407A" mode="determinate" value={questionsAnswered} max={sessionLength} />
         <MobileInterface
           key={JSON.stringify(question)}

--- a/ui/src/message_popup/experience_page.jsx
+++ b/ui/src/message_popup/experience_page.jsx
@@ -178,13 +178,12 @@ export default React.createClass({
       <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
         <div className="instructions">
           <InstructionsCard 
-           itemsToShow={query}
+           query={query}
            />
           <ScaffoldingCard
             initialEmail={this.context.auth.userProfile.email}
             scaffolding={scaffolding}
-            itemsToShow={query}
-            allowChoosingResponseMode={_.has(query, 'modes')}
+            query={query}
             onSessionConfigured={this.onSaveScaffoldingAndSession}
            />
         </div>

--- a/ui/src/message_popup/experience_page_test.jsx
+++ b/ui/src/message_popup/experience_page_test.jsx
@@ -1,29 +1,38 @@
 /* flow weak */
 import React from 'react';
-import ReactDOM from 'react-dom';
 
-import {shallow, mount} from 'enzyme';
+import {render} from 'enzyme';
 import {expect} from 'chai';
 import TestAuthContainer from '../test_auth_container.jsx';
-
-import ExperiencePage from './experience_page.jsx';
-import NavigationAppBar from '../components/navigation_app_bar.jsx';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 
-//
+import ExperiencePage from './experience_page.jsx';
+
+// Wrap with application context for a full render
+// (eg., theming, authorization).
+function withContext(child) {
+  return (
+    <MuiThemeProvider>
+      <TestAuthContainer>
+        {child}
+      </TestAuthContainer>
+    </MuiThemeProvider>
+  );
+}
+
+// TODO(kr) it doesn't yet work to do a full render of ExperiencePage,
+// because the TextField Material UI component relies on element.scrollHeight,
+// which isn't present in jsdom.
+// Not sure of a good workaround, but submitted
+// https://github.com/callemall/material-ui/pull/5015 as a workaround and
+// to get input.
 describe('<ExperiencePage />', () => {
-  it('renders', () => {    
-    const wrapper = mount(
-      <MuiThemeProvider>
-        <TestAuthContainer>
-          <ExperiencePage query={{modes: true}} />
-        </TestAuthContainer>
-      </MuiThemeProvider>
-    );
-    // console.log(wrapper.debug());
-    expect(wrapper.find(NavigationAppBar)).to.have.length(1);
-    // const el = ReactDOM.findDOMNode(wrapper.instance());
-    // expect(getComputedStyle(el).width).to.equal(33);
-    // expect(wrapper.props()).to.equal(4);
+  it('renders instructions', () => {    
+    const wrapper = render(withContext(<ExperiencePage query={{modes: true}} />));
+
+    expect(wrapper.find('.instructions').length).to.equal(1);
+    expect(wrapper.find('.prototype').length).to.equal(0);
+    expect(wrapper.find('.done').length).to.equal(0);
+    expect(wrapper.find('.question').length).to.equal(0);
   });
 });

--- a/ui/src/message_popup/experience_page_test.jsx
+++ b/ui/src/message_popup/experience_page_test.jsx
@@ -1,0 +1,29 @@
+/* flow weak */
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import {shallow, mount} from 'enzyme';
+import {expect} from 'chai';
+import TestAuthContainer from '../test_auth_container.jsx';
+
+import ExperiencePage from './experience_page.jsx';
+import NavigationAppBar from '../components/navigation_app_bar.jsx';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+
+//
+describe('<ExperiencePage />', () => {
+  it('renders', () => {    
+    const wrapper = mount(
+      <MuiThemeProvider>
+        <TestAuthContainer>
+          <ExperiencePage query={{modes: true}} />
+        </TestAuthContainer>
+      </MuiThemeProvider>
+    );
+    // console.log(wrapper.debug());
+    expect(wrapper.find(NavigationAppBar)).to.have.length(1);
+    // const el = ReactDOM.findDOMNode(wrapper.instance());
+    // expect(getComputedStyle(el).width).to.equal(33);
+    // expect(wrapper.props()).to.equal(4);
+  });
+});

--- a/ui/src/message_popup/instructions_card.jsx
+++ b/ui/src/message_popup/instructions_card.jsx
@@ -7,12 +7,12 @@ export default React.createClass({
   displayName: "InstructionsCard",
   
   propTypes: {
-    itemsToShow: React.PropTypes.object.isRequired,
+    query: React.PropTypes.object.isRequired,
   },
   
   getInitialState(){
     return ({
-      isSolutionMode: _.has(this.props.itemsToShow, "solution"),
+      isSolutionMode: _.has(this.props.query, "solution"),
     });
   },
   
@@ -28,7 +28,7 @@ export default React.createClass({
         }
         <p style={styles.paragraph}>You may be asked to write, sketch or say your responses aloud.</p>
         <p style={styles.paragraph}>Each question is timed to simulate responding in the moment in the classroom.  Aim to respond to each scenario in about 90 seconds.</p>
-        {_.has(this.props.itemsToShow, "mobilePrototype") &&
+        {_.has(this.props.query, "mobilePrototype") &&
           <p style={styles.paragraph}>You can tap on the icons in the left margin to see more information about the question's students.</p>
         }
         <Divider />

--- a/ui/src/message_popup/popup_question.jsx
+++ b/ui/src/message_popup/popup_question.jsx
@@ -59,14 +59,12 @@ export default React.createClass({
     onLog: React.PropTypes.func.isRequired,
     onDone: React.PropTypes.func.isRequired,
     isLastQuestion: React.PropTypes.bool.isRequired,
-    drawResponseMode: React.PropTypes.func // for testing
+    drawResponseMode: React.PropTypes.func.isRequired
   },
 
   getInitialState: function() {
     const {question, scaffolding} = this.props;
-    const responseMode = (this.props.drawResponseMode)
-      ? this.props.drawResponseMode(question, scaffolding)
-      : this.drawResponseMode(question, scaffolding);
+    const responseMode = this.props.drawResponseMode(question, scaffolding);
 
     return {
       responseMode,
@@ -74,12 +72,6 @@ export default React.createClass({
       allowResponding: false,
       response: null
     };
-  },
-
-  // This is not a pure function, it's not idempotent and can include
-  // randomness.  It shouldn't be called within render methods.
-  drawResponseMode(question, scaffolding) {
-    return Math.random() > 0.5 ? 'audio' : 'text';
   },
 
   // Allow pieces of the UI to log data for particular event types, along

--- a/ui/src/message_popup/scaffolding_card.jsx
+++ b/ui/src/message_popup/scaffolding_card.jsx
@@ -24,13 +24,12 @@ export default React.createClass({
       shouldShowSummary: React.PropTypes.bool.isRequired
     }).isRequired,
     initialEmail: React.PropTypes.string.isRequired,
-    itemsToShow: React.PropTypes.object.isRequired,
-    allowChoosingResponseMode: React.PropTypes.bool.isRequired,
+    query: React.PropTypes.object.isRequired,
     onSessionConfigured: React.PropTypes.func.isRequired
   },
   
   getInitialState(){
-    const isSolutionMode = _.has(this.props.itemsToShow, 'solution');
+    const isSolutionMode = _.has(this.props.query, 'solution');
     return ({
       email: this.props.initialEmail,
       sessionLength: 10,
@@ -119,16 +118,18 @@ export default React.createClass({
   },
   
   render(){
-    const {itemsToShow, allowChoosingResponseMode} = this.props;
+    const {query} = this.props;
     const {selectedIndicatorId, sessionLength, scaffolding} = this.state;
     const {shouldShowStudentCard, shouldShowSummary, helpType} = scaffolding;
     const questionsLength = this.getQuestions(selectedIndicatorId).length;
 
     const showSlider = true;
-    const showStudentCardsToggle = _.has(itemsToShow, 'all') || _.has(itemsToShow, 'cards') || _.has(itemsToShow, 'basic');
-    const showSummaryToggle = _.has(itemsToShow, 'all') || _.has(itemsToShow, 'summary');
-    const showHelpToggle = _.has(itemsToShow, 'all') || _.has(itemsToShow, 'feedback') || _.has(itemsToShow, 'basic');
-    const showOriginalHelp = _.has(itemsToShow, 'all') || _.has(itemsToShow, 'originalHelp');
+    const showAll = _.has(query, 'all');
+    const showStudentCardsToggle = showAll || _.has(query, 'cards') || _.has(query, 'basic');
+    const showSummaryToggle = showAll || _.has(query, 'summary');
+    const showHelpToggle = showAll || _.has(query, 'feedback') || _.has(query, 'basic');
+    const showOriginalHelp = showAll || _.has(query, 'originalHelp');
+    const showChooseResponseMode = showAll || _.has(query, 'modes');
 
     // This is a workaround for a bug in Slider while we wait for https://github.com/callemall/material-ui/pull/4895 to land
     const sliderKey = [questionsLength, selectedIndicatorId].join('-');
@@ -145,7 +146,7 @@ export default React.createClass({
           </div>
         }
 
-        {allowChoosingResponseMode && this.renderResponseModeChoice()}
+        {showChooseResponseMode && this.renderResponseModeChoice()}
         
         <Divider />
         

--- a/ui/src/test_auth_container.jsx
+++ b/ui/src/test_auth_container.jsx
@@ -1,0 +1,29 @@
+/* @flow weak */
+import React from 'react';
+import AuthContainer from './auth_container.jsx';
+import sinon from 'sinon';
+
+
+// Testing only, used to inject an auth context.
+export default React.createClass({
+  displayName: 'TestAuthContainer',
+
+  propTypes: AuthContainer.propTypes,
+
+  childContextTypes: AuthContainer.childContextTypes,
+
+  getChildContext() {
+    return {
+      auth: {
+        userProfile: {
+          email: 'user@foo.com'
+        },
+        doLogout: sinon.spy()
+      }
+    };
+  },
+
+  render() {
+    return this.props.children;
+  }
+});

--- a/ui/src/test_auth_container.jsx
+++ b/ui/src/test_auth_container.jsx
@@ -8,7 +8,9 @@ import sinon from 'sinon';
 export default React.createClass({
   displayName: 'TestAuthContainer',
 
-  propTypes: AuthContainer.propTypes,
+  propTypes: {
+    children: React.PropTypes.element.isRequired
+  },
 
   childContextTypes: AuthContainer.childContextTypes,
 

--- a/ui/test/setup.js
+++ b/ui/test/setup.js
@@ -31,3 +31,7 @@ console.error = function(message) {
   throw new Error(message, args.slice(1));
   consoleError.apply(console, args);
 };
+
+// for material-ui, see https://github.com/zilverline/react-tap-event-plugin
+// can only be called once
+require('react-tap-event-plugin')();


### PR DESCRIPTION
This adds a query string param that will show a UI allowing the user to set the strategy for picking audio or text responses.  For now it's either randomly mixed or all of a particular response type.

I also spent some time trying to get full renders working during test.  This involved:
- making a new `TestAuthContainer` to inject authentication context for test
- adding a call to `react-tap-event-plugin` in the Mocha `setup.js`
- running into a Material UI component relying on `element.scrollHeight`, which isn't supported in `jsdom`
- filing [this workaround upstream](https://github.com/callemall/material-ui/pull/5015) that I don't expect will be merged, and don't have any great ideas to workaround
- adding a minimal static HTML render test

### URL:
![screen shot 2016-08-17 at 3 15 00 pm](https://cloud.githubusercontent.com/assets/1056957/17755501/3bbf4f20-64a8-11e6-96c4-e6edb755cc0b.png)

### UI:
![screen shot 2016-08-17 at 3 14 55 pm](https://cloud.githubusercontent.com/assets/1056957/17755499/39c5b92a-64a8-11e6-8970-db835adc722f.png)
