### PR TITLE
Use blobURL (instead of downloadURL) to show the audio in the summary page

### DIFF
--- a/ui/src/components/audio_recorder_flow.jsx
+++ b/ui/src/components/audio_recorder_flow.jsx
@@ -93,8 +93,8 @@ export default React.createClass({
   },
 
   onDoneCapture(blob:Blob) {
-    this.props.onLogMessage('message_popup_audio_on_done_capture');
     var downloadUrl = URL.createObjectURL(blob);
+    this.props.onLogMessage('message_popup_audio_on_done_capture', {'blobUrl': downloadUrl});
     this.setState({blob, downloadUrl});
   },
 

--- a/ui/src/message_popup/playtest/danson_experience_page.jsx
+++ b/ui/src/message_popup/playtest/danson_experience_page.jsx
@@ -89,7 +89,7 @@ export default React.createClass({
   },
   
   onLog(type, response:ResponseT) {
-    if (type === 'message_popup_audio_response') {
+    if (type === 'message_popup_audio_on_done_capture') {
       var {gameSession} = this.state;
       this.setState({
         gameSession: {
@@ -186,12 +186,19 @@ export default React.createClass({
   renderDone() {
     const audioResponses = this.state.gameSession.audioResponses;
     const truncatedAudioResponses = [];
+    const reviewedQuestions = {};  // Keeps track of reviewedQuestions to ensure we only show the last response if the user does multiple retries.
     const maxCharPerLine = 120;
     for(var i = 0; i < audioResponses.length; i++) {
       var obj = {};
-      obj.audioUrl = audioResponses[i].audioUrl.uploadedUrl;
+      obj.audioUrl = audioResponses[i].blobUrl;
       obj.questionText = audioResponses[i].question.text.length < maxCharPerLine ? audioResponses[i].question.text : audioResponses[i].question.text.substring(0, maxCharPerLine) + ' ...';
-      truncatedAudioResponses.push(obj);
+      var questionId = audioResponses[i].question.id;
+      if(questionId in reviewedQuestions) {
+        truncatedAudioResponses[reviewedQuestions[questionId]] = obj;
+      } else {
+        reviewedQuestions[questionId] = i;
+        truncatedAudioResponses.push(obj);
+      }
     }
     return (
       <div className="done">


### PR DESCRIPTION
This ensures the user does not have to log in, the playback UI works smoother (i.e. the progress bar moves in sync with the audio), and there is no download icon in the summary page.

## New summary page
<img width="845" alt="screenshot 2016-12-07 13 50 56" src="https://cloud.githubusercontent.com/assets/9402134/20981853/34d1dcb2-bc84-11e6-9af6-095ba7b717c1.png">


## Old summary page
#### Before authenticating
<img width="1260" alt="screenshot 2016-12-07 12 25 10" src="https://cloud.githubusercontent.com/assets/9402134/20981837/22fbe6cc-bc84-11e6-9f24-93a76a7b0e91.png">

#### After authenticating
![screenshot 2016-12-06 15 50 10](https://cloud.githubusercontent.com/assets/9402134/20981894/52fecb46-bc84-11e6-8e22-6d51dc408c28.png)
