### PR TITLE
Guard stopping stream, and add call to destroy audio context

### DIFF
--- a/ui/src/components/audio_capture.jsx
+++ b/ui/src/components/audio_capture.jsx
@@ -50,6 +50,7 @@ export default React.createClass({
 
   onBlobReady(blob) {
     this.props.onDoneCapture(blob);
+    this.recorder.destroy();
     delete this.recorder;
   },
 

--- a/ui/src/components/audio_recorder.js
+++ b/ui/src/components/audio_recorder.js
@@ -66,8 +66,8 @@ export default class AudioRecorder {
   }
 
   destroy() {
-    this.recordingStream.stop();
-    this.audioContext.close();
+    if (this.recordingStream.stop) this.recordingStream.stop();
+    if (this.audioContext.close) this.audioContext.close();
 
     delete this.buffers;
     delete this.bufferLength;


### PR DESCRIPTION
Addressing resource leak:
```
NotSupportedError: Failed to construct 'AudioContext': The number of hardware contexts provided (6) is greater than or equal to the maximum bound (6).
```