### PR TITLE
Add a new endpoint and experiment with a Mechanical Turk HIT

### DIFF
--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -21,7 +21,6 @@ import * as MessagePopup from './message_popup/index.js';
 import {challenges, slates} from './challenge/challenges.js';
 
 
-
 export default React.createClass({
   displayName: 'App',
 
@@ -54,6 +53,7 @@ export default React.createClass({
     '/teachermoments': 'messagePopup',
     '/playtest/:cohortKey': 'messagePopupPlaytest',
     '/teachermoments/alpha': 'alphaPlaytest',
+    '/teachermoments/turk-0000': 'turk0000',
     '/teachermoments/mentoring': 'mentoringPlaytest',
     '/teachermoments/mindset': 'mindsetPlaytest',
     '/teachermoments/danson': 'dansonPlaytest',
@@ -117,6 +117,14 @@ export default React.createClass({
 
   alphaPlaytest(query = {}) {
     return <MessagePopup.InsubordinationPage query={{}}/>;
+  },
+
+  turk0000(query = {}) {
+    return (
+      <MessagePopup.MTurkPage
+        query={query}
+        experimentFactory={MessagePopup.InsubordinationExperiment} />
+    );
   },
 
   mentoringPlaytest(query = {}) {

--- a/ui/src/helpers/api.js
+++ b/ui/src/helpers/api.js
@@ -1,7 +1,7 @@
 /* @flow weak */
 import _ from 'lodash';
-import superagent from 'superagent';
 import * as Routes from '../routes.js';
+import superagent from 'superagent';
 import SuperagentPromise from 'superagent-promise';
 const request = SuperagentPromise(superagent, Promise);
 

--- a/ui/src/message_popup/index.js
+++ b/ui/src/message_popup/index.js
@@ -9,6 +9,9 @@ import DansonExperiencePage from './playtest/danson_experience_page.jsx';
 import InsubordinationPage from './playtest/insubordination_page.jsx';
 import MentoringPage from './playtest/mentoring_page.jsx';
 import MindsetPage from './playtest/mindset_page.jsx';
+import MTurkPage from './playtest/mturk_page.jsx';
+import InsubordinationExperiment from './playtest/insubordination_experiment.jsx';
+
 import ExplorationPage from './exploration_page.jsx';
 import ScoringPage from './scoring_page.jsx';
 import EvaluationViewerPage from './evaluation_viewer_page.jsx';
@@ -40,6 +43,8 @@ export {
   InsubordinationPage,
   MentoringPage,
   MindsetPage,
+  InsubordinationExperiment,
+  MTurkPage,
   ExplorationPage,
   ScoringPage,
   EvaluationViewerPage,

--- a/ui/src/message_popup/playtest/insubordination_experiment.jsx
+++ b/ui/src/message_popup/playtest/insubordination_experiment.jsx
@@ -1,0 +1,116 @@
+/* @flow weak */
+import React from 'react';
+import uuid from 'uuid';
+
+import Divider from 'material-ui/Divider';
+
+import LinearSession from '../linear_session/linear_session.jsx';
+import RaisedButton from 'material-ui/RaisedButton';
+import ClassifyQuestion from '../linear_session/classify_question.jsx';
+import RecordThenClassifyQuestion from '../linear_session/record_then_classify_question.jsx';
+import {InsubordinationScenarios} from './insubordination_scenarios.js';
+
+
+
+// And experiment page, handles forming a cohort and displaying the substance of the experiment.
+export default React.createClass({
+  displayName: 'InsubordinationExperiment',
+
+  propTypes: {
+    userIdentifier: React.PropTypes.string.isRequired,
+    onLogMessage: React.PropTypes.func.isRequired,
+    onExperimentDone: React.PropTypes.func.isRequired
+  },
+
+  getInitialState() {
+    const {userIdentifier} = this.props;
+    const cohortKey = InsubordinationScenarios.cohortKey(userIdentifier);
+    const questions = InsubordinationScenarios.questionsFor(cohortKey);
+
+    return {
+      questions,
+      hasStarted: false,
+      experimentUuid: uuid.v4()
+    };
+  },
+
+  onStart() {
+    this.setState({ hasStarted: true });
+  },
+
+  onExperimentDone(questions, responses) {
+    this.props.onExperimentDone({questions, responses});
+  },
+
+  render() {
+    const {hasStarted, questions} = this.state;
+    const {onLogMessage} = this.props;
+    if (!hasStarted) return this.renderIntro();
+
+    return <LinearSession
+      questions={questions}
+      questionEl={this.renderQuestionEl}
+      summaryEl={this.renderSummaryEl}
+      onLogMessage={onLogMessage}
+    />;
+  },
+
+  renderIntro() {
+    return (
+      <div>
+        <div>
+          <p>Welcome!</p>
+          <p>Imagine you're a middle school math teacher in an urban public school.</p>
+          <p>You will go through a set of scenarios that simulate a conversation between you and a student.</p>
+          <p>Provide an audio response to each prompt. Please respond like you would in a real conversation.</p>
+        </div>
+        <RaisedButton
+          onTouchTap={this.onStart}
+          secondary={true}
+          label="Start" />
+      </div>
+    );
+  },
+
+  // Only ask for audio on questions with choices, otherwise let them continue
+  renderQuestionEl(question, onLog, onResponseSubmitted) {
+    if (question.choices.length === 0) {
+      return <ClassifyQuestion
+        key={question.id}
+        question={question}
+        choices={['OK']}
+        onLogMessage={onLog}
+        onResponseSubmitted={onResponseSubmitted}
+      />;
+    } else {
+      return <RecordThenClassifyQuestion
+        key={question.id}
+        question={question}
+        choices={question.choices}
+        onLogMessage={onLog}
+        onResponseSubmitted={onResponseSubmitted}
+      />;
+    }
+  },
+
+  renderSummaryEl(questions, responses) {
+    return (
+      <div style={{padding: 20}}>
+        <div style={{paddingBottom: 20, fontWeight: 'bold'}}>Thanks!  Here are your responses:</div>
+        <div style={{paddingBottom: 30}}>
+          {responses.map((response, i) =>
+            <div key={i} style={{paddingTop: 10}}>
+              <div>{questions[i].text}</div>
+              <div>> {response.choice}</div>
+              <Divider style={{marginTop: 15}} />
+            </div>
+          )}
+        </div>
+        <RaisedButton
+          onTouchTap={this.onExperimentDone.bind(this, questions, responses)}
+          secondary={true}
+          label="Done" />
+      </div>
+    );
+  }
+});

--- a/ui/src/message_popup/playtest/mturk_page.jsx
+++ b/ui/src/message_popup/playtest/mturk_page.jsx
@@ -1,0 +1,69 @@
+/* @flow weak */
+import React from 'react';
+import uuid from 'uuid';
+
+import ResponsiveFrame from '../../components/responsive_frame.jsx';
+import * as Api from '../../helpers/api.js';
+import superagent from 'superagent';
+import SuperagentPromise from 'superagent-promise';
+const request = SuperagentPromise(superagent, Promise);
+
+
+export default React.createClass({
+  displayName: 'MTurkPage',
+
+  propTypes: {
+    query: React.PropTypes.shape({
+      assignmentId: React.PropTypes.string.isRequired,
+      hitId: React.PropTypes.string.isRequired,
+      turkSubmitTo: React.PropTypes.string.isRequired,
+      workerId: React.PropTypes.string.isRequired
+    }).isRequired,
+    experimentFactory: React.PropTypes.func.isRequired
+  },
+
+  getInitialState() {
+    return {
+      mTurkWrapperUuid: uuid.v4()
+    };
+  },
+
+  doEndExperiment() {
+    console.log('Submitting...'); // eslint-disable-line no-console
+    const {turkSubmitTo} = this.props.query;
+    request
+      .post(turkSubmitTo)
+      .end();
+  },
+
+  onLogMessage(type, response) {
+    const {query} = this.props; 
+    const {mTurkWrapperUuid} = this.state;
+
+    Api.logEvidence(type, {
+      ...response,
+      mTurkParams: query,
+      mTurkWrapperUuid: mTurkWrapperUuid,
+      clientTimestampMs: new Date().getTime(),
+    });
+  },
+
+  onExperimentDone(payload) {
+    this.onLogMessage('mturk_experiment_done', payload);
+    this.doEndExperiment();
+  },
+
+  render() {
+    return (
+      <ResponsiveFrame>
+        <div style={{padding: 20}}>
+          {React.createElement(this.props.experimentFactory, {
+            userIdentifier: this.props.query.workerId,
+            onLogMessage: this.onLogMessage,
+            onExperimentDone: this.onExperimentDone
+          })}
+        </div>
+      </ResponsiveFrame>
+    );
+  }
+});


### PR DESCRIPTION
This is an experiment to add the plumbing necessary to run this as a Mechanical Turk HIT.  We aren't running any actual experiments and this is only intended to learn how it would work and try things out in the MTurk Requester Sandbox.

This creates a new endpoint, and copies parts of `InsubordinationPage` out into `InsubordinationExperiment`, which removes bits related to requesting the user's email and nav bar for restarting the session.  A new `MTurkPage` component takes params from Mechanical Turk, passes an opaque `userIdentifier` along to the experiment page along with an `onLogMessage` function that mixes in all the Mechanical Turk information when logging.  Finally, an `onExperimentDone` page allows the experiment to signify it's done, and `MTurkPage` completes the call to Amazon to finish the HIT.

Screenshot, with frame removed:
![screen shot 2017-01-20 at 12 54 53 pm](https://cloud.githubusercontent.com/assets/1056957/22159594/aa1e1c1c-df0f-11e6-92f9-86701d423d5e.png)
