### PR TITLE
Factor out student card, add Sketchpad models in TextWithModel scenarios

### DIFF
--- a/ui/src/components/audio_recorder.js
+++ b/ui/src/components/audio_recorder.js
@@ -50,14 +50,15 @@ export default class AudioRecorder {
   }
 
   _onAudioProcess(event) {
-    // save left and right buffers
-    for(let i = 0; i < 2; i++) {
-      const channel = event.inputBuffer.getChannelData(i);
-      this.buffers[i].push(new Float32Array(channel));
+    if (this.buffers && this.hasOwnProperty('bufferLength')) {
+      // save left and right buffers 
+      for(let i = 0; i < 2; i++) {
+        const channel = event.inputBuffer.getChannelData(i);
+        this.buffers[i].push(new Float32Array(channel));
+      }
+      this.bufferLength += this.bufferSize;
     }
-    this.bufferLength += this.bufferSize;
   }
-
 
   stop(onBlobReady) {
     this.recordingStream.getTracks()[0].stop();

--- a/ui/src/data/virtual_school.js
+++ b/ui/src/data/virtual_school.js
@@ -374,6 +374,12 @@ const julyStudentsFromMursion = [
 
 const demoStudents = [{
   id: 4001,
+  sketchFab: {
+    id: 'f6548660b118491fbf32d78d5dbc8403',
+    eye: [-3, -20, -6],
+    target: [0.0, 0.01, 0.15]
+  },
+  sketchFabId: '',
   name: `Danny`,
   grade: `7th grade`,
   gender: `male`,
@@ -385,6 +391,37 @@ const demoStudents = [{
   interests: `Plays in a band, sings in the school chorus`,
   familyBackground: `1 older brother`,
   ses: null,
+}, {
+  id: 4002,
+  sketchFab: {
+    id: '127655328fe34d4089cc9e8647645464',
+    eye: [-2, -20, -1],
+    target: [-0.02, 0.00, 0.1]
+  },
+  name: `Dani`,
+  grade: `7th grade`,
+  gender: `female`,
+  race: `Indian`,
+  behavior: null,
+  ell: null,
+  learningDisabilities: null,
+  academicPerformance: null,
+  interests: null,
+  familyBackground: null,
+  ses: null
+}, {
+  id: 4003,
+  name: `Rita`,
+  grade: `7th grade`,
+  gender: `female`,
+  race: `Caucasian`,
+  behavior: null,
+  ell: null,
+  learningDisabilities: `ADHD`,
+  academicPerformance: null,
+  interests: 'Active in theater clubs',
+  familyBackground: null,
+  ses: null
 }].map(addFields({
   isMursion: false,
   cohortKey: '20161026'

--- a/ui/src/message_popup/demo_page.jsx
+++ b/ui/src/message_popup/demo_page.jsx
@@ -40,7 +40,6 @@ export default React.createClass({
     return {
       scaffolding: {
         helpType: 'none',
-        shouldShowStudentCard: true,
         shouldShowSummary: false
       },
       gameSession: null,
@@ -71,9 +70,15 @@ export default React.createClass({
   },
 
   drawResponseMode(question, scaffolding) {
-    // Start with text and alternate
+    // Tied to the specific scenarios
     const {questionsAnswered} = this.state.gameSession;
-    return (questionsAnswered % 2 === 0) ? 'text' : 'audio';
+    return ['text', 'text', 'audio', 'audio'][questionsAnswered];
+  },
+
+  drawStudentCard(question, scaffolding) {
+    // Tied to the specific scenarios
+    const {questionsAnswered} = this.state.gameSession;
+    return [true, false, false, true][questionsAnswered];
   },
 
   onLog(type, response:ResponseT) {
@@ -112,6 +117,7 @@ export default React.createClass({
       gameSession: {
         email,
         drawResponseMode: this.drawResponseMode,
+        drawStudentCard: this.drawStudentCard,
         sessionId: uuid.v4(),
         questions: withStudents(demoQuestions),
         questionsAnswered: 0,
@@ -201,7 +207,7 @@ export default React.createClass({
   
   renderPopupQuestion() {
     const {scaffolding, gameSession, limitMs} = this.state;
-    const {questions, questionsAnswered, drawResponseMode} = gameSession;
+    const {questions, questionsAnswered, drawResponseMode, drawStudentCard} = gameSession;
     const sessionLength = questions.length;
     const question = questions[questionsAnswered];
 
@@ -217,6 +223,7 @@ export default React.createClass({
             onLog={this.onLog}
             onDone={this.onQuestionDone}
             drawResponseMode={drawResponseMode}
+            drawStudentCard={drawStudentCard}
             isLastQuestion={(questionsAnswered + 1 === sessionLength)}/>
         </VelocityTransitionGroup>
         <Snackbar

--- a/ui/src/message_popup/demo_page_test.jsx
+++ b/ui/src/message_popup/demo_page_test.jsx
@@ -1,0 +1,46 @@
+/* @flow weak */
+import React from 'react';
+
+import {render, mount} from 'enzyme';
+import {expect} from 'chai';
+import TestAuthContainer from '../test_auth_container.jsx';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+
+import DemoPage from './demo_page.jsx';
+import PopupQuestion from './popup_question.jsx';
+import PlainTextQuestion from './renderers/plain_text_question.jsx';
+
+// Wrap with application context for a full render
+// (eg., theming, authorization).
+function withContext(child) {
+  return (
+    <MuiThemeProvider>
+      <TestAuthContainer>
+        {child}
+      </TestAuthContainer>
+    </MuiThemeProvider>
+  );
+}
+
+describe('<DemoPage />', () => {
+  it('renders instructions', () => {    
+    const wrapper = render(withContext(<DemoPage />));
+
+    expect(wrapper.find('.instructions').length).to.equal(1);
+    expect(wrapper.find('.prototype').length).to.equal(0);
+    expect(wrapper.find('.done').length).to.equal(0);
+    expect(wrapper.find('.question').length).to.equal(0);
+  });
+
+  it('transitions to first question', () => {
+    const wrapper = mount(withContext(<DemoPage />));
+    wrapper.find(DemoPage).node.onSave();
+
+    expect(wrapper.find(PopupQuestion).length).to.equal(1);
+    expect(wrapper.find(PopupQuestion).props().scaffolding).to.deep.equal({
+      helpType: 'none',
+      shouldShowSummary: false
+    });
+    expect(wrapper.find(PlainTextQuestion).length).to.equal(1);
+  });
+});

--- a/ui/src/message_popup/experience_page.jsx
+++ b/ui/src/message_popup/experience_page.jsx
@@ -47,7 +47,6 @@ export default React.createClass({
     return {
       scaffolding: {
         helpType: isSolutionMode ? 'none' : 'feedback',
-        shouldShowStudentCard: isSolutionMode ? _.has(this.props.query, 'cards') : true,
         shouldShowSummary: !isSolutionMode,
       },
       gameSession: null,
@@ -99,12 +98,19 @@ export default React.createClass({
   },
   
   onSaveScaffoldingAndSession(scaffoldingSessionParams){
-    const {scaffolding, email, questionsForSession, drawResponseMode} = scaffoldingSessionParams;
+    const {
+      scaffolding,
+      email,
+      questionsForSession,
+      drawResponseMode,
+      drawStudentCard
+    } = scaffoldingSessionParams;
     this.setState({
       scaffolding,
       gameSession: {
         email,
         drawResponseMode,
+        drawStudentCard,
         sessionId: uuid.v4(),
         questions: questionsForSession,
         questionsAnswered: 0,
@@ -193,7 +199,7 @@ export default React.createClass({
   
   renderPopupQuestion() {
     const {scaffolding, gameSession, limitMs} = this.state;
-    const {questions, questionsAnswered, drawResponseMode} = gameSession;
+    const {questions, questionsAnswered, drawResponseMode, drawStudentCard} = gameSession;
     const sessionLength = questions.length;
     const question = questions[questionsAnswered];
 
@@ -209,6 +215,7 @@ export default React.createClass({
             onLog={this.onLog}
             onDone={this.onQuestionDone}
             drawResponseMode={drawResponseMode}
+            drawStudentCard={drawStudentCard}
             isLastQuestion={(questionsAnswered + 1 === sessionLength)}/>
         </VelocityTransitionGroup>
         <Snackbar

--- a/ui/src/message_popup/mobile_prototype/mobile_interface.jsx
+++ b/ui/src/message_popup/mobile_prototype/mobile_interface.jsx
@@ -30,7 +30,6 @@ export default React.createClass({
   propTypes: {
     scaffolding: React.PropTypes.shape({
       helpType: React.PropTypes.string.isRequired,
-      shouldShowStudentCard: React.PropTypes.bool.isRequired,
       shouldShowSummary: React.PropTypes.bool.isRequired,
     }).isRequired,
     question: React.PropTypes.object.isRequired,
@@ -162,14 +161,14 @@ export default React.createClass({
   logData(type, params = {}) {
     const {elapsedMs, initialResponse} = this.state;
     const {question, scaffolding} = this.props;
-    const {shouldShowStudentCard, helpType} = scaffolding;
+    const {helpType} = scaffolding;
     const {finalResponseText} = params;
     const response:RevisingTextResponseT = {
       question,
-      shouldShowStudentCard,
       helpType,
       elapsedMs,
       initialResponseText: initialResponse,
+      didShowStudentCard: true,
       finalResponseText
     };
     this.props.onLog(type, response);
@@ -247,8 +246,7 @@ export default React.createClass({
   },
 
   renderDialogs(){
-    const {scaffolding, question} = this.props;
-    const {shouldShowStudentCard} = scaffolding;
+    const {question} = this.props;
     const {dialog} = this.state;
     const selectedStudent = dialog !== null ? (dialog.type === 'student' ? dialog.student : undefined) : undefined;
     return (
@@ -278,13 +276,13 @@ export default React.createClass({
             open={dialog !== null && dialog.type === 'student'}
             onRequestClose={this.onCloseDialog}>
             <div style={styles.studentAttribute}>{`${selectedStudent.grade} ${selectedStudent.gender}, ${selectedStudent.race}`}</div>
-            {shouldShowStudentCard && selectedStudent.behavior && <div style={styles.studentAttribute}>{selectedStudent.behavior}</div>}
-            {shouldShowStudentCard && selectedStudent.ell && <div style={styles.studentAttribute}>{selectedStudent.ell}</div>}
-            {shouldShowStudentCard && selectedStudent.learningDisabilities && <div style={styles.studentAttribute}>{selectedStudent.learningDisabilities}</div>}
-            {shouldShowStudentCard && selectedStudent.academicPerformance && <div style={styles.studentAttribute}>{selectedStudent.academicPerformance}</div>}
-            {shouldShowStudentCard && selectedStudent.interests && <div style={styles.studentAttribute}>{selectedStudent.interests}</div>}
-            {shouldShowStudentCard && selectedStudent.familyBackground && <div style={styles.studentAttribute}>{selectedStudent.familyBackground}</div>}
-            {shouldShowStudentCard && selectedStudent.ses && <div style={styles.studentAttribute}>{selectedStudent.ses}</div>}
+            {selectedStudent.behavior && <div style={styles.studentAttribute}>{selectedStudent.behavior}</div>}
+            {selectedStudent.ell && <div style={styles.studentAttribute}>{selectedStudent.ell}</div>}
+            {selectedStudent.learningDisabilities && <div style={styles.studentAttribute}>{selectedStudent.learningDisabilities}</div>}
+            {selectedStudent.academicPerformance && <div style={styles.studentAttribute}>{selectedStudent.academicPerformance}</div>}
+            {selectedStudent.interests && <div style={styles.studentAttribute}>{selectedStudent.interests}</div>}
+            {selectedStudent.familyBackground && <div style={styles.studentAttribute}>{selectedStudent.familyBackground}</div>}
+            {selectedStudent.ses && <div style={styles.studentAttribute}>{selectedStudent.ses}</div>}
           </Dialog>
         }
       </div>

--- a/ui/src/message_popup/playtest/playtest_experience_page.jsx
+++ b/ui/src/message_popup/playtest/playtest_experience_page.jsx
@@ -46,7 +46,6 @@ export default React.createClass({
     return {
       scaffolding: {
         helpType: isSolutionMode ? 'none' : 'feedback',
-        shouldShowStudentCard: isSolutionMode ? _.has(this.props.query, 'cards') : true,
         shouldShowSummary: !isSolutionMode,
       },
       gameSession: null,
@@ -87,6 +86,11 @@ export default React.createClass({
     }
   },
 
+  // This implementation is static
+  drawStudentCard(question, scaffolding) {
+    return true;
+  },
+  
   onLog(type, response:ResponseT) {
     Api.logEvidence(type, {
       ...response,
@@ -115,7 +119,6 @@ export default React.createClass({
     const {email} = this.state;  
     const scaffolding = {
       helpType: 'feedback', // feedback, hints or none
-      shouldShowStudentCard: false,
       shouldShowSummary: false,
     };
 
@@ -124,6 +127,7 @@ export default React.createClass({
       gameSession: {
         email,
         drawResponseMode: this.drawResponseMode,
+        drawStudentCard: this.drawStudentCard,
         sessionId: uuid.v4(),
         questions: withStudents(playtestQuestions),
         questionsAnswered: 0,
@@ -227,7 +231,7 @@ export default React.createClass({
   
   renderPopupQuestion() {
     const {scaffolding, gameSession, limitMs} = this.state;
-    const {questions, questionsAnswered, drawResponseMode} = gameSession;
+    const {questions, questionsAnswered, drawResponseMode, drawStudentCard} = gameSession;
     const sessionLength = questions.length;
     const question = questions[questionsAnswered];
 
@@ -243,6 +247,7 @@ export default React.createClass({
             onLog={this.onLog}
             onDone={this.onQuestionDone}
             drawResponseMode={drawResponseMode}
+            drawStudentCard={drawStudentCard}
             isLastQuestion={(questionsAnswered + 1 === sessionLength)}/>
         </VelocityTransitionGroup>
         <Snackbar

--- a/ui/src/message_popup/popup_question_test.jsx
+++ b/ui/src/message_popup/popup_question_test.jsx
@@ -9,7 +9,6 @@ import * as TestFixtures from './test_fixtures.js';
 import PopupQuestion from './popup_question.jsx';
 import SummaryCard from './summary_card.jsx';
 import ScenarioRenderer from './renderers/scenario_renderer.jsx';
-import PromptsRenderer from './renderers/prompts_renderer.jsx';
 import RevisingTextResponse from './renderers/revising_text_response.jsx';
 import AudioResponse from './renderers/audio_response.jsx';
 
@@ -23,13 +22,13 @@ function testProps(props) {
     onDone: sinon.spy(),
     isLastQuestion: false,
     drawResponseMode: () => 'text',
+    drawStudentCard: () => true,
     ...props
   };
 }
 
 function expectChildElementsIn(wrapper) {
   expect(wrapper.find(ScenarioRenderer).length).to.equal(1);
-  expect(wrapper.find(PromptsRenderer).length).to.equal(1);
   expect(wrapper.find(SummaryCard).length).to.equal(0);
 }
 

--- a/ui/src/message_popup/questions.js
+++ b/ui/src/message_popup/questions.js
@@ -558,14 +558,14 @@ export const doSomethingQuestions:[QuestionT] = [
   {
     studentIds: [4001],
     id: 305,
-    text: 'You are checking homework, and you notice Danny doesn\'t have his hw out and ready.  You write it down on your clipboard without interrupting his Do Now.  You ask his partner where her homework is.  Danny looks up and says loudly, "you didn\'t ask me for my homework--what, it\'s cause I\'m black!"',
+    text: 'You are checking homework, and you notice Danny doesn\'t have his homework out and ready.  You write it down on your clipboard without interrupting his Do Now.  You ask his partner where her homework is.  Danny looks up and says loudly, "you didn\'t ask me for my homework--what, it\'s cause I\'m black!"',
     examples: [],
     nonExamples: []
   },
   {
-    studentIds: [2003],
+    studentIds: [4002],
     id: 306,
-    text: 'During a lesson on the rug, you are engaging the class in a Read Aloud, students are clearly engaged.  However, you soon notice Jasmine in the back of the room writing all over her desk top seeming not to be paying attention.',
+    text: 'During a lesson on the rug, you are engaging the class in a Read Aloud, students are clearly engaged.  However, you soon notice Dani in the back of the room writing all over her desk top seeming not to be paying attention.',
     examples: [],
     nonExamples: []
   },
@@ -739,7 +739,7 @@ export const playtestQuestions:[QuestionT] = [
 const justinAndRitaQuestions = [
   {
     id: 3001,
-    studentIds: [],
+    studentIds: [4003],
     youTubeId: 'EvQ1S6-ImRk',
     youTubeParams: {
       end: 124

--- a/ui/src/message_popup/renderers/plain_text_question.jsx
+++ b/ui/src/message_popup/renderers/plain_text_question.jsx
@@ -1,0 +1,27 @@
+/* @flow weak */
+import React from 'react';
+
+
+// Render a plain text question, nothing else.
+export default React.createClass({
+  displayName: 'PlainTextQuestion',
+
+  propTypes: {
+    question: React.PropTypes.object.isRequired,
+  },
+
+  render() {
+    const {question} = this.props;
+
+    return <div style={styles.textQuestion}>{question.text}</div>;
+  }
+});
+
+const styles = {
+  textQuestion: {
+    whiteSpace: 'pre-wrap',
+    fontSize: 16,
+    lineHeight: 1.2,
+    padding: 20
+  }
+};

--- a/ui/src/message_popup/renderers/prompts_renderer.jsx
+++ b/ui/src/message_popup/renderers/prompts_renderer.jsx
@@ -10,17 +10,18 @@ export default React.createClass({
   displayName: 'PromptsRenderer',
 
   propTypes: {
+    showStudentCard: React.PropTypes.bool.isRequired,
     scaffolding: React.PropTypes.object.isRequired,
     question: React.PropTypes.object.isRequired,
     student: React.PropTypes.object
   },
 
   render() {
-    const {scaffolding, student, question} = this.props;
+    const {scaffolding, showStudentCard, student, question} = this.props;
     const {examples, nonExamples} = question;
     return (
       <div>
-        {scaffolding.shouldShowStudentCard && student &&
+        {showStudentCard && student &&
           <StudentCard useCardStyles={true} student={student} />}
         {scaffolding.helpType === 'hints' && 
           <div style={styles.hintCard}>
@@ -33,7 +34,6 @@ export default React.createClass({
 
 const styles = {
   hintCard: {
-    marginTop: 5,
     padding: 10,
     paddingBottom: 0
   }

--- a/ui/src/message_popup/renderers/scenario_renderer_test.jsx
+++ b/ui/src/message_popup/renderers/scenario_renderer_test.jsx
@@ -1,23 +1,59 @@
 /* @flow weak */
 import React from 'react';
+import _ from 'lodash';
 
 import {shallow} from 'enzyme';
 import {expect} from 'chai';
 import sinon from 'sinon';
 import * as TestFixtures from '../test_fixtures.js';
+import {allStudents} from '../../data/virtual_school.js';
 
 import ScenarioRenderer from './scenario_renderer.jsx';
+import PlainTextQuestion from './plain_text_question.jsx';
+import VideoScenario from './video_scenario.jsx';
+import TextModelScenario from './text_model_scenario.jsx';
 
 
 describe('<ScenarioRenderer />', () => {
-  it('renders', () => {
+  it('renders plain text', () => {
     const question = TestFixtures.testQuestion;
     const wrapper = shallow(
       <ScenarioRenderer
+        scaffolding={TestFixtures.solutionScaffolding}
+        showStudentCard={false}
         question={question}
         onScenarioDone={sinon.spy()}
       />
     );
-    expect(wrapper.text()).to.equal(question.text);
+    expect(wrapper.find(PlainTextQuestion).length).to.equal(1);
+  });
+
+  it('renders video scenarios', () => {
+    const question = {...TestFixtures.testQuestion, youTubeId: 'foo'};
+    const wrapper = shallow(
+      <ScenarioRenderer
+        scaffolding={TestFixtures.solutionScaffolding}
+        showStudentCard={false}
+        question={question}
+        onScenarioDone={sinon.spy()}
+      />
+    );
+    expect(wrapper.find(VideoScenario).length).to.equal(1);
+  });
+
+  it('renders text model scenarios for students with data', () => {
+    const question = TestFixtures.testQuestion;
+    const student = _.find(allStudents, { id: 4001 });
+    const wrapper = shallow(
+      <ScenarioRenderer
+        scaffolding={TestFixtures.solutionScaffolding}
+        showStudentCard={false}
+        question={question}
+        student={student}
+        onScenarioDone={sinon.spy()}
+      />
+    );
+    expect(Object.keys(student.sketchFab)).to.have.members(['id', 'eye', 'target']);
+    expect(wrapper.find(TextModelScenario).length).to.equal(1);
   });
 });

--- a/ui/src/message_popup/renderers/text_model_scenario.jsx
+++ b/ui/src/message_popup/renderers/text_model_scenario.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+
+import * as PropTypes from '../../prop_types.js';
+import PlainTextQuestion from './plain_text_question.jsx';
+
+// Render a text scenario with a 3D model from SketchPad
+// Requires data set on the student about the id for the 
+// SketchPad model, and about the camera orientation.
+export default React.createClass({
+  displayName: 'TextModelScenario',
+
+  propTypes: {
+    scaffolding: PropTypes.Scaffolding.isRequired,
+    question: React.PropTypes.object.isRequired,
+    student: PropTypes.Student.isRequired,
+    modelHeight: React.PropTypes.number.isRequired,
+    onScenarioDone: React.PropTypes.func.isRequired
+  },
+
+  componentDidMount() {
+    this.injectScript();
+  },
+
+  componentWillUnmount() {
+    if (this.api) this.api.stop();
+    if (this.client) delete this.client;
+    if (window.Sketchfab) delete window.Sketchfab;
+  },
+
+  api: null,
+  el: null,
+  client: null,
+
+  // injects window.Sketchfab
+  injectScript() {
+    const sketchPadScriptUrl = 'https://d1jlf623bx36qa.cloudfront.net/api/sketchfab-viewer-1.0.0.js';
+    const script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.async = true;
+    script.onload = this.onScriptLoaded;
+    script.src = sketchPadScriptUrl;
+    document.getElementsByTagName('head')[0].appendChild(script);
+  },
+
+  // see https://help.sketchfab.com/hc/en-us/articles/203509907-Share-Embed-Online
+  onScriptLoaded() {
+    const {sketchFab} = this.props.student;
+    this.client = new window.Sketchfab('1.0.0', this.el);
+    this.client.init(sketchFab.id, {
+      autostart: 1,
+      camera: 0,
+      ui_stop: 0,
+      preload: 1,
+      autospin: 0.01,
+      success: this.onSuccess,
+      error: this.onError
+    });
+  },
+
+  onError(err) {
+    console.error('onError', err); // eslint-disable-line no-console
+  },
+
+  onSuccess(api) {
+    api.start();
+    api.addEventListener('viewerready', this.onApiLoaded);
+    this.api = api;
+  },
+
+  onApiLoaded() {
+    const {sketchFab} = this.props.student;
+    if (this.api) {
+      this.api.setFov(1);
+      this.api.lookat(sketchFab.eye, sketchFab.target, 0.001);
+      this.props.onScenarioDone();
+    }
+  },
+
+  render() {
+    const {question, modelHeight} = this.props;
+
+    return (
+      <div>
+        <PlainTextQuestion question={question} />
+        <div className="sketchfab-embed-wrapper">
+          <iframe
+            style={{...styles.sketchFabIframe, height: modelHeight}}
+            ref={(el) => { if (el) this.el = el; }}
+            width="100%"
+            frameBorder={0}
+          >Loading...</iframe>
+        </div>
+      </div>
+    );
+  }
+});
+
+const styles = {
+  sketchFabIframe: {
+    backgroundColor: 'black'
+  }
+};

--- a/ui/src/message_popup/scaffolding_card.jsx
+++ b/ui/src/message_popup/scaffolding_card.jsx
@@ -28,7 +28,6 @@ export default React.createClass({
   propTypes: {
     scaffolding: React.PropTypes.shape({
       helpType: React.PropTypes.string.isRequired,
-      shouldShowStudentCard: React.PropTypes.bool.isRequired,
       shouldShowSummary: React.PropTypes.bool.isRequired
     }).isRequired,
     initialEmail: React.PropTypes.string.isRequired,
@@ -44,7 +43,6 @@ export default React.createClass({
       sessionLength: 10,
       scaffolding: {
         helpType: this.props.scaffolding.helpType,
-        shouldShowStudentCard: this.props.scaffolding.shouldShowStudentCard,
         shouldShowSummary: this.props.scaffolding.shouldShowSummary,
       },
       selectedIndicatorId: ALL_INDICATORS,
@@ -74,6 +72,11 @@ export default React.createClass({
     return 'text';
   },
 
+  // This implementation is static
+  drawStudentCard(question, scaffolding) {
+    return true;
+  },
+
   onResponseModeChanged(event, responseModeKey) {
     this.setState({ responseModeKey });
   },
@@ -86,7 +89,8 @@ export default React.createClass({
       scaffolding,
       email,
       questionsForSession,
-      drawResponseMode: this.drawResponseMode
+      drawResponseMode: this.drawResponseMode,
+      drawStudentCard: this.drawStudentCard
     });
   },
   
@@ -102,12 +106,6 @@ export default React.createClass({
   
   onSliderChange(event, value){
     this.setState({ sessionLength: value });
-  },
-  
-  onStudentCardsToggled(){
-    var scaffolding = {...this.state.scaffolding};
-    scaffolding.shouldShowStudentCard = !scaffolding.shouldShowStudentCard;
-    this.setState({ scaffolding });
   },
   
   onSummaryToggled(){ 
@@ -134,12 +132,11 @@ export default React.createClass({
   render(){
     const {query} = this.props;
     const {selectedIndicatorId, sessionLength, scaffolding} = this.state;
-    const {shouldShowStudentCard, shouldShowSummary, helpType} = scaffolding;
+    const {shouldShowSummary, helpType} = scaffolding;
     const questionsLength = this.getQuestions(selectedIndicatorId).length;
 
     const showSlider = true;
     const showAll = _.has(query, 'all');
-    const showStudentCardsToggle = showAll || _.has(query, 'cards') || _.has(query, 'basic');
     const showSummaryToggle = showAll || _.has(query, 'summary');
     const showHelpToggle = showAll || _.has(query, 'feedback') || _.has(query, 'basic');
     const showOriginalHelp = showAll || _.has(query, 'originalHelp');
@@ -164,17 +161,10 @@ export default React.createClass({
         
         <Divider />
         
-        {(showStudentCardsToggle || showHelpToggle || showSummaryToggle || showOriginalHelp) &&
+        {(showHelpToggle || showSummaryToggle || showOriginalHelp) &&
           <div>
             <div style={styles.optionTitle}>Scaffolding:</div>
             <div style={_.merge({ padding: 20 }, styles.option)}>
-              {showStudentCardsToggle &&
-              <Toggle
-              label="With student cards"
-              labelPosition="right"
-              toggled={shouldShowStudentCard}
-              onToggle={this.onStudentCardsToggled} />
-              }
               {showSummaryToggle &&
               <Toggle
               label="Show summary after each question"
@@ -189,7 +179,7 @@ export default React.createClass({
               toggled={helpType==='feedback'}
               onToggle={this.onHelpToggled} />
               }
-              {(showStudentCardsToggle || showSummaryToggle || showHelpToggle) && showOriginalHelp &&
+              {(showSummaryToggle || showHelpToggle) && showOriginalHelp &&
               <div style={{margin: 10}}><Divider /></div>
               }
               {showOriginalHelp &&

--- a/ui/src/message_popup/scaffolding_card_test.jsx
+++ b/ui/src/message_popup/scaffolding_card_test.jsx
@@ -50,7 +50,7 @@ describe('<ScaffoldingCard />', () => {
     expect(wrapper.find('RadioButtonGroup[name="responseMode"]').length).to.equal(1);
 
     expect(wrapper.text()).to.contain('Scaffolding');
-    expect(wrapper.find(Toggle).length).to.equal(3);
+    expect(wrapper.find(Toggle).length).to.equal(2);
     expect(wrapper.find('RadioButtonGroup[name="helpOptions"]').length).to.equal(1);
   });
 });

--- a/ui/src/message_popup/student_card.jsx
+++ b/ui/src/message_popup/student_card.jsx
@@ -60,7 +60,6 @@ export default React.createClass({
 const styles = {
   cardStyles: {
     backgroundColor: '#F1C889',
-    marginTop: 5,
     padding: 10
   },
   name: {

--- a/ui/src/message_popup/test_fixtures.js
+++ b/ui/src/message_popup/test_fixtures.js
@@ -15,11 +15,9 @@ export const testQuestions = {
 };
 export const practiceScaffolding = {
   helpType: 'feedback',
-  shouldShowStudentCard: true,
   shouldShowSummary: true
 };
 export const solutionScaffolding = {
   helpType: 'solution',
-  shouldShowStudentCard: true,
   shouldShowSummary: false
 };

--- a/ui/src/prop_types.js
+++ b/ui/src/prop_types.js
@@ -43,3 +43,8 @@ export const Student = React.PropTypes.shape({
   familyBackground: React.PropTypes.string,
   ses: React.PropTypes.string
 });
+
+export const Scaffolding = React.PropTypes.shape({
+  helpType: React.PropTypes.string.isRequired,
+  shouldShowSummary: React.PropTypes.bool.isRequired
+});


### PR DESCRIPTION
This adds in support for showing SketchPad models of students, and refactors the `shouldShowStudentCard` param to be dynamic.  It updates the demo page to show this, and updates other related code as well.

![screen shot 2016-10-31 at 12 01 14 pm](https://cloud.githubusercontent.com/assets/1056957/19863047/1882d1ac-9f69-11e6-9ee1-fabf29b18316.png)

![screen shot 2016-10-31 at 12 01 29 pm](https://cloud.githubusercontent.com/assets/1056957/19863051/1c3ade66-9f69-11e6-9fd7-7f063dd15265.png)

![screen shot 2016-10-31 at 12 01 37 pm](https://cloud.githubusercontent.com/assets/1056957/19863056/1eb5c1d8-9f69-11e6-9ae5-8f3ed12dfcfb.png)

![screen shot 2016-10-31 at 12 02 13 pm](https://cloud.githubusercontent.com/assets/1056957/19863062/222e80ac-9f69-11e6-95a9-d004accf86de.png)


