### PR TITLE
Copy revisions for response modes, additional tests

### DIFF
--- a/ui/.flowconfig
+++ b/ui/.flowconfig
@@ -6,3 +6,6 @@
 .*/node_modules/react-swipeable-views/src/.*
 .*/node_modules/reqwest/.*
 .*/node_modules/cjson/.*
+
+[libs]
+test/mocha_declarations.js

--- a/ui/src/message_popup/experience_page_test.jsx
+++ b/ui/src/message_popup/experience_page_test.jsx
@@ -1,4 +1,4 @@
-/* flow weak */
+/* @flow weak */
 import React from 'react';
 
 import {render} from 'enzyme';

--- a/ui/src/message_popup/popup_question_test.jsx
+++ b/ui/src/message_popup/popup_question_test.jsx
@@ -1,4 +1,4 @@
-/* flow weak */
+/* @flow weak */
 import React from 'react';
 
 import {shallow} from 'enzyme';

--- a/ui/src/message_popup/renderers/audio_response_test.jsx
+++ b/ui/src/message_popup/renderers/audio_response_test.jsx
@@ -1,4 +1,4 @@
-/* flow weak */
+/* @flow weak */
 import React from 'react';
 
 import {shallow} from 'enzyme';

--- a/ui/src/message_popup/renderers/hint_card_test.jsx
+++ b/ui/src/message_popup/renderers/hint_card_test.jsx
@@ -1,4 +1,4 @@
-/* flow weak */
+/* @flow weak */
 import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from 'chai';

--- a/ui/src/message_popup/renderers/revising_text_response_test.jsx
+++ b/ui/src/message_popup/renderers/revising_text_response_test.jsx
@@ -1,4 +1,4 @@
-/* flow weak */
+/* @flow weak */
 import React from 'react';
 
 import {shallow} from 'enzyme';

--- a/ui/src/message_popup/renderers/scenario_renderer_test.jsx
+++ b/ui/src/message_popup/renderers/scenario_renderer_test.jsx
@@ -1,4 +1,4 @@
-/* flow weak */
+/* @flow weak */
 import React from 'react';
 
 import {shallow} from 'enzyme';

--- a/ui/src/message_popup/scaffolding_card.jsx
+++ b/ui/src/message_popup/scaffolding_card.jsx
@@ -1,21 +1,28 @@
-import React from "react";
+/* @flow weak */
+import _ from 'lodash';
+import React from 'react';
+
 import Toggle from 'material-ui/Toggle';
 import Divider from 'material-ui/Divider';
 import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
-import TextChangeEvent from '../types/dom_types.js';
 import {RadioButton, RadioButtonGroup} from 'material-ui/RadioButton';
 import Slider from 'material-ui/Slider';
-import _ from 'lodash';
 
 import {indicators} from '../data/indicators.js';
 import {allQuestions} from './questions.js';
 import {withStudents, questionsForIndicator} from './transformations.jsx';
-
 const ALL_INDICATORS = -1;
 
+/*
+Shows the user configuration options for a session and passes
+the chosen configuration back to `onSessionConfigured`.
+
+Callers can control which options are available
+by querystring options in `query`.
+*/
 export default React.createClass({
-  displayName: "ScaffoldingCard",
+  displayName: 'ScaffoldingCard',
   
   propTypes: {
     scaffolding: React.PropTypes.shape({
@@ -113,8 +120,9 @@ export default React.createClass({
     this.setState({scaffolding});
   },
 
-  onTextChanged({target:{value}}:TextChangeEvent) {
-    this.setState({email: value});
+  onTextChanged(e) {
+    const email = e.target.value;
+    this.setState({email});
   },
   
   render(){
@@ -141,7 +149,7 @@ export default React.createClass({
       
         {showSlider &&
           <div>
-            <div style={styles.optionTitle}>Session Length: {sessionLength} {sessionLength===1 ? "question" : "questions"}</div>
+            <div style={styles.optionTitle}>Session length: {sessionLength} {sessionLength===1 ? "scenario" : "scenarios"}</div>
             <Slider key={sliderKey} value={sessionLength} min={0} max={questionsLength} step={1} onChange={this.onSliderChange}/>
           </div>
         }
@@ -152,7 +160,7 @@ export default React.createClass({
         
         {(showStudentCardsToggle || showHelpToggle || showSummaryToggle || showOriginalHelp) &&
           <div>
-            <div style={styles.optionTitle}>Scaffolding</div>
+            <div style={styles.optionTitle}>Scaffolding:</div>
             <div style={_.merge({ padding: 20 }, styles.option)}>
               {showStudentCardsToggle &&
               <Toggle
@@ -191,6 +199,7 @@ export default React.createClass({
         <Divider />
 
         <TextField
+          name="email"
           style={{width: '100%'}}
           underlineShow={false}
           floatingLabelText="What's your email address?"
@@ -220,7 +229,7 @@ export default React.createClass({
       <div>
         <div style={styles.optionTitle}>Practice scenarios:</div>
         <RadioButtonGroup
-          name="indica"
+          name="indicatorId"
           valueSelected={selectedIndicatorId.toString()}
           onChange={this.onIndicatorChanged}
           style={{...styles.option, padding: 20 }}>
@@ -242,16 +251,16 @@ export default React.createClass({
     const {responseModeKey} = this.state;
     return (
       <div>
-        <div >Response modes:</div>
+        <div >Respond by:</div>
         <RadioButtonGroup
           name="responseMode"
           valueSelected={responseModeKey}
           style={{...styles.option, padding: 20 }}
           onChange={this.onResponseModeChanged}
         >
-          <RadioButton value="mixed" label="Mixed" />
-          <RadioButton value="text" label="Text" />
-          <RadioButton value="audio" label="Audio" />
+          <RadioButton value="text" label="Writing" />
+          <RadioButton value="audio" label="Speaking" />
+          <RadioButton value="mixed" label="Random" />
         </RadioButtonGroup>
       </div>
     );

--- a/ui/src/message_popup/scaffolding_card_test.jsx
+++ b/ui/src/message_popup/scaffolding_card_test.jsx
@@ -1,0 +1,59 @@
+/* @flow weak */
+import React from 'react';
+
+import {shallow} from 'enzyme';
+import sinon from 'sinon';
+import {expect} from 'chai';
+import * as TestFixtures from './test_fixtures.js';
+
+import ScaffoldingCard from './scaffolding_card.jsx';
+import RaisedButton from 'material-ui/RaisedButton';
+import {RadioButtonGroup} from 'material-ui/RadioButton';
+import TextField from 'material-ui/TextField';
+import Toggle from 'material-ui/Toggle';
+import Slider from 'material-ui/Slider';
+
+
+function testProps(props) {
+  return {
+    scaffolding: TestFixtures.practiceScaffolding,
+    initialEmail: 'user@test.com',
+    query: {},
+    onSessionConfigured: sinon.spy(),
+    ...props
+  };
+}
+
+function expectCoreOptions(wrapper) {
+  expect(wrapper.text()).to.contain('Practice scenarios:');
+  expect(wrapper.find('RadioButtonGroup[name="indicatorId"]').length).to.equal(1);
+
+  expect(wrapper.text()).to.contain('Session length:');
+  expect(wrapper.find(Slider).length).to.equal(1);
+
+  expect(wrapper.find('TextField[name="email"]').props().floatingLabelText).to.equal("What's your email address?");
+  expect(wrapper.find('RaisedButton[label="Start"]').length).to.equal(1);
+}
+
+
+
+describe('<ScaffoldingCard />', () => {
+  it('renders', () => {
+    const props = testProps();
+    const wrapper = shallow(<ScaffoldingCard {...props} />);
+    expectCoreOptions(wrapper);
+  });
+
+  it('renders all options with ?all in query params', () => {
+    const props = testProps({ query: { all: true }});
+    const wrapper = shallow(<ScaffoldingCard {...props} />);
+
+    expectCoreOptions(wrapper);
+    expect(wrapper.text()).to.contain('Respond by:');
+    expect(wrapper.find('RadioButtonGroup[name="responseMode"]').length).to.equal(1);
+
+    expect(wrapper.text()).to.contain('Scaffolding');
+    expect(wrapper.find(Toggle).length).to.equal(3);
+    expect(wrapper.find('RadioButtonGroup[name="helpOptions"]').length).to.equal(1);
+  });
+});

--- a/ui/src/message_popup/scaffolding_card_test.jsx
+++ b/ui/src/message_popup/scaffolding_card_test.jsx
@@ -7,9 +7,6 @@ import {expect} from 'chai';
 import * as TestFixtures from './test_fixtures.js';
 
 import ScaffoldingCard from './scaffolding_card.jsx';
-import RaisedButton from 'material-ui/RaisedButton';
-import {RadioButtonGroup} from 'material-ui/RadioButton';
-import TextField from 'material-ui/TextField';
 import Toggle from 'material-ui/Toggle';
 import Slider from 'material-ui/Slider';
 

--- a/ui/src/message_popup/test_fixtures.js
+++ b/ui/src/message_popup/test_fixtures.js
@@ -1,4 +1,4 @@
-/* flow weak */
+/* @flow weak */
 import _ from 'lodash';
 import {allQuestions} from './questions.js';
 import {allArchivedQuestions} from './author/archived_questions.js';

--- a/ui/src/test_auth_container.jsx
+++ b/ui/src/test_auth_container.jsx
@@ -8,10 +8,6 @@ import sinon from 'sinon';
 export default React.createClass({
   displayName: 'TestAuthContainer',
 
-  propTypes: {
-    children: React.PropTypes.element.isRequired
-  },
-
   childContextTypes: AuthContainer.childContextTypes,
 
   getChildContext() {
@@ -26,6 +22,6 @@ export default React.createClass({
   },
 
   render() {
-    return this.props.children;
+    return this.props.children || null;
   }
 });

--- a/ui/src/test_auth_container.jsx
+++ b/ui/src/test_auth_container.jsx
@@ -8,6 +8,10 @@ import sinon from 'sinon';
 export default React.createClass({
   displayName: 'TestAuthContainer',
 
+  propTypes: {
+    children: React.PropTypes.element
+  },
+
   childContextTypes: AuthContainer.childContextTypes,
 
   getChildContext() {
@@ -22,6 +26,6 @@ export default React.createClass({
   },
 
   render() {
-    return this.props.children || null;
+    return this.props.children;
   }
 });

--- a/ui/test/mocha_declarations.js
+++ b/ui/test/mocha_declarations.js
@@ -1,0 +1,6 @@
+// Flow annotations for Mocha globals
+// via https://github.com/facebook/flow/issues/1632
+declare function describe(name:string, callback:Function):void;
+declare function before(callback:Function):void;
+declare function beforeEach(callback:Function):void;
+declare function it(name:string, callback:Function):void;


### PR DESCRIPTION
This makes some small copy changes to emphasize user actions rather than technology or medium, and also adds some new tests.  In the process, I discovered mistakes in flow annotations for existing test files (`flow weak` instead of `@flow weak`) and added those back.

Before:
<img width="158" alt="screen shot 2016-08-19 at 2 31 48 pm" src="https://cloud.githubusercontent.com/assets/1056957/17820828/adcb4324-661c-11e6-91ca-6dc294e806c1.png">


After:
<img width="392" alt="screen shot 2016-08-19 at 2 41 37 pm" src="https://cloud.githubusercontent.com/assets/1056957/17820824/a940885a-661c-11e6-9f4c-9ea8ecbf3b80.png">
