### PR TITLE
Fix bug with not logging audio responses

### DIFF
--- a/ui/src/message_popup/popup_question.jsx
+++ b/ui/src/message_popup/popup_question.jsx
@@ -98,9 +98,12 @@ export default React.createClass({
     this.setState({ elapsedMs: this.state.elapsedMs + ONE_SECOND });
   },
 
+  // For now, this does not log to the server.  Individual response components
+  // are responsible for handling logging about their particular
+  // response types.
   onResponseSubmitted(response:ResponseT) {
     this.clearIntervals();
-    
+
     if (!this.props.scaffolding.shouldShowSummary) return this.onDone();
     if (this.state.responseMode === 'audio') return this.onDone();
     this.setState({response});
@@ -153,6 +156,8 @@ export default React.createClass({
     );
   },
 
+  // Each response is responsible for logging interaction data
+  // to the server.
   renderResponse() {
     const {responseMode, elapsedMs} = this.state;
     const {scaffolding, limitMs, question} = this.props;

--- a/ui/src/message_popup/renderers/audio_response.jsx
+++ b/ui/src/message_popup/renderers/audio_response.jsx
@@ -20,11 +20,13 @@ export default React.createClass({
     question: React.PropTypes.object.isRequired,
     scaffolding: React.PropTypes.object.isRequired,
     limitMs: React.PropTypes.number.isRequired,
+    elapsedMs: React.PropTypes.number.isRequired,
     onLogMessage: React.PropTypes.func.isRequired,
     onResponseSubmitted: React.PropTypes.func.isRequired
   },
 
   onDone(audioUrl) {
+    this.props.onLogMessage('message_popup_audio_response', {audioUrl});
     this.props.onResponseSubmitted({audioUrl});
   },
 

--- a/ui/src/message_popup/renderers/audio_response_test.jsx
+++ b/ui/src/message_popup/renderers/audio_response_test.jsx
@@ -1,0 +1,44 @@
+/* flow weak */
+import React from 'react';
+
+import {shallow} from 'enzyme';
+import {expect} from 'chai';
+import sinon from 'sinon';
+import * as TestFixtures from '../test_fixtures.js';
+
+import AudioResponse from './audio_response.jsx';
+import AudioRecorderFlow from '../../components/audio_recorder_flow.jsx';
+
+function testProps(props) {
+  return {
+    question: TestFixtures.testQuestion,
+    scaffolding: TestFixtures.practiceScaffolding,
+    limitMs: 30000,
+    elapsedMs: 0,
+    onLogMessage: sinon.spy(),
+    onResponseSubmitted: sinon.spy(),
+    ...props
+  };
+}
+
+describe('<AudioResponse />', () => {
+  it('renders', () => {
+    const props = testProps();
+    const wrapper = shallow(<AudioResponse {...props} />);
+    expect(wrapper.find(AudioRecorderFlow).length).to.equal(1);
+  });
+
+  it('logs and submits response when capture flow is done', () => {
+    const audioUrl = 'https://foo.bar/123';
+    const props = testProps();
+    const wrapper = shallow(<AudioResponse {...props} />);
+    wrapper.instance().onDone(audioUrl);
+
+    expect(props.onLogMessage.callCount).to.equal(1);
+    expect(props.onLogMessage.firstCall.args).to.deep.equal([
+      'message_popup_audio_response',
+      {audioUrl}
+    ]);
+    expect(props.onResponseSubmitted.firstCall.args[0]).to.deep.equal({audioUrl});
+  });
+});


### PR DESCRIPTION
The audio files are captured, but the response records weren't being logged.  Adds comments as well indicating that response components need to log all their own data.