### PR TITLE
Add more logging around S3 being unavailable

### DIFF
--- a/server/endpoints/audio.js
+++ b/server/endpoints/audio.js
@@ -54,7 +54,16 @@ function get(s3) {
       Key: getAudioKey(request, id)
     };
     console.log('Reading from S3...');
-    s3.getObject(params).createReadStream().pipe(response);
+    try {
+      s3.getObject(params).createReadStream().pipe(response);
+      return;
+    }
+    catch (err) {
+      console.log('Error reading from S3: ', err);
+      response.status(503);
+      response.json({});
+      return;
+    }
   }
 }
 

--- a/ui/src/components/audio_recorder_flow.jsx
+++ b/ui/src/components/audio_recorder_flow.jsx
@@ -54,6 +54,7 @@ export default React.createClass({
     const xhr = new XMLHttpRequest();
     xhr.open('POST', url);
     xhr.onload = this.onDoneUploading;
+    xhr.onerror = this.onErrorUploading;
     xhr.send(blob);
   },
 
@@ -121,6 +122,13 @@ export default React.createClass({
       uploadState: 'done',
     });
     this.props.onDone({uploadedUrl});
+  },
+
+  // Log error and halt
+  onErrorUploading(event) {
+    this.props.onLogMessage('message_popup_audio_error_uploading');
+    this.setState({ uploadState: 'error' });
+    console.error('AudioRecorderFlow.onErrorUploading', event); // eslint-disable-line no-console
   },
 
   render() {


### PR DESCRIPTION
The server now tolerates S3 being unavailable when reading audio files (eg., when no internet connectivity), and returns a 503.

The client code for recording audio logs an error to the console if the POST request to the server fails (eg., when no internet connectivity).

Making the client more robust to failures involves other changes (since that would mean actual data loss); for now this just logs more explicitly.