### PR TITLE
Move positioning of 'Recording...' text so buttons don't jump

### DIFF
--- a/ui/src/message_popup/renderers/minimal_audio_response.jsx
+++ b/ui/src/message_popup/renderers/minimal_audio_response.jsx
@@ -76,8 +76,9 @@ export default React.createClass({
   renderRecording({onDone}) {
     return (
       <div>
-        <div style={{...styles.instruction, color: Colors.accent1Color}}>Recording...</div>
+        <div style={styles.instruction}></div>
         <RaisedButton key="done" onTouchTap={onDone} label="Done" primary={true} />
+        <div style={{...styles.recordingMessage, color: Colors.accent1Color}}>Recording...</div>
       </div>
     );
   },
@@ -102,5 +103,8 @@ const styles = {
   },
   instruction: {
     paddingBottom: 5
+  },
+  recordingMessage: {
+    paddingTop: 10
   }
 };


### PR DESCRIPTION
This moves the text below the button, since in the case where there's no prompt text, the button would jump when "Recording..." was added during the state transition.

After:

<img width="354" alt="screen shot 2017-02-16 at 8 49 12 am" src="https://cloud.githubusercontent.com/assets/1056957/23025594/760ce84a-f42c-11e6-8372-0c0ac8b19803.png">
