### PR TITLE
Allow auth to not require email

### DIFF
--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -72,7 +72,7 @@ export default React.createClass({
   render(){
     return (
       <MuiThemeProvider muiTheme={this.props.muiTheme}>
-        <AuthContainer>
+        <AuthContainer isEmailRequired={false}>
           {this.renderCurrentRoute()}
         </AuthContainer>
       </MuiThemeProvider>

--- a/ui/src/auth_container.jsx
+++ b/ui/src/auth_container.jsx
@@ -20,7 +20,8 @@ export default React.createClass({
 
   propTypes: {
     children: React.PropTypes.element.isRequired,
-    localStorageKey: React.PropTypes.string
+    localStorageKey: React.PropTypes.string,
+    isEmailRequired: React.PropTypes.bool.isRequired
   },
 
   childContextTypes: {
@@ -38,8 +39,8 @@ export default React.createClass({
 
   getInitialState() {
     return {
-      userEmail: '',
-      hasConfirmedEmail: false,
+      userEmail: 'unknown@mit.edu',
+      hasConfirmedEmail: !this.props.isEmailRequired,
       isNavigatingAway: false
     };
   },


### PR DESCRIPTION
For gradual onboarding in demos or talks (versus playtests, where this is required up front).