### PR TITLE
Fall back to image instead of 3D model if slow network

### DIFF
--- a/ui/src/data/virtual_school.js
+++ b/ui/src/data/virtual_school.js
@@ -377,7 +377,8 @@ const demoStudents = [{
   sketchFab: {
     id: 'f6548660b118491fbf32d78d5dbc8403',
     eye: [-3, -20, -6],
-    target: [0.0, 0.01, 0.15]
+    target: [0.0, 0.01, 0.15],
+    fallbackUrl: 'http://tsl-hacking.s3-website-us-east-1.amazonaws.com/teacher-moments/danny.jpg'
   },
   sketchFabId: '',
   name: `Danny`,
@@ -396,7 +397,8 @@ const demoStudents = [{
   sketchFab: {
     id: '2106cb61b95c48dc8b506ffb3c1daa6e',
     eye: [-12, -20, -1],
-    target: [-0.09, -0.05, 0.10]
+    target: [-0.09, -0.05, 0.10],
+    fallbackUrl: 'http://tsl-hacking.s3-website-us-east-1.amazonaws.com/teacher-moments/sheena.jpg'
   },
   name: `Sheena`,
   grade: `7th grade`,

--- a/ui/src/message_popup/renderers/scenario_renderer_test.jsx
+++ b/ui/src/message_popup/renderers/scenario_renderer_test.jsx
@@ -12,7 +12,12 @@ import ScenarioRenderer from './scenario_renderer.jsx';
 import PlainTextQuestion from './plain_text_question.jsx';
 import VideoScenario from './video_scenario.jsx';
 import TextModelScenario from './text_model_scenario.jsx';
+import TextImageScenario from './text_image_scenario.jsx';
+import AudioCapture from '../../components/audio_capture.jsx';
 
+function testStudentWithModel() {
+  return _.find(allStudents, { id: 4001 });
+}
 
 describe('<ScenarioRenderer />', () => {
   it('renders plain text', () => {
@@ -42,18 +47,34 @@ describe('<ScenarioRenderer />', () => {
   });
 
   it('renders text model scenarios for students with data', () => {
-    const question = TestFixtures.testQuestion;
-    const student = _.find(allStudents, { id: 4001 });
+    sinon.stub(AudioCapture, 'isAudioSupported').returns(true);
     const wrapper = shallow(
       <ScenarioRenderer
         scaffolding={TestFixtures.solutionScaffolding}
         showStudentCard={false}
-        question={question}
-        student={student}
+        question={TestFixtures.testQuestion}
+        student={testStudentWithModel()}
         onScenarioDone={sinon.spy()}
       />
     );
-    expect(Object.keys(student.sketchFab)).to.have.members(['id', 'eye', 'target']);
+    AudioCapture.isAudioSupported.restore();
+
     expect(wrapper.find(TextModelScenario).length).to.equal(1);
+  });
+
+  it('falls back to text image scenarios when slow network', () => {
+    sinon.stub(AudioCapture, 'isAudioSupported').returns(false);
+    const wrapper = shallow(
+      <ScenarioRenderer
+        scaffolding={TestFixtures.solutionScaffolding}
+        showStudentCard={false}
+        question={TestFixtures.testQuestion}
+        student={testStudentWithModel()}
+        onScenarioDone={sinon.spy()}
+      />
+    );
+    AudioCapture.isAudioSupported.restore();
+
+    expect(wrapper.find(TextImageScenario).length).to.equal(1);
   });
 });

--- a/ui/src/message_popup/renderers/text_image_scenario.jsx
+++ b/ui/src/message_popup/renderers/text_image_scenario.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import * as PropTypes from '../../prop_types.js';
+import PlainTextQuestion from './plain_text_question.jsx';
+
+// Render a text scenario with an image.
+export default React.createClass({
+  displayName: 'TextImageScenario',
+
+  propTypes: {
+    question: React.PropTypes.object.isRequired,
+    student: PropTypes.Student.isRequired,
+    modelHeight: React.PropTypes.number.isRequired,
+    onScenarioDone: React.PropTypes.func.isRequired,
+  },
+
+  componentDidMount() {
+    this.props.onScenarioDone();
+  },
+  
+  render() {
+    const {question, modelHeight} = this.props;
+    const {sketchFab} = this.props.student;
+
+    return (
+      <div>
+        <PlainTextQuestion question={question} />
+        <div>
+          <img
+            src={sketchFab.fallbackUrl}
+            style={{height: modelHeight}}
+            width="100%"
+          />
+        </div>
+      </div>
+    );
+  }
+});

--- a/ui/src/message_popup/renderers/text_model_scenario.jsx
+++ b/ui/src/message_popup/renderers/text_model_scenario.jsx
@@ -3,9 +3,9 @@ import React from 'react';
 import * as PropTypes from '../../prop_types.js';
 import PlainTextQuestion from './plain_text_question.jsx';
 
-// Render a text scenario with a 3D model from SketchPad
+// Render a text scenario with a 3D model from Sketchfab
 // Requires data set on the student about the id for the 
-// SketchPad model, and about the camera orientation.
+// Sketchfab model, and about the camera orientation.
 export default React.createClass({
   displayName: 'TextModelScenario',
 


### PR DESCRIPTION
Fall back to a static image if Audio isn't supported (ie., it's mobile web) and network may be slow.  There are lots of other ways to improve this, but this is for the demo in a few hours where internet connectivity is limited and poor, trying to address:

<img width="372" alt="screen shot 2016-11-01 at 10 49 48 am" src="https://cloud.githubusercontent.com/assets/1056957/19893819/ed33d420-a020-11e6-93c6-9aac8e7e40de.png">
