### PR TITLE
Workaround regression in responsive layout on desktop

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -8,6 +8,7 @@
     body {
       margin: 0;
       font-family: 'Roboto', sans-serif;
+      background: black;
     }
   </style>
   <link href='https://fonts.googleapis.com/css?family=Roboto:400,300,500' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
Before:
<img width="491" alt="screen shot 2016-12-20 at 3 22 30 pm" src="https://cloud.githubusercontent.com/assets/1056957/21366563/3f79878e-c6c8-11e6-8c69-8d96a73818b2.png">


After:
<img width="461" alt="screen shot 2016-12-20 at 3 22 24 pm" src="https://cloud.githubusercontent.com/assets/1056957/21366558/3a58b77a-c6c8-11e6-8fc4-ac410774afa5.png">
