### PR TITLE
Fix bug in ResponsiveFrame scrolling on desktop

### DIFF
--- a/ui/src/components/responsive_frame.jsx
+++ b/ui/src/components/responsive_frame.jsx
@@ -51,13 +51,13 @@ const styles = {
   desktopOuterFrame: {
     background: 'black',
     paddingTop: 20,
-    height: 2000,
     display: 'flex',
     justifyContent: 'center'
   },
   desktopInnerFrame: {
     width: 375,
     height: 667,
+    overflowY: 'scroll',
     background: 'white',
     border: '1px solid #999'
   }


### PR DESCRIPTION
This affected large pages on the desktop mode.

Before:
<img width="487" alt="screen shot 2016-12-06 at 1 17 36 pm" src="https://cloud.githubusercontent.com/assets/1056957/20937791/78b3d94a-bbb6-11e6-9437-ae7abb765750.png">

After:
<img width="465" alt="screen shot 2016-12-06 at 1 15 02 pm" src="https://cloud.githubusercontent.com/assets/1056957/20937800/816fd14c-bbb6-11e6-9d68-0846c2bbff1f.png">
