### PR TITLE
Adds Authoring UI component tests

### DIFF
--- a/ui/src/message_popup/author/question_editing_components/examples_test.jsx
+++ b/ui/src/message_popup/author/question_editing_components/examples_test.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from 'chai';
+import sinon from 'sinon';
+
+import {testQuestion} from '../../test_fixtures.js';
+import Examples from './examples.jsx';
+import TextField from 'material-ui/TextField';
+
+function testProps(props){
+  return ({
+    type: 'Good',
+    examplesText: testQuestion.examples.join('\n\n'),
+    onExamplesChange: sinon.spy(),
+    ...props
+  });
+}
+
+describe('<EditingComponent.Examples />', ()=>{
+  it('renders the correct good examples text', ()=>{
+    const props = testProps();
+    const wrapper = shallow(<Examples {...props} />);
+    console.log(wrapper.debug());
+    const text = testQuestion.examples.join('\n\n');
+    expect(wrapper.find(TextField)).to.have.length(1);
+    expect(wrapper.find(TextField).props().value).to.equal(text);
+  });
+});

--- a/ui/src/message_popup/author/question_editing_components/examples_test.jsx
+++ b/ui/src/message_popup/author/question_editing_components/examples_test.jsx
@@ -20,9 +20,19 @@ describe('<EditingComponent.Examples />', ()=>{
   it('renders the correct good examples text', ()=>{
     const props = testProps();
     const wrapper = shallow(<Examples {...props} />);
-    console.log(wrapper.debug());
     const text = testQuestion.examples.join('\n\n');
     expect(wrapper.find(TextField)).to.have.length(1);
     expect(wrapper.find(TextField).props().value).to.equal(text);
+  });
+  it('renders the correct bad examples text', ()=>{
+    const text = testQuestion.nonExamples.join('\n\n');
+    const props = testProps({
+      type: 'Bad',
+      examplesText: text
+    });
+    const wrapper = shallow(<Examples {...props} />);
+    expect(wrapper.find(TextField)).to.have.length(1);
+    expect(wrapper.find(TextField).props().value).to.equal(text);
+
   });
 });

--- a/ui/src/message_popup/author/question_editing_components/indicators_test.jsx
+++ b/ui/src/message_popup/author/question_editing_components/indicators_test.jsx
@@ -7,7 +7,7 @@ import Indicators from './indicators.jsx';
 
 import {RadioButton, RadioButtonGroup} from 'material-ui/RadioButton';
 
-import {testQuestion} from '../../test_fixtures.js'
+import {testQuestion} from '../../test_fixtures.js';
 import {withIndicator} from '../../transformations.jsx';
 import {indicators} from '../../../data/indicators.js';
 

--- a/ui/src/message_popup/author/question_editing_components/indicators_test.jsx
+++ b/ui/src/message_popup/author/question_editing_components/indicators_test.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from 'chai';
+import sinon from 'sinon';
+
+import Indicators from './indicators.jsx';
+
+import {RadioButton, RadioButtonGroup} from 'material-ui/RadioButton';
+
+import {testQuestion} from '../../test_fixtures.js'
+import {withIndicator} from '../../transformations.jsx';
+import {indicators} from '../../../data/indicators.js';
+
+function testProps(props){
+  return ({
+    indicator: withIndicator(testQuestion).indicator,
+    onIndicatorChange: sinon.spy()
+  });
+}
+
+describe('<EditingComponent.Inidicators />', ()=>{
+  it('renders all the available indicators', ()=>{
+    const props = testProps();
+    const wrapper = shallow(<Indicators {...props} />);
+    expect(wrapper.find(RadioButtonGroup)).to.have.length(1);
+    expect(wrapper.find(RadioButton)).to.have.length(indicators.length);
+    wrapper.find(RadioButton).forEach((node) => {
+      expect(node.props().value).to.be.oneOf(indicators.map(indicator => indicator.id.toString()));
+    });
+  });
+  it('selects the correct initial indicator', ()=>{
+    const props = testProps();
+    const wrapper = shallow(<Indicators {...props} />);
+    expect(wrapper.find(RadioButtonGroup).props().valueSelected).to.equal(testQuestion.indicatorId.toString());
+  });
+  it('changes to the correct indicator', ()=>{
+    const props = testProps();
+    const wrapper = shallow(<Indicators {...props} />);
+    const newIndicator = indicators[1];
+    wrapper.find(RadioButtonGroup).simulate('change', {target: {value: newIndicator.id}});
+    expect(props.onIndicatorChange.callCount).to.equal(1);
+    expect(props.onIndicatorChange.firstCall.args).to.deep.equal([{target: {value: newIndicator.id}}]);
+  });
+});

--- a/ui/src/message_popup/author/question_editing_components/question_text.jsx
+++ b/ui/src/message_popup/author/question_editing_components/question_text.jsx
@@ -21,7 +21,7 @@ export default React.createClass({
         <div style={styles.title}>Question Text</div>
         <Divider />
         {originalText !== undefined && <div style={styles.originalQuestionTitle}>Original Question Text</div>}
-        {originalText !== undefined && <div style={styles.originalQuestionText}>{originalText}</div>}
+        {originalText !== undefined && <div className="originalQuestionText" style={styles.originalQuestionText}>{originalText}</div>}
         <TextField 
           id='new-text'
           value={questionText}

--- a/ui/src/message_popup/author/question_editing_components/question_text_test.jsx
+++ b/ui/src/message_popup/author/question_editing_components/question_text_test.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from 'chai';
+import sinon from 'sinon';
+
+import QuestionText from './question_text.jsx';
+
+import TextField from 'material-ui/TextField';
+
+import {testQuestion} from '../../test_fixtures.js';
+
+function testProps(props){
+  return ({
+    originalText: testQuestion.text,
+    questionText: testQuestion.text + ' THIS HAS BEEN EDITED!',
+    onQuestionTextChange: sinon.spy(),
+    ...props
+  });
+}
+
+describe('<EditingComponent.QuestionText />', ()=>{
+  it('renders the original question text', ()=>{
+    const props = testProps();
+    const wrapper = shallow(<QuestionText {...props} />);
+    expect(wrapper.find(".originalQuestionText").text()).to.equal(props.originalText);
+    expect(wrapper.find(TextField)).to.have.length(1);
+    expect(wrapper.find(TextField).props().value).to.equal(props.questionText);
+  });
+  it('does not render original question text if not provided', ()=>{
+    const props = testProps({originalText: undefined});
+    const wrapper = shallow(<QuestionText {...props} />);
+    expect(wrapper.find(".originalQuestionText")).to.have.length(0);
+  });
+  it('returns the changed text', ()=>{
+    const props = testProps();
+    const wrapper = shallow(<QuestionText {...props} />);
+    wrapper.find(TextField).simulate('change', { target: { value: testQuestion.text } });
+    expect(props.onQuestionTextChange.callCount).to.equal(1);
+    expect(props.onQuestionTextChange.firstCall.args).to.deep.equal([{ target: { value: testQuestion.text } }]);
+  });
+});

--- a/ui/src/message_popup/author/question_editing_components/students_test.jsx
+++ b/ui/src/message_popup/author/question_editing_components/students_test.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+import {expect} from 'chai';
+import sinon from 'sinon';
+
+import {ListItem} from 'material-ui/List';
+import AutoComplete from 'material-ui/AutoComplete';
+
+import Students from './students.jsx';
+import IconButton from 'material-ui/IconButton';
+
+import {testQuestion} from '../../test_fixtures.js';
+import {allStudents} from '../../../data/virtual_school.js';
+
+function testProps(props){
+  return ({
+    students: testQuestion.students,
+    addStudent: sinon.spy(),
+    removeStudent: sinon.spy(),
+    availableStudentList: allStudents.filter(student => !testQuestion.students.map(innerStudent => innerStudent.id).includes(student.id))
+  });
+}
+
+describe('<EditingComponent.Student />', ()=>{
+  it('renders the initial students', ()=>{
+    const props = testProps();
+    const wrapper = shallow(<Students {...props} />);
+    expect(wrapper.find(ListItem)).to.have.length(props.students.length);
+    wrapper.find(ListItem).forEach(node => {
+      expect(node.props().primaryText).to.be.oneOf(props.students.map(student => student.name));
+    });
+  });
+  it('has the correct data source loaded in the auto complete', ()=>{
+    const props = testProps();
+    const wrapper = shallow(<Students {...props} />);
+    expect(wrapper.find(AutoComplete)).to.have.length(1);
+    expect(wrapper.find(AutoComplete).props().dataSource).to.deep.equal(props.availableStudentList.map(student => student.name));
+  });
+});

--- a/ui/src/message_popup/author/question_editing_components/students_test.jsx
+++ b/ui/src/message_popup/author/question_editing_components/students_test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {shallow, mount} from 'enzyme';
+import {shallow} from 'enzyme';
 import {expect} from 'chai';
 import sinon from 'sinon';
 
@@ -7,7 +7,6 @@ import {ListItem} from 'material-ui/List';
 import AutoComplete from 'material-ui/AutoComplete';
 
 import Students from './students.jsx';
-import IconButton from 'material-ui/IconButton';
 
 import {testQuestion} from '../../test_fixtures.js';
 import {allStudents} from '../../../data/virtual_school.js';

--- a/ui/src/message_popup/author/questions_page_test.jsx
+++ b/ui/src/message_popup/author/questions_page_test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import _ from 'lodash';
+import {mount, shallow} from 'enzyme';
 import {expect} from 'chai';
 
 import QuestionsPage from './questions_page.jsx';
@@ -7,12 +8,25 @@ import QuestionButton from './question_button.jsx';
 import ArchivedQuestionButton from './archived_question_button.jsx';
 import {testQuestions} from '../test_fixtures.js';
 
+import TestAuthContainer from '../../test_auth_container.jsx';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+
 function testProps(props) {
   return {
     allQuestions: testQuestions,
     loaded: true,
     ...props
   };
+}
+
+function withContext(child) {
+  return (
+    <MuiThemeProvider>
+      <TestAuthContainer>
+        {child}
+      </TestAuthContainer>
+    </MuiThemeProvider>
+  );
 }
 
 describe('<QuestionsPage />', ()=>{
@@ -38,5 +52,12 @@ describe('<QuestionsPage />', ()=>{
     const wrapper = shallow(<QuestionsPage {...props} />);
     expect(wrapper.find(QuestionButton)).to.have.length(0);
     expect(wrapper.find(ArchivedQuestionButton)).to.have.length(0);
+  });
+  it('redirects when a question is touched', ()=>{
+    const props = testProps();
+    const wrapper = mount(withContext(<QuestionsPage {...props} />));
+    const firstQuestionButton = wrapper.find(QuestionButton).first();
+    firstQuestionButton.simulate('touchTap');
+    expect(window.location.href).to.equal(`/teachermoments/author/questions/${_.first(testQuestions.currentQuestions).id}`);
   });
 });


### PR DESCRIPTION
I added a few tests for the individual components that make up the authoring UI.

I was originally going to make tests for `EditQuestionPage` and `NewQuestionPage` but that is currently being blocked by the fact that `mount` currently has an issue with material-ui textfields.