### PR TITLE
Make the scenario prompts expandable and collapsable in the summary page

### DIFF
--- a/ui/src/message_popup/playtest/danson_experience_page.jsx
+++ b/ui/src/message_popup/playtest/danson_experience_page.jsx
@@ -25,6 +25,7 @@ import NavigationAppBar from '../../components/navigation_app_bar.jsx';
 
 import MobileInterface from '../mobile_prototype/mobile_interface.jsx';
 import {dansonQuestions} from '../questions.js';
+import AudioResponseSummary from '../renderers/audio_response_summary.jsx';
 
 /*
 Shows the MessagePopup game
@@ -184,42 +185,8 @@ export default React.createClass({
   },
 
   renderDone() {
-    const audioResponses = this.state.gameSession.audioResponses;
-    const truncatedAudioResponses = [];
-    const reviewedQuestions = {};  // Keeps track of reviewedQuestions to ensure we only show the last response if the user does multiple retries.
-    const maxCharPerLine = 120;
-    for(var i = 0; i < audioResponses.length; i++) {
-      var obj = {};
-      obj.audioUrl = audioResponses[i].blobUrl;
-      obj.questionText = audioResponses[i].question.text.length < maxCharPerLine ? audioResponses[i].question.text : audioResponses[i].question.text.substring(0, maxCharPerLine) + ' ...';
-      var questionId = audioResponses[i].question.id;
-      if(questionId in reviewedQuestions) {
-        truncatedAudioResponses[reviewedQuestions[questionId]] = obj;
-      } else {
-        reviewedQuestions[questionId] = i;
-        truncatedAudioResponses.push(obj);
-      }
-    }
     return (
-      <div className="done">
-        <VelocityTransitionGroup enter={{animation: "slideDown"}} leave={{animation: "slideUp"}} runOnMount={true}>
-          <div style={styles.doneTitle}>
-            <p style={styles.paragraph}>You've finished the simulation.</p>
-            <p style={styles.paragraph}><strong>Do not close this page</strong>. You will need it for the reflection.</p>
-            <p style={styles.paragraph}>Please return to the form for the post-simulation reflection.</p>
-          </div>
-          <p style={styles.summaryTitle}>Summary</p>
-          <Divider />
-          {truncatedAudioResponses.map((obj, i) =>
-            <div key={i} style ={_.merge(styles.instructions)}>
-              <p style={styles.paragraph}>{obj.questionText}</p>
-              <audio controls={true} src={obj.audioUrl} />
-              <Divider />
-            </div>
-          )}
-          <div style={styles.container} />
-        </VelocityTransitionGroup>
-      </div>
+      <AudioResponseSummary gameSession={this.state.gameSession} />
     );
   },
 

--- a/ui/src/message_popup/playtest/danson_experience_page.jsx
+++ b/ui/src/message_popup/playtest/danson_experience_page.jsx
@@ -186,7 +186,7 @@ export default React.createClass({
 
   renderDone() {
     return (
-      <AudioResponseSummary gameSession={this.state.gameSession} />
+      <AudioResponseSummary audioResponses={this.state.gameSession.audioResponses} />
     );
   },
 

--- a/ui/src/message_popup/renderers/audio_response_summary.jsx
+++ b/ui/src/message_popup/renderers/audio_response_summary.jsx
@@ -17,17 +17,19 @@ export default React.createClass({
   },
 
   render() {
+
     const audioResponses = [];
-    const reviewedQuestions = {};  // Keeps track of reviewedQuestions to ensure we only show the last response if the user does multiple retries.
-    this.props.audioResponses.map((arObj, i) => {
+    var lastQuestionId = null;  // For detecting questions with more than one response
+    this.props.audioResponses.map((arObj) => {
       var obj = {};
-      obj.audioUrl = arObj.blobUrl;
-      obj.questionText = arObj.question.text;
       var questionId = arObj.question.id;
-      if(questionId in reviewedQuestions) {
-        audioResponses[reviewedQuestions[questionId]] = obj;
+      if(questionId === lastQuestionId) {
+        var lastObj = audioResponses[audioResponses.length - 1];
+        lastObj.audioUrls.push(arObj.blobUrl);
       } else {
-        reviewedQuestions[questionId] = audioResponses.length;
+        lastQuestionId = questionId;
+        obj.audioUrls = [arObj.blobUrl];
+        obj.questionText = arObj.question.text;
         audioResponses.push(obj);
       }
     });
@@ -45,7 +47,9 @@ export default React.createClass({
           {audioResponses.map((obj, i) =>
             <div key={i} style ={_.merge(styles.instructions)}>
               <ReadMore fulltext={obj.questionText} />
-              <audio controls={true} src={obj.audioUrl} />
+              {obj.audioUrls.map((audioUrl, i) => 
+                <audio key={'audio-url-' + i} controls={true} src={audioUrl} />
+              )}
               <Divider />
             </div>
           )}

--- a/ui/src/message_popup/renderers/audio_response_summary.jsx
+++ b/ui/src/message_popup/renderers/audio_response_summary.jsx
@@ -20,17 +20,17 @@ export default React.createClass({
 
     const audioResponses = [];
     var lastQuestionId = null;  // For detecting questions with more than one response
-    this.props.audioResponses.map((arObj) => {
-      var obj = {};
-      var questionId = arObj.question.id;
+    this.props.audioResponses.map((originalAudioResponse) => {
+      var audioResponse = {};
+      var questionId = originalAudioResponse.question.id;
       if(questionId === lastQuestionId) {
         var lastObj = audioResponses[audioResponses.length - 1];
-        lastObj.audioUrls.push(arObj.blobUrl);
+        lastObj.audioUrls.push(originalAudioResponse.blobUrl);
       } else {
         lastQuestionId = questionId;
-        obj.audioUrls = [arObj.blobUrl];
-        obj.questionText = arObj.question.text;
-        audioResponses.push(obj);
+        audioResponse.audioUrls = [originalAudioResponse.blobUrl];
+        audioResponse.questionText = originalAudioResponse.question.text;
+        audioResponses.push(audioResponse);
       }
     });
 
@@ -44,11 +44,11 @@ export default React.createClass({
           </div>
           <p style={styles.summaryTitle}>Summary</p>
           <Divider />
-          {audioResponses.map((obj, i) =>
-            <div key={i} style ={_.merge(styles.instructions)}>
-              <ReadMore fulltext={obj.questionText} />
-              {obj.audioUrls.map((audioUrl, i) => 
-                <audio key={'audio-url-' + i} controls={true} src={audioUrl} />
+          {audioResponses.map((audioResponse) =>
+            <div key={audioResponse.questionId} style ={_.merge(styles.instructions)}>
+              <ReadMore fulltext={audioResponse.questionText} />
+              {audioResponse.audioUrls.map((audioUrl, i) => 
+                <audio key={audioResponse.questionId + '-response-' + i} controls={true} src={audioUrl} />
               )}
               <Divider />
             </div>

--- a/ui/src/message_popup/renderers/audio_response_summary.jsx
+++ b/ui/src/message_popup/renderers/audio_response_summary.jsx
@@ -13,13 +13,13 @@ export default React.createClass({
   displayName: 'AudioResponseSummary',
 
   propTypes: {
-    gameSession: React.PropTypes.object.isRequired,
+    audioResponses: React.PropTypes.array.isRequired,
   },
 
   render() {
     const audioResponses = [];
     const reviewedQuestions = {};  // Keeps track of reviewedQuestions to ensure we only show the last response if the user does multiple retries.
-    this.props.gameSession.audioResponses.map((arObj, i) => {
+    this.props.audioResponses.map((arObj, i) => {
       var obj = {};
       obj.audioUrl = arObj.blobUrl;
       obj.questionText = arObj.question.text;

--- a/ui/src/message_popup/renderers/audio_response_summary.jsx
+++ b/ui/src/message_popup/renderers/audio_response_summary.jsx
@@ -45,7 +45,7 @@ export default React.createClass({
           <p style={styles.summaryTitle}>Summary</p>
           <Divider />
           {audioResponses.map((audioResponse) =>
-            <div key={audioResponse.questionId} style ={_.merge(styles.instructions)}>
+            <div key={audioResponse.questionId} style ={_.merge(styles.instructions, styles.summaryQuestion)}>
               <ReadMore fulltext={audioResponse.questionText} />
               {audioResponse.audioUrls.map((audioUrl, i) => 
                 <audio key={audioResponse.questionId + '-response-' + i} controls={true} src={audioUrl} />
@@ -93,6 +93,12 @@ const styles = {
     paddingBottom: 5,
     margin: 0,
     fontWeight: 'bold'
+  },
+  summaryQuestion: {
+    whiteSpace: 'pre-wrap',
+    fontSize: 16,
+    lineHeight: 1.2,
+    paddingTop: 20,
+    paddingBottom: 10
   }
-
 };

--- a/ui/src/message_popup/renderers/audio_response_summary.jsx
+++ b/ui/src/message_popup/renderers/audio_response_summary.jsx
@@ -1,0 +1,94 @@
+/* @flow weak */
+import _ from 'lodash';
+import React from 'react';
+import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
+import Divider from 'material-ui/Divider';
+
+import ReadMore from './read_more.jsx';
+
+/*
+Component that displays the summary of audio responses.
+*/
+export default React.createClass({
+  displayName: 'AudioResponseSummary',
+
+  propTypes: {
+    gameSession: React.PropTypes.object.isRequired,
+  },
+
+  render() {
+    const audioResponses = [];
+    const reviewedQuestions = {};  // Keeps track of reviewedQuestions to ensure we only show the last response if the user does multiple retries.
+    this.props.gameSession.audioResponses.map((arObj, i) => {
+      var obj = {};
+      obj.audioUrl = arObj.blobUrl;
+      obj.questionText = arObj.question.text;
+      var questionId = arObj.question.id;
+      if(questionId in reviewedQuestions) {
+        audioResponses[reviewedQuestions[questionId]] = obj;
+      } else {
+        reviewedQuestions[questionId] = audioResponses.length;
+        audioResponses.push(obj);
+      }
+    });
+
+    return (
+      <div className="done">
+        <VelocityTransitionGroup enter={{animation: "slideDown"}} leave={{animation: "slideUp"}} runOnMount={true}>
+          <div style={styles.doneTitle}>
+            <p style={styles.paragraph}>You've finished the simulation.</p>
+            <p style={styles.paragraph}><strong>Do not close this page</strong>. You will need it for the reflection.</p>
+            <p style={styles.paragraph}>Please return to the form for the post-simulation reflection.</p>
+          </div>
+          <p style={styles.summaryTitle}>Summary</p>
+          <Divider />
+          {audioResponses.map((obj, i) =>
+            <div key={i} style ={_.merge(styles.instructions)}>
+              <ReadMore fulltext={obj.questionText} />
+              <audio controls={true} src={obj.audioUrl} />
+              <Divider />
+            </div>
+          )}
+          <div style={styles.container} />
+        </VelocityTransitionGroup>
+      </div> 
+    );
+  },
+  
+});
+
+const styles = {
+  done: {
+    padding: 20,
+  },
+  container: {
+    fontSize: 20,
+    padding: 0,
+    margin:0,
+    paddingBottom: 45
+  },
+  button: {
+    marginTop: 20
+  },
+  doneTitle: {
+    padding: 20,
+    paddingBottom: 0,
+    margin:0,
+  },
+  instructions: {
+    paddingLeft: 20,
+    paddingRight: 20,
+  },
+  paragraph: {
+    marginTop: 20,
+    marginBottom: 20
+  },
+  summaryTitle: {
+    fontSize: 20,
+    padding: 20,
+    paddingBottom: 5,
+    margin: 0,
+    fontWeight: 'bold'
+  }
+
+};

--- a/ui/src/message_popup/renderers/read_more.jsx
+++ b/ui/src/message_popup/renderers/read_more.jsx
@@ -38,31 +38,20 @@ export default React.createClass({
 
   render() {    
     if (this.props.fulltext.length <= this.props.charCount) {
-      return <div style={styles.summaryQuestion}>{this.props.fulltext}</div>;
+      return <div>{this.props.fulltext}</div>;
     }
     if(this.state.expanded) {
       return (
-        <div style={styles.summaryQuestion}>
+        <div>
           {this.props.fulltext} <a href='#' onClick={this.collapse}>show less</a>
         </div>
       );
     } else {
       return (
-        <div style={styles.summaryQuestion}>
+        <div>
           {this.props.fulltext.substring(0, this.props.charCount) + '... '}
           <a href='#' onClick={this.expand}>read more</a>
         </div>);
     }
   },
 });
-
-const styles = {
-  summaryQuestion: {
-    whiteSpace: 'pre-wrap',
-    fontSize: 16,
-    lineHeight: 1.2,
-    paddingTop: 20,
-    paddingBottom: 10
-  }
-};
-

--- a/ui/src/message_popup/renderers/read_more.jsx
+++ b/ui/src/message_popup/renderers/read_more.jsx
@@ -12,6 +12,12 @@ export default React.createClass({
     charCount: React.PropTypes.node,
   },
 
+  getDefaultProps() {
+    return {
+      charCount: 140
+    };
+  },
+
   getInitialState() {
     return {
       expanded: false
@@ -30,10 +36,8 @@ export default React.createClass({
     });
   },
 
-  render() {
-    var charCount = (this.props.charCount === undefined) ? 140 : this.props.charCount;
-    
-    if (this.props.fulltext.length <= charCount) {
+  render() {    
+    if (this.props.fulltext.length <= this.props.charCount) {
       return <div style={styles.summaryQuestion}>{this.props.fulltext}</div>;
     }
     if(this.state.expanded) {
@@ -45,7 +49,7 @@ export default React.createClass({
     } else {
       return (
         <div style={styles.summaryQuestion}>
-          {this.props.fulltext.substring(0, charCount) + '... '}
+          {this.props.fulltext.substring(0, this.props.charCount) + '... '}
           <a href='#' onClick={this.expand}>read more</a>
         </div>);
     }

--- a/ui/src/message_popup/renderers/read_more.jsx
+++ b/ui/src/message_popup/renderers/read_more.jsx
@@ -1,0 +1,64 @@
+/* @flow weak */
+import React from 'react';
+
+/*
+  Component that displays a text block that can be expanded or collapsed.
+*/
+export default React.createClass({
+  displayName: 'ReadMore',
+
+  propTypes: {
+    fulltext: React.PropTypes.node.isRequired,
+    charCount: React.PropTypes.node,
+  },
+
+  getInitialState() {
+    return {
+      expanded: false
+    };
+  },
+
+  expand() {
+    this.setState({
+      expanded: true
+    });
+  },
+
+  collapse() {
+    this.setState({
+      expanded: false
+    });
+  },
+
+  render() {
+    var charCount = (this.props.charCount === undefined) ? 140 : this.props.charCount;
+    
+    if (this.props.fulltext.length <= charCount) {
+      return <div style={styles.summaryQuestion}>{this.props.fulltext}</div>;
+    }
+    if(this.state.expanded) {
+      return (
+        <div style={styles.summaryQuestion}>
+          {this.props.fulltext} <a href='#' onClick={this.collapse}>show less</a>
+        </div>
+      );
+    } else {
+      return (
+        <div style={styles.summaryQuestion}>
+          {this.props.fulltext.substring(0, charCount) + '... '}
+          <a href='#' onClick={this.expand}>read more</a>
+        </div>);
+    }
+  },
+});
+
+const styles = {
+  summaryQuestion: {
+    whiteSpace: 'pre-wrap',
+    fontSize: 16,
+    lineHeight: 1.2,
+    paddingTop: 20,
+    paddingBottom: 10
+  }
+};
+


### PR DESCRIPTION
There's a default (configurable) char count of 140. The scenario prompt can be displayed in 3 possible ways on the summary page:
* If the scenario prompt is <= 140 chars we display the full text.
* If the char count is > 140, by default the text will be truncated and "... read more" will be appended. The "read more" link can be selected to expand the text.
* If the char count is > 140 and the truncated text gets expanded, the "read more" link changes to a "show less" link which can be selected to truncate the text. 

### Screenshot
<img width="375" alt="screenshot 2017-01-05 13 30 32" src="https://cloud.githubusercontent.com/assets/9402134/21692518/498230a2-d34b-11e6-9180-df4f60cc759d.png">
