### PR TITLE
Add changes for october playtest

### DIFF
--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -51,6 +51,7 @@ export default React.createClass({
 
     '/message_popup*': 'messagePopupRedirect',
     '/teachermoments': 'messagePopup',
+    '/playtest/:cohortKey': 'messagePopupPlaytest',
     '/teachermoments/exploration': 'messagePopupExploration',
     '/teachermoments/evaluations/:id': 'messagePopupEvaluation',
     '/teachermoments/scoring': 'messagePopupScoring',
@@ -97,6 +98,12 @@ export default React.createClass({
     // Uses a unique key per query string so that navigating between
     // rebuilds the page.
     return <MessagePopup.ExperiencePage key={JSON.stringify(query)} query={query} />;
+  },
+
+  messagePopupPlaytest(cohortKey, query = {}) {
+    // Uses a unique key per query string so that navigating between
+    // rebuilds the page.
+    return <MessagePopup.PlaytestExperiencePage key={JSON.stringify(query)} cohortKey={cohortKey} query={{}}/>;
   },
   
   messagePopupExploration(query = {}) {

--- a/ui/src/components/audio_recorder_flow.jsx
+++ b/ui/src/components/audio_recorder_flow.jsx
@@ -33,7 +33,8 @@ export default React.createClass({
     processing: React.PropTypes.func,
     saving: React.PropTypes.func,
     done: React.PropTypes.func,
-    onDone: React.PropTypes.func.isRequired
+    onDone: React.PropTypes.func.isRequired,
+    onLogMessage: React.PropTypes.func.isRequired
   },
 
   getInitialState():State {
@@ -76,6 +77,7 @@ export default React.createClass({
   },
 
   onRecordClicked() {
+    this.props.onLogMessage('message_popup_audio_record_clicked');
     this.setState({
       ...this.getInitialState(),
       isRecording: true
@@ -83,6 +85,7 @@ export default React.createClass({
   },
 
   onDoneRecordingClicked() {
+    this.props.onLogMessage('message_popup_audio_done_recording_clicked');
     this.setState({
       isRecording: false,
       haveRecorded: true
@@ -90,17 +93,20 @@ export default React.createClass({
   },
 
   onDoneCapture(blob:Blob) {
+    this.props.onLogMessage('message_popup_audio_on_done_capture');
     var downloadUrl = URL.createObjectURL(blob);
     this.setState({blob, downloadUrl});
   },
 
   onSubmit() {
+    this.props.onLogMessage('message_popup_audio_on_submit');
     this.setState({ uploadState: 'pending' });
     const {blob} = this.state;
     if (blob) this.uploadBlob(blob);
   },
 
   onRetry() {
+    this.props.onLogMessage('message_popup_audio_on_retry');
     this.setState({
       ...this.getInitialState(),
       isRecording: true
@@ -108,6 +114,7 @@ export default React.createClass({
   },
 
   onDoneUploading(event) {
+    this.props.onLogMessage('message_popup_audio_done_uploading');
     const uploadedUrl = JSON.parse(event.target.response).url;
     this.setState({
       uploadedUrl,

--- a/ui/src/message_popup/index.js
+++ b/ui/src/message_popup/index.js
@@ -2,6 +2,7 @@
 import _ from 'lodash';
 import type {ResponseLogT} from './types.js';
 import ExperiencePage from './experience_page.jsx';
+import PlaytestExperiencePage from './playtest/playtest_experience_page.jsx';
 import ExplorationPage from './exploration_page.jsx';
 import ScoringPage from './scoring_page.jsx';
 import EvaluationViewerPage from './evaluation_viewer_page.jsx';
@@ -26,6 +27,7 @@ export function emailsFromLogs(logs:[ResponseLogT]) {
 
 export {
   ExperiencePage,
+  PlaytestExperiencePage,
   ExplorationPage,
   ScoringPage,
   EvaluationViewerPage,

--- a/ui/src/message_popup/playtest/playtest_experience_page.jsx
+++ b/ui/src/message_popup/playtest/playtest_experience_page.jsx
@@ -1,0 +1,305 @@
+/* @flow weak */
+import _ from 'lodash';
+import React from 'react';
+import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
+import 'velocity-animate/velocity.ui';
+import uuid from 'node-uuid';
+
+import RaisedButton from 'material-ui/RaisedButton';
+import Divider from 'material-ui/Divider';
+import LinearProgress from 'material-ui/LinearProgress';
+import Snackbar from 'material-ui/Snackbar';
+import MenuItem from 'material-ui/MenuItem';
+import TextField from 'material-ui/TextField';
+
+import PopupQuestion from '../popup_question.jsx';
+import type {ResponseT} from '../popup_question.jsx';
+
+import RefreshIcon from 'material-ui/svg-icons/navigation/refresh';
+
+import {withStudents} from '../transformations.jsx';
+
+import * as Api from '../../helpers/api.js';
+import FinalSummaryCard from '../final_summary_card.jsx';
+import NavigationAppBar from '../../components/navigation_app_bar.jsx';
+
+import MobileInterface from '../mobile_prototype/mobile_interface.jsx';
+import {playtestQuestions} from '../questions.js';
+
+/*
+Shows the MessagePopup game
+*/
+export default React.createClass({
+  displayName: 'MessagePopupExperiencePage',
+
+  propTypes: {
+    query: React.PropTypes.object.isRequired,
+    cohortKey: React.PropTypes.string.isRequired
+  },
+
+  contextTypes: {
+    auth: React.PropTypes.object.isRequired
+  },
+
+  getInitialState() {
+    const isSolutionMode = _.has(this.props.query, 'solution');
+    return {
+      scaffolding: {
+        helpType: isSolutionMode ? 'none' : 'feedback',
+        shouldShowStudentCard: isSolutionMode ? _.has(this.props.query, 'cards') : true,
+        shouldShowSummary: !isSolutionMode,
+      },
+      gameSession: null,
+      toastRevision: false,
+      limitMs: 90000,
+      email: this.context.auth.userProfile.email
+    };
+  },
+  
+  playToast(){
+    if(this.state.scaffolding.helpType === 'feedback' && !this.state.scaffolding.shouldShowSummary){
+      this.setState({toastRevision: true});
+    }
+  },
+  
+  removeToast(){
+    this.setState({toastRevision: false});
+  },
+  
+  addResponseTime(elapsedMs){
+    var gameSession = {...this.state.gameSession};
+    gameSession.msResponseTimes.push(elapsedMs);
+    this.setState({ gameSession });
+  },
+
+  resetExperience(){
+    this.setState(this.getInitialState());
+  },
+
+  drawResponseMode(question, scaffolding) {
+    // Alternates between groups of text and audio responses. The order gets reversed if you're in cohort B instead of A. 
+    const isReversedOrder = this.props.cohortKey.toLowerCase() === 'b';
+    const questionGroupSize = 2;
+    if (isReversedOrder) {
+      return (Math.floor((this.state.gameSession.questionsAnswered / questionGroupSize) % 2) === 0) ?  'text' : 'audio';
+    } else {
+      return (Math.floor((this.state.gameSession.questionsAnswered / questionGroupSize) % 2) === 0) ?  'audio' : 'text';
+    }
+  },
+
+  onLog(type, response:ResponseT) {
+    Api.logEvidence(type, {
+      ...response,
+      name: this.state.gameSession.email,
+      email: this.state.gameSession.email,
+      sessionId: this.state.gameSession.sessionId,
+      clientTimestampMs: new Date().getTime(),
+      cohortKey: this.props.cohortKey
+    });
+  },
+
+  onTextChanged(e) {
+    const email = e.target.value;
+    this.setState({email});
+  },
+  
+  onQuestionDone(elapsedMs) {
+    this.playToast();
+    this.addResponseTime(elapsedMs);
+    var gameSession = {...this.state.gameSession};
+    gameSession.questionsAnswered += 1;
+    this.setState({ gameSession });
+  },
+
+  onSave(){
+    const {email} = this.state;  
+    const scaffolding = {
+      helpType: 'feedback', // feedback, hints or none
+      shouldShowStudentCard: false,
+      shouldShowSummary: false,
+    };
+
+    this.setState({
+      scaffolding,
+      gameSession: {
+        email,
+        drawResponseMode: this.drawResponseMode,
+        sessionId: uuid.v4(),
+        questions: withStudents(playtestQuestions),
+        questionsAnswered: 0,
+        msResponseTimes: []
+      },
+    });
+  },
+
+  render() {
+    return (
+      <div>
+        <NavigationAppBar
+          title="Teacher Moments"
+          prependMenuItems={
+            <MenuItem
+              onTouchTap={this.resetExperience}
+              leftIcon={<RefreshIcon />}
+              primaryText="Restart game" />
+          }
+        />
+        {this.renderMainScreen()}
+      </div>
+    );
+  },
+
+  renderMainScreen() {
+    // configure the game
+    const {gameSession} = this.state;
+    const hasStarted = gameSession !== null;
+    if (!hasStarted) return this.renderInstructions();
+
+    // all done!
+    const questionsAnswered = hasStarted ? gameSession.questionsAnswered : 0;
+    const questions = hasStarted ? gameSession.questions : [];
+    const sessionLength = hasStarted ? questions.length : 0;
+    if (questionsAnswered >= sessionLength) return this.renderDone();
+
+    // text-messaging prototype
+    if (_.has(this.props.query, 'mobilePrototype')) return this.renderMobilePrototype();
+
+    // question screen
+    return this.renderPopupQuestion();
+  },
+
+  renderDone() {
+    return (
+      <div className="done">
+        <VelocityTransitionGroup enter={{animation: "slideDown"}} leave={{animation: "slideUp"}} runOnMount={true}>
+          <div style={_.merge(_.clone(styles.container), styles.done)}>
+            <div style={styles.doneTitle}>You've finished! Please complete the feedback survey in the next browser tab.</div>
+            <Divider />
+            <p style={styles.paragraph}>Cohort: {this.props.cohortKey}</p>
+            <Divider />
+            <FinalSummaryCard 
+              msResponseTimes={this.state.gameSession.msResponseTimes} 
+              limitMs={this.state.limitMs} />
+            
+          </div>
+        </VelocityTransitionGroup>
+      </div>
+    );
+  },
+
+  renderInstructions() {
+    return (
+      <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
+        <div className="instructions">
+          <div style ={_.merge(_.clone(styles.container), styles.instructions)}>
+            <p style={styles.paragraph}>Welcome!</p>
+            <p style={styles.paragraph}>This station is about responding to students in the moment. It is set in the context of a 7th grade classroom.</p>
+            <p style={styles.paragraph}>This may feel uncomfortable at first, but it's better to get comfortable here than with real students.</p>
+            <p style={styles.paragraph}>You may be asked to write or say your responses aloud.</p>
+            <p style={styles.paragraph}>Each question is timed to simulate responding in the moment in the classroom. Aim to respond to each scenario in about 90 seconds.</p>
+            <Divider />
+          </div>
+        </div>
+        <div style={{padding: 20}}>
+          <TextField
+          name="email"
+          style={{width: '100%'}}
+          underlineShow={false}
+          floatingLabelText="What's your email address?"
+          value={this.state.email}
+          onChange={this.onTextChanged}
+          multiLine={true}
+          rows={2}/>
+          <div style={{display: 'flex', flexDirection: 'row', alignItems: 'flex-end'}}>
+            <RaisedButton
+              disabled={this.state.email === ''}
+              onTouchTap={this.onSave}
+              style={styles.button}
+              secondary={true}
+              label="Start" />
+          </div>    
+        </div>
+        
+      </VelocityTransitionGroup>
+
+      );
+  },
+  
+  renderPopupQuestion() {
+    const {scaffolding, gameSession, limitMs} = this.state;
+    const {questions, questionsAnswered, drawResponseMode} = gameSession;
+    const sessionLength = questions.length;
+    const question = questions[questionsAnswered];
+
+    return (
+      <div className="question" style={styles.container}>        
+        <LinearProgress color="#EC407A" mode="determinate" value={questionsAnswered} max={sessionLength} />
+        <VelocityTransitionGroup enter={{animation: "slideDown"}} leave={{animation: "slideUp"}} runOnMount={true}>
+          <PopupQuestion
+            key={JSON.stringify(question)}
+            question={question}
+            scaffolding={scaffolding}
+            limitMs={limitMs}
+            onLog={this.onLog}
+            onDone={this.onQuestionDone}
+            drawResponseMode={drawResponseMode}
+            isLastQuestion={(questionsAnswered + 1 === sessionLength)}/>
+        </VelocityTransitionGroup>
+        <Snackbar
+          open={this.state.toastRevision}
+          message="Response recorded for feedback"
+          autoHideDuration={2000}
+          onRequestClose={this.removeToast}
+        />
+      </div>
+    );
+  },
+  
+  renderMobilePrototype() {
+    const {scaffolding, gameSession, limitMs} = this.state;
+    const {questions, questionsAnswered} = gameSession;
+    const sessionLength = questions.length;
+    const question = withStudents(questions)[questionsAnswered];
+    return ( 
+      <div className="prototype">
+        <LinearProgress color="#EC407A" mode="determinate" value={questionsAnswered} max={sessionLength} />
+        <MobileInterface
+          key={JSON.stringify(question)}
+          scaffolding={scaffolding}
+          question={question}
+          onQuestionDone={this.onQuestionDone}
+          limitMs={limitMs}
+          onLog={this.onLog}
+          isLastQuestion={questionsAnswered+1===sessionLength ? true : false}
+          />
+      </div>
+    );
+  }
+});
+
+const styles = {
+  done: {
+    padding: 20,
+  },
+  container: {
+    fontSize: 20,
+    padding: 0,
+    margin:0,
+    paddingBottom: 45
+  },
+  button: {
+    marginTop: 20
+  },
+  doneTitle: {
+    marginBottom: 10
+  },
+  instructions: {
+    paddingLeft: 20,
+    paddingRight: 20,
+  },
+  paragraph: {
+    marginTop: 20,
+    marginBottom: 20
+  }
+
+};

--- a/ui/src/message_popup/questions.js
+++ b/ui/src/message_popup/questions.js
@@ -648,6 +648,93 @@ export const doSomethingQuestions:[QuestionT] = [
   }
 ].map(forIndicator(601));
 
+export const playtestQuestions:[QuestionT] = [
+  {
+    studentIds: [],
+    id: 331,
+    text: 'After lunch, you come back to the room and see someone took down the color chart or homework chart and threw it on the floor.  It is not clear who did this. How would you Respond to the class?',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 332,
+    text: 'During a mini lesson you inadvertently say a phrase that clearly is taken as a sexual innuendo by a small group of students who start laughing out loud.  Others are in the dark or missed it.  You hear them ask, "what?.." How would you Respond to the class?',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 333,
+    text: 'You are checking homework, and you notice Danny doesn\'t have his homework out and ready.  You write it down on your clipboard without interrupting his Do Now.  You ask his partner where her homework is.  Danny looks up and says loudly, "you didn\'t ask me for my homework--what, it\'s cause I\'m black!" How do you respond to Danny?',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 334,
+    text: 'It is the first public share of student work.  Students are sharing their thinking maps in small groups.  One student clearly spent more time on his piece and added glitter and neon.  When he begins to share, the most volatile student lets out a laugh, “ohh my god that is sooo gay.” How do you respond to the student?',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 335,
+    text: 'You are having a class discussion about career paths. All the students are actively engaged in the conversation and taking turns to talk about what they would like to be when they grow up. When it gets to Peter’s turn, he says he would like to become a nurse. At this point, the most volatile student lets out a laugh, “ohh my god that is sooo lame.” How do you respond to the student?',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 336,
+    text: 'Students are working in small groups of two. Danny and James are working together. You hear Danny call James "stupid" and tells him that his ideas "suck". How do you respond to Danny?',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 337,
+    text: 'You have started a well planned launch of a lesson where just about every word and idea is critical to the student entry into the problem solving part of the lesson. A student waves his/her hand and asks to go to the bathroom. How do you respond to the student?',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 338,
+    text: 'It\'s rug time. You transition the class to the rug. One student refuses to leave his seat and starts yelling out negative comments, "I hate this class. The work we do is stupid." How do you respond to the student?',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 339,
+    text: 'The lesson is going along smoothly. You ask a question and calls on a student, as the student begins to respond, David (another student) then yells out, "You NEVER call on me!" and rips his paper up. How do you respond to David?',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 340,
+    text: 'The class is actively engaged in a discussion about a time they felt grown up, and as you scan the room, you notice a student has their head down and is staring into space. How do you respond to the student?',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 341,
+    text: 'Students have just returned to class from special and have started the routine of independent reading. You are passing out the snack for the day - bananas. As you reach one student, she asks, "What can we have if we don\'t like bananas?" You say, "Bananas are the only choice. It\'s bananas or you can wait until lunch." The student yells out "WHAT?! I don\'t like bananas," walks out of her seat, rolls up half the rug, and then starts slamming the door repeatedly. How do you respond to the student?',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 342,
+    text: 'It\'s the third day of school, a student walks in the middle of the mini lesson and yells, "Ms. I\'m in your class now!" The class bursts out in equal parts "ooooohhhh" and "oh nooooooo"  The newly entering student begins to answer back, "What?" How would you Respond to the class?',
+    examples: [],
+    nonExamples: []
+  },
+].map(forIndicator(601));
+
 
 const justinAndRitaQuestions = [
   {

--- a/ui/src/message_popup/renderers/audio_response.jsx
+++ b/ui/src/message_popup/renderers/audio_response.jsx
@@ -39,6 +39,7 @@ export default React.createClass({
           reviewing={this.renderReviewing}
           recording={this.renderRecording}
           onDone={this.onDone}
+          onLogMessage={this.props.onLogMessage}
         />
       </div>
     );

--- a/ui/src/message_popup/renderers/audio_response.jsx
+++ b/ui/src/message_popup/renderers/audio_response.jsx
@@ -45,38 +45,46 @@ export default React.createClass({
   },
 
   renderStart({onRecord}) {
+    const seconds = Math.round(this.props.elapsedMs / 1000);
     return (
       <div>
         <div style={styles.instruction}>Speak directly to the student.</div>
         <RaisedButton key="record" onTouchTap={onRecord} label="Record" secondary={true} />
+        {seconds > 0 && <div style= {styles.ticker}>{seconds}s</div>}
       </div>
     );
   },
 
   renderRecording({onDone}) {
+    const seconds = Math.round(this.props.elapsedMs / 1000);
     return (
       <div>
         <div style={{...styles.instruction, color: Colors.accent1Color}}>Recording...</div>
         <RaisedButton key="done" onTouchTap={onDone} label="Done" primary={true} />
+        {seconds > 0 && <div style= {styles.ticker}>{seconds}s</div>}
       </div>
     );
   },
 
   renderReviewing({blob, downloadUrl, onSubmit, onRetry}) {
+    const seconds = Math.round(this.props.elapsedMs / 1000);
     return (
       <div>
         <div style={styles.instruction}>Review your answer!</div>
         <audio controls={true} src={downloadUrl} />
         <RaisedButton onTouchTap={onRetry} label="Record again" />
         <RaisedButton onTouchTap={onSubmit} label="Submit" primary={true} />
+        {seconds > 0 && <div style= {styles.ticker}>{seconds}s</div>}
       </div>
     );
   },
 
   renderDone({uploadedUrl}) {
+    const seconds = Math.round(this.props.elapsedMs / 1000);
     return (
       <div>
         <RaisedButton label="Done" onTouchTap={this.onDone.bind(this, uploadedUrl)} primary={true} />
+        {seconds > 0 && <div style= {styles.ticker}>{seconds}s</div>}
       </div>
     );
   }
@@ -89,5 +97,10 @@ const styles = {
   },
   instruction: {
     paddingBottom: 5
+  },
+  ticker: {
+    display: 'inline-block',
+    marginLeft: 15,
+    fontSize: 20
   }
 };


### PR DESCRIPTION
Add changes for october playtest. The main changes are:
* Modify app.jsx to create endpoint "/playtest:cohortKey". The cohort Key should be A or B. This reverses the order of text vs audio responses.
* Added playtest_experience_page.jsx to get read of the default scaffolding and include a custom starting and ending screen.
* Added playtest questions to questions.js

# Screenshots of modified screens
<img width="600" alt="screenshot 2016-10-18 11 27 39" src="https://cloud.githubusercontent.com/assets/9402134/19484638/397db748-9526-11e6-8d49-e1f84c000133.png">


<img width="600" alt="screenshot 2016-10-18 11 29 00" src="https://cloud.githubusercontent.com/assets/9402134/19484637/397d25bc-9526-11e6-8852-403207d07ca1.png">


![screenshot 2016-10-18 13 37 52](https://cloud.githubusercontent.com/assets/9402134/19489179/24625712-9538-11e6-83c0-227ecabcb94d.png)
