### PR TITLE
Update demo page to remove full menu

### DIFF
--- a/ui/src/components/navigation_app_bar.jsx
+++ b/ui/src/components/navigation_app_bar.jsx
@@ -23,6 +23,7 @@ export default React.createClass({
   propTypes: {
     title: React.PropTypes.string.isRequired,
     style: React.PropTypes.object,
+    iconElementLeft: React.PropTypes.element,
     iconElementRight: React.PropTypes.element,
     prependMenuItems: React.PropTypes.element
   },
@@ -52,15 +53,15 @@ export default React.createClass({
 
   render() {
     const {userProfile, doLogout} = this.context.auth;
-    const {iconElementRight, prependMenuItems} = this.props;
+    const {iconElementLeft, iconElementRight, prependMenuItems} = this.props;
 
     return (
       <div>
         <AppBar
           title={this.props.title}
           style={this.props.style}
-          iconElementLeft={
-            <IconButton onTouchTap={this.onToggled} >
+          iconElementLeft={iconElementLeft || 
+            <IconButton onTouchTap={this.onToggled}>
               <MenuIcon />
             </IconButton>
           }

--- a/ui/src/message_popup/demo_page.jsx
+++ b/ui/src/message_popup/demo_page.jsx
@@ -9,18 +9,14 @@ import RaisedButton from 'material-ui/RaisedButton';
 import Divider from 'material-ui/Divider';
 import LinearProgress from 'material-ui/LinearProgress';
 import Snackbar from 'material-ui/Snackbar';
-import MenuItem from 'material-ui/MenuItem';
+import IconButton from 'material-ui/IconButton';
+import RefreshIcon from 'material-ui/svg-icons/navigation/refresh';
 
 import PopupQuestion from './popup_question.jsx';
 import type {ResponseT} from './popup_question.jsx';
-
-import RefreshIcon from 'material-ui/svg-icons/navigation/refresh';
-
 import {withStudents} from './transformations.jsx';
-
 import * as Api from '../helpers/api.js';
 import NavigationAppBar from '../components/navigation_app_bar.jsx';
-
 import MobileInterface from './mobile_prototype/mobile_interface.jsx';
 import {allQuestions} from './questions.js';
 import AudioCapture from '../components/audio_capture.jsx';
@@ -145,11 +141,10 @@ export default React.createClass({
         <div style={styles.mobile}>
           <NavigationAppBar
             title="Teacher Moments"
-            prependMenuItems={
-              <MenuItem
-                onTouchTap={this.resetExperience}
-                leftIcon={<RefreshIcon />}
-                primaryText="Restart game" />
+            iconElementLeft={
+              <IconButton onTouchTap={this.resetExperience} >
+                <RefreshIcon />
+              </IconButton>
             }
           />
           {this.renderMainScreen()}

--- a/ui/src/message_popup/demo_page_test.jsx
+++ b/ui/src/message_popup/demo_page_test.jsx
@@ -1,7 +1,7 @@
 /* @flow weak */
 import React from 'react';
 
-import {render, mount} from 'enzyme';
+import {mount} from 'enzyme';
 import {expect} from 'chai';
 import TestAuthContainer from '../test_auth_container.jsx';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
@@ -9,6 +9,7 @@ import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import DemoPage from './demo_page.jsx';
 import PopupQuestion from './popup_question.jsx';
 import PlainTextQuestion from './renderers/plain_text_question.jsx';
+import RefreshIcon from 'material-ui/svg-icons/navigation/refresh';
 
 // Wrap with application context for a full render
 // (eg., theming, authorization).
@@ -24,12 +25,13 @@ function withContext(child) {
 
 describe('<DemoPage />', () => {
   it('renders instructions', () => {    
-    const wrapper = render(withContext(<DemoPage />));
+    const wrapper = mount(withContext(<DemoPage />));
 
     expect(wrapper.find('.instructions').length).to.equal(1);
     expect(wrapper.find('.prototype').length).to.equal(0);
     expect(wrapper.find('.done').length).to.equal(0);
     expect(wrapper.find('.question').length).to.equal(0);
+    expect(wrapper.find(RefreshIcon).length).to.equal(1);
   });
 
   it('transitions to first question', () => {

--- a/ui/src/message_popup/experience_page_test.jsx
+++ b/ui/src/message_popup/experience_page_test.jsx
@@ -7,6 +7,7 @@ import TestAuthContainer from '../test_auth_container.jsx';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 
 import ExperiencePage from './experience_page.jsx';
+import MenuIcon from 'material-ui/svg-icons/navigation/menu';
 
 // Wrap with application context for a full render
 // (eg., theming, authorization).


### PR DESCRIPTION
The navigation isn't helpful for demos or playtests.

![screen shot 2016-11-01 at 10 55 39 am](https://cloud.githubusercontent.com/assets/1056957/19894146/5416f298-a022-11e6-88e0-c36dda0c3d76.png)
