### PR TITLE
Add Lori Danson Simulation for Playtest

### DIFF
--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -53,6 +53,7 @@ export default React.createClass({
     
     '/teachermoments': 'messagePopup',
     '/playtest/:cohortKey': 'messagePopupPlaytest',
+    '/teachermoments/danson': 'dansonPlaytest',
     '/teachermoments/twine': 'messagePopupTwine',
     '/teachermoments/demo': 'messagePopupDemo',
     '/teachermoments/exploration': 'messagePopupExploration',
@@ -109,6 +110,10 @@ export default React.createClass({
 
   messagePopupDemo(query = {}) {
     return <MessagePopup.DemoPage key={JSON.stringify(query)} />;
+  },
+
+  dansonPlaytest(query = {}) {
+    return <MessagePopup.DansonExperiencePage query={{}}/>;
   },
 
   messagePopupPlaytest(cohortKey, query = {}) {

--- a/ui/src/components/responsive_frame.jsx
+++ b/ui/src/components/responsive_frame.jsx
@@ -59,6 +59,7 @@ const styles = {
     height: 667,
     overflowY: 'scroll',
     background: 'white',
-    border: '1px solid #999'
+    border: '1px solid #999',
+    overflow: 'auto'
   }
 };

--- a/ui/src/components/responsive_frame.jsx
+++ b/ui/src/components/responsive_frame.jsx
@@ -17,7 +17,7 @@ export default React.createClass({
 
   getDefaultProps() {
     return {
-      minWidth: 400,
+      minWidth: 450,
       minHeight: 400
     };
   },

--- a/ui/src/components/responsive_frame.jsx
+++ b/ui/src/components/responsive_frame.jsx
@@ -59,7 +59,6 @@ const styles = {
     height: 667,
     overflowY: 'scroll',
     background: 'white',
-    border: '1px solid #999',
-    overflow: 'auto'
+    border: '1px solid #999'
   }
 };

--- a/ui/src/data/indicators.js
+++ b/ui/src/data/indicators.js
@@ -7,4 +7,5 @@ export const indicators = [
   { id: 601, text: 'Actively responded to inappropriate student behaviors in the moment.' },
   { id: 701, text: 'Encouraged multiple perspectives and solutions to problems.' },
   { id: 801, text: 'Clarified student misconceptions about math content in the moment.' },
+  { id: 901, text: 'Engaged in difficult conversation with parent.' },
 ];

--- a/ui/src/message_popup/demo_page.jsx
+++ b/ui/src/message_popup/demo_page.jsx
@@ -76,6 +76,10 @@ export default React.createClass({
     return ['text', 'text', 'audio', 'audio'][questionsAnswered];
   },
 
+  drawResponsePrompt(question, scaffolding) {
+    return 'Speak directly to the student';
+  },
+
   drawStudentCard(question, scaffolding) {
     // Tied to the specific scenarios
     const {questionsAnswered} = this.state.gameSession;
@@ -118,6 +122,7 @@ export default React.createClass({
       gameSession: {
         email,
         drawResponseMode: this.drawResponseMode,
+        drawResponsePrompt: this.drawResponsePrompt,
         drawStudentCard: this.drawStudentCard,
         sessionId: uuid.v4(),
         questions: withStudents(demoQuestions),
@@ -192,7 +197,7 @@ export default React.createClass({
   
   renderPopupQuestion() {
     const {scaffolding, gameSession, limitMs} = this.state;
-    const {questions, questionsAnswered, drawResponseMode, drawStudentCard} = gameSession;
+    const {questions, questionsAnswered, drawResponseMode, drawResponsePrompt, drawStudentCard} = gameSession;
     const sessionLength = questions.length;
     const question = questions[questionsAnswered];
 
@@ -208,6 +213,7 @@ export default React.createClass({
             onLog={this.onLog}
             onDone={this.onQuestionDone}
             drawResponseMode={drawResponseMode}
+            drawResponsePrompt={drawResponsePrompt}
             drawStudentCard={drawStudentCard}
             isLastQuestion={(questionsAnswered + 1 === sessionLength)}/>
         </VelocityTransitionGroup>

--- a/ui/src/message_popup/experience_page.jsx
+++ b/ui/src/message_popup/experience_page.jsx
@@ -103,6 +103,7 @@ export default React.createClass({
       email,
       questionsForSession,
       drawResponseMode,
+      drawResponsePrompt,
       drawStudentCard
     } = scaffoldingSessionParams;
     this.setState({
@@ -110,6 +111,7 @@ export default React.createClass({
       gameSession: {
         email,
         drawResponseMode,
+        drawResponsePrompt,
         drawStudentCard,
         sessionId: uuid.v4(),
         questions: questionsForSession,
@@ -199,7 +201,7 @@ export default React.createClass({
   
   renderPopupQuestion() {
     const {scaffolding, gameSession, limitMs} = this.state;
-    const {questions, questionsAnswered, drawResponseMode, drawStudentCard} = gameSession;
+    const {questions, questionsAnswered, drawResponseMode, drawResponsePrompt, drawStudentCard} = gameSession;
     const sessionLength = questions.length;
     const question = questions[questionsAnswered];
 
@@ -215,6 +217,7 @@ export default React.createClass({
             onLog={this.onLog}
             onDone={this.onQuestionDone}
             drawResponseMode={drawResponseMode}
+            drawResponsePrompt={drawResponsePrompt}
             drawStudentCard={drawStudentCard}
             isLastQuestion={(questionsAnswered + 1 === sessionLength)}/>
         </VelocityTransitionGroup>

--- a/ui/src/message_popup/index.js
+++ b/ui/src/message_popup/index.js
@@ -5,6 +5,7 @@ import ExperiencePage from './experience_page.jsx';
 import DemoPage from './demo_page.jsx';
 import TwinePage from './twine/twine_page.jsx';
 import PlaytestExperiencePage from './playtest/playtest_experience_page.jsx';
+import DansonExperiencePage from './playtest/danson_experience_page.jsx';
 import ExplorationPage from './exploration_page.jsx';
 import ScoringPage from './scoring_page.jsx';
 import EvaluationViewerPage from './evaluation_viewer_page.jsx';
@@ -32,6 +33,7 @@ export {
   DemoPage,
   TwinePage,
   PlaytestExperiencePage,
+  DansonExperiencePage,
   ExplorationPage,
   ScoringPage,
   EvaluationViewerPage,

--- a/ui/src/message_popup/playtest/danson_experience_page.jsx
+++ b/ui/src/message_popup/playtest/danson_experience_page.jsx
@@ -21,7 +21,6 @@ import ResponsiveFrame from '../../components/responsive_frame.jsx';
 import {withStudents} from '../transformations.jsx';
 
 import * as Api from '../../helpers/api.js';
-import FinalSummaryCard from '../final_summary_card.jsx';
 import NavigationAppBar from '../../components/navigation_app_bar.jsx';
 
 import MobileInterface from '../mobile_prototype/mobile_interface.jsx';
@@ -194,7 +193,6 @@ export default React.createClass({
       obj.questionText = audioResponses[i].question.text.length < maxCharPerLine ? audioResponses[i].question.text : audioResponses[i].question.text.substring(0, maxCharPerLine) + ' ...';
       truncatedAudioResponses.push(obj);
     }
-    console.log(audioResponses);
     return (
       <div className="done">
         <VelocityTransitionGroup enter={{animation: "slideDown"}} leave={{animation: "slideUp"}} runOnMount={true}>

--- a/ui/src/message_popup/playtest/danson_experience_page.jsx
+++ b/ui/src/message_popup/playtest/danson_experience_page.jsx
@@ -51,7 +51,7 @@ export default React.createClass({
       gameSession: null,
       toastRevision: false,
       limitMs: 90000,
-      email: this.context.auth.userProfile.email
+      email: this.context.auth.userProfile.email === "unknown@mit.edu" ? '' : this.context.auth.userProfile.email
     };
   },
   

--- a/ui/src/message_popup/playtest/danson_experience_page.jsx
+++ b/ui/src/message_popup/playtest/danson_experience_page.jsx
@@ -47,6 +47,7 @@ export default React.createClass({
       scaffolding: {
         helpType: isSolutionMode ? 'none' : 'feedback',
         shouldShowSummary: !isSolutionMode,
+        hideTimer: true,
       },
       gameSession: null,
       toastRevision: false,
@@ -91,7 +92,6 @@ export default React.createClass({
       email: this.state.gameSession.email,
       sessionId: this.state.gameSession.sessionId,
       clientTimestampMs: new Date().getTime(),
-      cohortKey: this.props.cohortKey
     });
   },
 
@@ -108,11 +108,12 @@ export default React.createClass({
     this.setState({ gameSession });
   },
 
-  onSave(){
+  onStart(){
     const {email} = this.state;  
     const scaffolding = {
       helpType: 'feedback', // feedback, hints or none
       shouldShowSummary: false,
+      hideTimer: true
     };
 
     this.setState({
@@ -211,7 +212,7 @@ export default React.createClass({
           <div style={{display: 'flex', flexDirection: 'row', alignItems: 'flex-end'}}>
             <RaisedButton
               disabled={this.state.email === ''}
-              onTouchTap={this.onSave}
+              onTouchTap={this.onStart}
               style={styles.button}
               secondary={true}
               label="Start" />

--- a/ui/src/message_popup/playtest/danson_experience_page.jsx
+++ b/ui/src/message_popup/playtest/danson_experience_page.jsx
@@ -1,0 +1,304 @@
+/* @flow weak */
+import _ from 'lodash';
+import React from 'react';
+import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
+import 'velocity-animate/velocity.ui';
+import uuid from 'uuid';
+
+import RaisedButton from 'material-ui/RaisedButton';
+import Divider from 'material-ui/Divider';
+import LinearProgress from 'material-ui/LinearProgress';
+import Snackbar from 'material-ui/Snackbar';
+import MenuItem from 'material-ui/MenuItem';
+import TextField from 'material-ui/TextField';
+
+import PopupQuestion from '../popup_question.jsx';
+import type {ResponseT} from '../popup_question.jsx';
+
+import RefreshIcon from 'material-ui/svg-icons/navigation/refresh';
+import ResponsiveFrame from '../../components/responsive_frame.jsx';
+
+import {withStudents} from '../transformations.jsx';
+
+import * as Api from '../../helpers/api.js';
+import FinalSummaryCard from '../final_summary_card.jsx';
+import NavigationAppBar from '../../components/navigation_app_bar.jsx';
+
+import MobileInterface from '../mobile_prototype/mobile_interface.jsx';
+import {dansonQuestions} from '../questions.js';
+
+/*
+Shows the MessagePopup game
+*/
+export default React.createClass({
+  displayName: 'MessagePopupExperiencePage',
+
+  propTypes: {
+    query: React.PropTypes.object.isRequired,
+  },
+
+  contextTypes: {
+    auth: React.PropTypes.object.isRequired
+  },
+
+  getInitialState() {
+    const isSolutionMode = _.has(this.props.query, 'solution');
+    return {
+      scaffolding: {
+        helpType: isSolutionMode ? 'none' : 'feedback',
+        shouldShowSummary: !isSolutionMode,
+      },
+      gameSession: null,
+      toastRevision: false,
+      limitMs: 90000,
+      email: this.context.auth.userProfile.email
+    };
+  },
+  
+  playToast(){
+    if(this.state.scaffolding.helpType === 'feedback' && !this.state.scaffolding.shouldShowSummary){
+      this.setState({toastRevision: true});
+    }
+  },
+  
+  removeToast(){
+    this.setState({toastRevision: false});
+  },
+  
+  addResponseTime(elapsedMs){
+    var gameSession = {...this.state.gameSession};
+    gameSession.msResponseTimes.push(elapsedMs);
+    this.setState({ gameSession });
+  },
+
+  resetExperience(){
+    this.setState(this.getInitialState());
+  },
+
+  drawResponseMode(question, scaffolding) {
+    return 'audio';
+  },
+
+  // This implementation is static
+  drawStudentCard(question, scaffolding) {
+    return true;
+  },
+  
+  onLog(type, response:ResponseT) {
+    Api.logEvidence(type, {
+      ...response,
+      name: this.state.gameSession.email,
+      email: this.state.gameSession.email,
+      sessionId: this.state.gameSession.sessionId,
+      clientTimestampMs: new Date().getTime(),
+      cohortKey: this.props.cohortKey
+    });
+  },
+
+  onTextChanged(e) {
+    const email = e.target.value;
+    this.setState({email});
+  },
+  
+  onQuestionDone(elapsedMs) {
+    this.playToast();
+    this.addResponseTime(elapsedMs);
+    var gameSession = {...this.state.gameSession};
+    gameSession.questionsAnswered += 1;
+    this.setState({ gameSession });
+  },
+
+  onSave(){
+    const {email} = this.state;  
+    const scaffolding = {
+      helpType: 'feedback', // feedback, hints or none
+      shouldShowSummary: false,
+    };
+
+    this.setState({
+      scaffolding,
+      gameSession: {
+        email,
+        drawResponseMode: this.drawResponseMode,
+        drawStudentCard: this.drawStudentCard,
+        sessionId: uuid.v4(),
+        questions: withStudents(dansonQuestions),
+        questionsAnswered: 0,
+        msResponseTimes: []
+      },
+    });
+  },
+
+  render() {
+    return (
+      <ResponsiveFrame>
+        <div>
+          <NavigationAppBar
+            title="Teacher Moments"
+            prependMenuItems={
+              <MenuItem
+                onTouchTap={this.resetExperience}
+                leftIcon={<RefreshIcon />}
+                primaryText="Restart game" />
+            }
+          />
+          {this.renderMainScreen()}
+        </div>
+      </ResponsiveFrame>
+    );
+  },
+
+  renderMainScreen() {
+    // configure the game
+    const {gameSession} = this.state;
+    const hasStarted = gameSession !== null;
+    if (!hasStarted) return this.renderInstructions();
+
+    // all done!
+    const questionsAnswered = hasStarted ? gameSession.questionsAnswered : 0;
+    const questions = hasStarted ? gameSession.questions : [];
+    const sessionLength = hasStarted ? questions.length : 0;
+    if (questionsAnswered >= sessionLength) return this.renderDone();
+
+    // text-messaging prototype
+    if (_.has(this.props.query, 'mobilePrototype')) return this.renderMobilePrototype();
+
+    // question screen
+    return this.renderPopupQuestion();
+  },
+
+  renderDone() {
+    return (
+      <div className="done">
+        <VelocityTransitionGroup enter={{animation: "slideDown"}} leave={{animation: "slideUp"}} runOnMount={true}>
+          <div style={_.merge(_.clone(styles.container), styles.done)}>
+            <div style={styles.doneTitle}>
+              <p style={styles.paragraph}>You've finished the simulation. Please return to the form for the post-simulation teacher reflection.</p>
+              <p style={styles.paragraph}>Please <strong>do not close this page</strong>. You will need it for the reflection.</p>
+            </div>
+            <Divider />
+            <FinalSummaryCard 
+              msResponseTimes={this.state.gameSession.msResponseTimes} 
+              limitMs={this.state.limitMs} />
+          </div>
+        </VelocityTransitionGroup>
+      </div>
+    );
+  },
+
+  renderInstructions() {
+    return (
+      <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
+        <div className="instructions">
+          <div style ={_.merge(_.clone(styles.container), styles.instructions)}>
+            <p style={styles.paragraph}>Welcome!</p>
+            <p style={styles.paragraph}>You will go through a set of scenarios that simulate the conversation between you and Mrs. Danson.</p>
+            <p style={styles.paragraph}>You need to provide an audio response to each prompt. Please respond as quickly as possible (like you would do in a real conversation).</p>
+            <p style={styles.paragraph}>This may feel uncomfortable at first, but it's better to feel uncomfortable here than with a real parent.</p>
+            <Divider />
+          </div>
+        </div>
+        <div style={{padding: 20}}>
+          <TextField
+          name="email"
+          style={{width: '100%'}}
+          underlineShow={false}
+          floatingLabelText="What's your email address?"
+          value={this.state.email}
+          onChange={this.onTextChanged}
+          multiLine={true}
+          rows={2}/>
+          <div style={{display: 'flex', flexDirection: 'row', alignItems: 'flex-end'}}>
+            <RaisedButton
+              disabled={this.state.email === ''}
+              onTouchTap={this.onSave}
+              style={styles.button}
+              secondary={true}
+              label="Start" />
+          </div>    
+        </div>
+        
+      </VelocityTransitionGroup>
+
+      );
+  },
+  
+  renderPopupQuestion() {
+    const {scaffolding, gameSession, limitMs} = this.state;
+    const {questions, questionsAnswered, drawResponseMode, drawStudentCard} = gameSession;
+    const sessionLength = questions.length;
+    const question = questions[questionsAnswered];
+
+    return (
+      <div className="question" style={styles.container}>        
+        <LinearProgress color="#EC407A" mode="determinate" value={questionsAnswered} max={sessionLength} />
+        <VelocityTransitionGroup enter={{animation: "slideDown"}} leave={{animation: "slideUp"}} runOnMount={true}>
+          <PopupQuestion
+            key={JSON.stringify(question)}
+            question={question}
+            scaffolding={scaffolding}
+            limitMs={limitMs}
+            onLog={this.onLog}
+            onDone={this.onQuestionDone}
+            drawResponseMode={drawResponseMode}
+            drawStudentCard={drawStudentCard}
+            isLastQuestion={(questionsAnswered + 1 === sessionLength)}/>
+        </VelocityTransitionGroup>
+        <Snackbar
+          open={this.state.toastRevision}
+          message="Response recorded for feedback"
+          autoHideDuration={2000}
+          onRequestClose={this.removeToast}
+        />
+      </div>
+    );
+  },
+  
+  renderMobilePrototype() {
+    const {scaffolding, gameSession, limitMs} = this.state;
+    const {questions, questionsAnswered} = gameSession;
+    const sessionLength = questions.length;
+    const question = withStudents(questions)[questionsAnswered];
+    return ( 
+      <div className="prototype">
+        <LinearProgress color="#EC407A" mode="determinate" value={questionsAnswered} max={sessionLength} />
+        <MobileInterface
+          key={JSON.stringify(question)}
+          scaffolding={scaffolding}
+          question={question}
+          onQuestionDone={this.onQuestionDone}
+          limitMs={limitMs}
+          onLog={this.onLog}
+          isLastQuestion={questionsAnswered+1===sessionLength ? true : false}
+          />
+      </div>
+    );
+  }
+});
+
+const styles = {
+  done: {
+    padding: 20,
+  },
+  container: {
+    fontSize: 20,
+    padding: 0,
+    margin:0,
+    paddingBottom: 45
+  },
+  button: {
+    marginTop: 20
+  },
+  doneTitle: {
+    marginBottom: 10
+  },
+  instructions: {
+    paddingLeft: 20,
+    paddingRight: 20,
+  },
+  paragraph: {
+    marginTop: 20,
+    marginBottom: 20
+  }
+
+};

--- a/ui/src/message_popup/playtest/danson_experience_page.jsx
+++ b/ui/src/message_popup/playtest/danson_experience_page.jsx
@@ -80,6 +80,10 @@ export default React.createClass({
     return 'audio';
   },
 
+  drawResponsePrompt(question, scaffolding) {
+    return 'Respond to Mrs. Danson';
+  },
+
   // This implementation is static
   drawStudentCard(question, scaffolding) {
     return true;
@@ -122,6 +126,7 @@ export default React.createClass({
         email,
         drawResponseMode: this.drawResponseMode,
         drawStudentCard: this.drawStudentCard,
+        drawResponsePrompt: this.drawResponsePrompt,
         sessionId: uuid.v4(),
         questions: withStudents(dansonQuestions),
         questionsAnswered: 0,
@@ -226,7 +231,7 @@ export default React.createClass({
   
   renderPopupQuestion() {
     const {scaffolding, gameSession, limitMs} = this.state;
-    const {questions, questionsAnswered, drawResponseMode, drawStudentCard} = gameSession;
+    const {questions, questionsAnswered, drawResponseMode, drawStudentCard, drawResponsePrompt} = gameSession;
     const sessionLength = questions.length;
     const question = questions[questionsAnswered];
 
@@ -243,6 +248,7 @@ export default React.createClass({
             onDone={this.onQuestionDone}
             drawResponseMode={drawResponseMode}
             drawStudentCard={drawStudentCard}
+            drawResponsePrompt={drawResponsePrompt}
             isLastQuestion={(questionsAnswered + 1 === sessionLength)}/>
         </VelocityTransitionGroup>
         <Snackbar

--- a/ui/src/message_popup/popup_question.jsx
+++ b/ui/src/message_popup/popup_question.jsx
@@ -60,6 +60,7 @@ export default React.createClass({
     isLastQuestion: React.PropTypes.bool.isRequired,
     drawResponseMode: React.PropTypes.func.isRequired,
     drawStudentCard: React.PropTypes.func.isRequired,
+    drawResponsePrompt: React.PropTypes.func.isRequired,
     shouldScrollOnMount: React.PropTypes.bool,
     shouldScrollToResponse: React.PropTypes.bool
   },
@@ -74,10 +75,12 @@ export default React.createClass({
   getInitialState: function() {
     const {question, scaffolding} = this.props;
     const responseMode = this.props.drawResponseMode(question, scaffolding);
+    const responsePrompt = this.props.drawResponsePrompt(question, scaffolding);
     const willShowStudentCard = this.props.drawStudentCard(question, scaffolding);
 
     return {
       responseMode,
+      responsePrompt,
       willShowStudentCard,
       elapsedMs: 0,
       allowResponding: false,
@@ -186,11 +189,12 @@ export default React.createClass({
   // Each response is responsible for logging interaction data
   // to the server.
   renderResponse() {
-    const {responseMode, elapsedMs} = this.state;
+    const {responseMode, elapsedMs, responsePrompt} = this.state;
     const {scaffolding, limitMs, question} = this.props;
     const responseProps = {
       scaffolding,
       question,
+      responsePrompt,
       limitMs,
       elapsedMs,
       onResponseSubmitted: this.onResponseSubmitted,

--- a/ui/src/message_popup/popup_question_test.jsx
+++ b/ui/src/message_popup/popup_question_test.jsx
@@ -22,6 +22,7 @@ function testProps(props) {
     onDone: sinon.spy(),
     isLastQuestion: false,
     drawResponseMode: () => 'text',
+    drawResponsePrompt: () => 'Speak directly to the student',
     drawStudentCard: () => true,
     ...props
   };

--- a/ui/src/message_popup/questions.js
+++ b/ui/src/message_popup/questions.js
@@ -799,7 +799,7 @@ export const dansonQuestions:[QuestionT] = [
     examples: [],
     nonExamples: []
   },
-].map(forIndicator(601));
+].map(forIndicator(901));
 
 const mathMisconceptionsQuestions = [
   {

--- a/ui/src/message_popup/questions.js
+++ b/ui/src/message_popup/questions.js
@@ -735,6 +735,72 @@ export const playtestQuestions:[QuestionT] = [
   },
 ].map(forIndicator(601));
 
+export const dansonQuestions:[QuestionT] = [
+  {
+    studentIds: [],
+    id: 351,
+    text: 'After the initial introductions, Mrs. Danson starts speaking:\n\n\"I requested today\'s conference in order to get to know you better, to frankly and clearly discuss Brian and his needs, and to establish an early pattern of communication between you and me.\
+    \n\nBrian was diagnosed with mild autism when he was 3 years old. As Brian entered and progressed through elementary school, I learned through experience that teachers often struggled with including Brian in regular education classrooms and providing him with formative and supportive learning environments.\
+    \n\nBrian has had various struggles with teachers and peers. For example, he\'s been removed from a school party because of organizational difficulties such as forgetting to hand work in. Also, students have harassed him verbally and physically, for example, by spitting at him, even while teachers were nearby.\
+    \n\nIn spite of these challenges, he has been able to achieve various successes at school. For example, he has helped many teachers troubleshoot computer problems, he performed well in a solo singing part in a school play, and he gets high scores in math standardized tests.\
+    \n\nI\'m here just to try and advocate for my son and get him through the educational system.\
+    \n\nI\'d like to talk to you about some of the typical behaviors Brian exhibits and discuss how you will work with Brian if/when he exhibits these behaviors in class.\
+    \n\nCould you please tell me what you know about autism.\"',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 352,
+    text: 'If Brian walks up to a girl, gives her an unwanted hug, and begins talking to her continuously and loudly about his computer games, how will you address this?',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 353,
+    text: 'How can we establish regular communication patterns between you and me?',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 354,
+    text: 'I\'m no dummy. Are you sure this is how you\'re going to communicate with me when you also serve many other kids and their families?',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 355,
+    text: 'I\'m concerned with Brian\'s academic performance, but I\'m also concerned about his social behaviors. Frankly, you have to be my eyes for me, watching over Brian while he\'s at school. I have to trust that you\'ll watch over him as his teacher. So … tell me how you\'re observant to the social behaviors of students?',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 356,
+    text: 'How can we include Brian in sports or other extracurricular activities that require him to work with other students?',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 357,
+    text: 'I\'m sure you think I\'m a pain in the neck kind of parent, but I\'m just trying to protect my son.',
+    examples: [],
+    nonExamples: []
+  },
+  {
+    studentIds: [],
+    id: 358,
+    text: 'I recognize that you\'re a young teacher. I don\'t want teachers to be afraid of students with special needs and I don\'t want you to be afraid of me. But, I\'m here because in the past some teachers have struggled with serving and including my son.\
+    \n\nDespite Brian\'s difficult history, he is always upbeat and many people gain personal satisfaction from helping him',
+    examples: [],
+    nonExamples: []
+  },
+].map(forIndicator(601));
+
 const mathMisconceptionsQuestions = [
   {
     id: 2001,

--- a/ui/src/message_popup/renderers/audio_response.jsx
+++ b/ui/src/message_popup/renderers/audio_response.jsx
@@ -22,7 +22,8 @@ export default React.createClass({
     limitMs: React.PropTypes.number.isRequired,
     elapsedMs: React.PropTypes.number.isRequired,
     onLogMessage: React.PropTypes.func.isRequired,
-    onResponseSubmitted: React.PropTypes.func.isRequired
+    onResponseSubmitted: React.PropTypes.func.isRequired,
+    responsePrompt: React.PropTypes.node.isRequired
   },
 
   onDone(audioUrl) {
@@ -57,7 +58,7 @@ export default React.createClass({
   renderStart({onRecord}) {
     return (
       <div>
-        <div style={styles.instruction}>Speak directly to the student.</div>
+        <div style={styles.instruction}>{this.props.responsePrompt}</div>
         <RaisedButton key="record" onTouchTap={onRecord} label="Record" secondary={true} />
         {this.renderTimer()}
       </div>

--- a/ui/src/message_popup/renderers/audio_response.jsx
+++ b/ui/src/message_popup/renderers/audio_response.jsx
@@ -45,47 +45,52 @@ export default React.createClass({
     );
   },
 
-  renderStart({onRecord}) {
+  renderTimer() {
+    if(this.props.scaffolding.hideTimer) return;
+
     const seconds = Math.round(this.props.elapsedMs / 1000);
+    return (
+      seconds > 0 && <div style= {styles.ticker}>{seconds}s</div>
+    );
+  },
+
+  renderStart({onRecord}) {
     return (
       <div>
         <div style={styles.instruction}>Speak directly to the student.</div>
         <RaisedButton key="record" onTouchTap={onRecord} label="Record" secondary={true} />
-        {seconds > 0 && <div style= {styles.ticker}>{seconds}s</div>}
+        {this.renderTimer()}
       </div>
     );
   },
 
   renderRecording({onDone}) {
-    const seconds = Math.round(this.props.elapsedMs / 1000);
     return (
       <div>
         <div style={{...styles.instruction, color: Colors.accent1Color}}>Recording...</div>
         <RaisedButton key="done" onTouchTap={onDone} label="Done" primary={true} />
-        {seconds > 0 && <div style= {styles.ticker}>{seconds}s</div>}
+        {this.renderTimer()}
       </div>
     );
   },
 
   renderReviewing({blob, downloadUrl, onSubmit, onRetry}) {
-    const seconds = Math.round(this.props.elapsedMs / 1000);
     return (
       <div>
         <div style={styles.instruction}>Review your answer!</div>
         <audio controls={true} src={downloadUrl} />
         <RaisedButton onTouchTap={onRetry} label="Record again" />
         <RaisedButton onTouchTap={onSubmit} label="Submit" primary={true} />
-        {seconds > 0 && <div style= {styles.ticker}>{seconds}s</div>}
+        {this.renderTimer()}
       </div>
     );
   },
 
   renderDone({uploadedUrl}) {
-    const seconds = Math.round(this.props.elapsedMs / 1000);
     return (
       <div>
         <RaisedButton label="Done" onTouchTap={this.onDone.bind(this, uploadedUrl)} primary={true} />
-        {seconds > 0 && <div style= {styles.ticker}>{seconds}s</div>}
+        {this.renderTimer()}
       </div>
     );
   }

--- a/ui/src/message_popup/renderers/audio_response_test.jsx
+++ b/ui/src/message_popup/renderers/audio_response_test.jsx
@@ -17,6 +17,7 @@ function testProps(props) {
     elapsedMs: 0,
     onLogMessage: sinon.spy(),
     onResponseSubmitted: sinon.spy(),
+    responsePrompt: 'Speak directly to the student',
     ...props
   };
 }

--- a/ui/src/message_popup/scaffolding_card.jsx
+++ b/ui/src/message_popup/scaffolding_card.jsx
@@ -72,6 +72,10 @@ export default React.createClass({
     return 'text';
   },
 
+  drawResponsePrompt(question, scaffolding) {
+    return 'Speak directly to the student';
+  },
+
   // This implementation is static
   drawStudentCard(question, scaffolding) {
     return true;
@@ -90,6 +94,7 @@ export default React.createClass({
       email,
       questionsForSession,
       drawResponseMode: this.drawResponseMode,
+      drawResponsePrompt: this.drawResponsePrompt,
       drawStudentCard: this.drawStudentCard
     });
   },


### PR DESCRIPTION
* Add endpoint and Experience Page for Lori Danson simulation (/teachermoments/danson)
* Add new indicator for difficult conversation between teacher & parent.
* Add questions for Lori Danson simulation.
* Add summary page that shows all responses at the end of all the scenarios.

* Add logic for hiding timer in audio response.
* Refactor code to ensure the response prompt can be customized in the experience page.
* Fix demo_page and unit tests that were previously failing after adding logic to customize the response prompt.

Bug fix: Adjust min width of responsive_frame to 450 to ensure it does not show a black background around screen.

## Screenshots
#### Welcome page
![screenshot 2016-12-06 15 49 09](https://cloud.githubusercontent.com/assets/9402134/20942979/bf29800e-bbcb-11e6-950b-5af70ef9f4b4.png)

#### One of the scenarios
![screenshot 2016-12-06 15 49 29](https://cloud.githubusercontent.com/assets/9402134/20942982/c3592b20-bbcb-11e6-9d1f-c0fea3581a89.png)

#### Summary page after responding to all scenarios
![screenshot 2016-12-06 15 50 10](https://cloud.githubusercontent.com/assets/9402134/20942987/c9176b62-bbcb-11e6-8013-2fb77d3c9e85.png)
