### PR TITLE
Add prototype CS substitute scenario

### DIFF
--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -59,6 +59,7 @@ export default React.createClass({
     '/teachermoments/danson': 'dansonPlaytest',
     '/teachermoments/twine': 'messagePopupTwine',
     '/teachermoments/demo': 'messagePopupDemo',
+    '/teachermoments/sub': 'messagePopupPairs',
     '/teachermoments/exploration': 'messagePopupExploration',
     '/teachermoments/evaluations/:id': 'messagePopupEvaluation',
     '/teachermoments/scoring': 'messagePopupScoring',
@@ -137,6 +138,10 @@ export default React.createClass({
 
   dansonPlaytest(query = {}) {
     return <MessagePopup.DansonExperiencePage query={{}}/>;
+  },
+
+  messagePopupPairs(query = {}) {
+    return <MessagePopup.PairsExperiencePage query={{}}/>;
   },
 
   messagePopupPlaytest(cohortKey, query = {}) {

--- a/ui/src/message_popup/index.js
+++ b/ui/src/message_popup/index.js
@@ -11,6 +11,7 @@ import MentoringPage from './playtest/mentoring_page.jsx';
 import MindsetPage from './playtest/mindset_page.jsx';
 import MTurkPage from './playtest/mturk_page.jsx';
 import InsubordinationExperiment from './playtest/insubordination_experiment.jsx';
+import PairsExperiencePage from './playtest/pairs_experience_page.jsx';
 
 import ExplorationPage from './exploration_page.jsx';
 import ScoringPage from './scoring_page.jsx';
@@ -44,6 +45,7 @@ export {
   MentoringPage,
   MindsetPage,
   InsubordinationExperiment,
+  PairsExperiencePage,
   MTurkPage,
   ExplorationPage,
   ScoringPage,

--- a/ui/src/message_popup/playtest/pairs_experience_page.jsx
+++ b/ui/src/message_popup/playtest/pairs_experience_page.jsx
@@ -1,0 +1,150 @@
+/* @flow weak */
+import React from 'react';
+import uuid from 'uuid';
+
+import * as Api from '../../helpers/api.js';
+import LinearSession from '../linear_session/linear_session.jsx';
+import SessionFrame from '../linear_session/session_frame.jsx';
+import IntroWithEmail from '../linear_session/intro_with_email.jsx';
+import PlainTextQuestion from '../renderers/plain_text_question.jsx';
+import ChoiceForBehaviorResponse from '../renderers/choice_for_behavior_response.jsx';
+import MinimalOpenResponse from '../renderers/minimal_open_response.jsx';
+import type {QuestionT} from './pairs_scenario.js';
+import {PairsScenario} from './pairs_scenario.js';
+
+
+
+type ResponseT = {
+  choice:string,
+  question:QuestionT
+};
+
+
+
+// The top-level page, manages logistics around email, cohorts and questions,
+// and the display of instructions, questions, and summary.
+//
+// This is a CS scenario around pair programming dynamics.
+export default React.createClass({
+  displayName: 'PairsExperiencePage',
+
+  propTypes: {
+    query: React.PropTypes.object.isRequired
+  },
+
+  contextTypes: {
+    auth: React.PropTypes.object.isRequired
+  },
+
+  // Cohort comes from URL
+  getInitialState() {
+    const contextEmail = this.context.auth.userProfile.email;
+    const email = contextEmail === "unknown@mit.edu" ? '' : contextEmail;
+    const cohortKey = this.props.query.cohort || 'default';
+
+    return {
+      email,
+      cohortKey,
+      questions: null,
+      sessionId: uuid.v4()
+    };
+  },
+
+  // Making questions from the cohort
+  onStart(email) {
+    const {cohortKey} = this.state;
+    const questions = PairsScenario.questionsFor(cohortKey);
+    this.setState({
+      email,
+      questions
+    });
+  },
+
+  onResetSession() {
+    this.setState(this.getInitialState());
+  },
+
+  onLogMessage(type, response:ResponseT) {
+    const {email, cohortKey, sessionId} = this.state;
+    Api.logEvidence(type, {
+      ...response,
+      sessionId,
+      email,
+      cohortKey,
+      name: email,
+      clientTimestampMs: new Date().getTime(),
+    });
+  },
+
+  render() {
+    return (
+      <SessionFrame onResetSession={this.onResetSession}>
+        {this.renderContent()}
+      </SessionFrame>
+    );
+  },
+
+  renderContent() {
+    const {questions} = this.state;
+    if (!questions) return this.renderIntro();
+
+    return <LinearSession
+      questions={questions}
+      questionEl={this.renderQuestionEl}
+      summaryEl={this.renderSummaryEl}
+      onLogMessage={this.onLogMessage}
+    />;
+  },
+
+  renderIntro() {
+    return (
+      <IntroWithEmail defaultEmail={this.state.email} onDone={this.onStart}>
+        <div>
+          <p>Welcome!</p>
+          <p>This is an interactive case study simulating a small part of a high school computer science lesson.</p>
+          <p>You'll review the context of the lesson briefly, share what you anticipate about the lesson, and then try it out!  Afterward you'll reflect before heading back to debrief with the group.</p>
+        </div>
+      </IntroWithEmail>
+    );
+  },
+
+  // Show overview and context, ask for open response for scenario.
+  renderQuestionEl(question:QuestionT, onLog, onResponseSubmitted) {
+    const interactionEl = (question.ask)
+      ? <MinimalOpenResponse
+          forceResponse={question.force || false}
+          responsePrompt=""
+          recordText="Click then speak"
+          ignoreText="Move on"
+          onLogMessage={onLog}
+          onResponseSubmitted={onResponseSubmitted}
+        />
+      : <ChoiceForBehaviorResponse
+          choices={['OK']}
+          onLogMessage={onLog}
+          onResponseSubmitted={onResponseSubmitted}
+        />;
+
+    return (
+      <div key={JSON.stringify(question)}>
+        <b style={{
+          display: 'block',
+          padding: '15px 20px 15px',
+          background: '#09407d',
+          color: 'white'
+        }}>{question.type}</b>
+        <PlainTextQuestion question={{text: question.el}} />
+        {interactionEl}
+      </div>
+    );
+  },
+
+  renderSummaryEl(questions:[QuestionT], responses:[ResponseT]) {
+    return (
+      <div style={{padding: 20}}>
+        <div>Thanks!</div>
+        <div style={{paddingTop: 20}}>You can close the computer and head on back to the group.</div>
+      </div>
+    );
+  }
+});

--- a/ui/src/message_popup/playtest/pairs_scenario.js
+++ b/ui/src/message_popup/playtest/pairs_scenario.js
@@ -1,0 +1,266 @@
+/* @flow weak */
+
+/*
+This file defines the content for the scenario around substituting a CS class.
+*/
+
+export type QuestionT = {
+  type:string, // Used as a label
+  el:string, // Contents of slide
+  ask:?bool, // Ask for open-ended user response?
+  force:?bool // Force the user to respond?
+};
+
+const slides:[QuestionT] = [];
+
+slides.push({ type: 'Overview', el:
+`1. Review context
+Imagine yourself being given a subsitute assignment in a particular school and classroom.  You won't know all the answers, and will have to improvise and adapt to make the best of the situation.
+
+2. Anticipate
+Skim the lesson plan and materials.  You shouldn't have an in-depth understanding of the lesson, but do your best to anticipate what might happen, before trying it out and adapting to what happens.
+
+3. Try it!
+When you're ready, you'll go through a set of short scenes that simulate interactions between you and some students in the class.
+
+4. Reflect
+Finally, you'll reflect on your experience.
+
+5. Discussion
+When you're all done here, head back to the classroom to rejoin the group.
+`});
+
+
+// Context
+slides.push({ type: 'Context', el:
+`For this assignment, you've been asked to substitute for Ms. Ada, who unexpectedly needed to take a personal day to attend to some family matters.
+
+Ms. Ada works in an urban public high school, and teaches several computer science courses.
+
+You'll be substituting for one lesson, so you won't have all the answers and will have to improvise and make the best of the situation.
+`});
+
+slides.push({ type: 'Context', el:
+`Today, Ms. Ada's first lesson is a computer science principles course based on the code.org curriculum.  Here's the overall course sequence:
+
+1. The Internet
+2. Digital Information
+3. > Algorithms and Programming <
+4. Big data and privacy
+5. Building apps
+
+You're about to kick off Unit 3, which is about Algorithms and Programming.
+`});
+
+slides.push({ type: 'Context', el:
+`The classroom layout has students at individual desks that they can move around easily to form pairs or groups.  Each student has a laptop with internet connectivity.
+
+Classroom materials like paper, pens, etc. are readily available.
+
+There's a projector that can show any computer screen on the front wall of the classroom.  The teacher's desk is in the back corner of the room.
+`});
+
+
+slides.push({ type: 'Context', el:
+`There are eight students in this class section:
+
+- Aaliyah
+- Claire
+- DeShawn
+- Dustin
+- Greg
+- Jake
+- Molly
+- Terrell
+
+One challenge in being a substitute is that you'll start the lesson without knowing much about these students.
+`});
+
+
+// Anticipate
+slides.push({ type: 'Anticipate', el:
+`Before you being, we have three questions about what you anticipate.
+`});
+
+slides.push({ type: 'Anticipate', el:
+`After skimming the lesson plan, what do you anticipate might happen during this class?
+`, ask: true, force: true});
+
+slides.push({ type: 'Anticipate', el:
+`What's are some best case and worst case scenarios for students during this lesson?
+`, ask: true, force: true});
+
+slides.push({ type: 'Anticipate', el:
+`What would success for students look like during this period?
+`, ask: true, force: true});
+
+
+// Try it!
+slides.push({ type: 'Try it!', el:
+`When you're ready, you'll go through a set of scenes.
+
+We'll fast forward to where students have already come in, you've launched the lesson successfully, and students are now working on the main activity.
+
+In the simulation, you'll be witnessing moments of students working as you circulate around the room.
+
+Improvise how you would act as a substitute teacher in those moments.  Click and speak aloud the words you'd say to those students, or say nothing and continue circulating.
+
+
+Ready to start?
+`});
+
+slides.push({ type: 'Try it!', el:
+`Greg and Jake are at desks next to each other.
+
+Jake: "Okay, so the first step is to stack our legos on top of each other."
+
+Greg: "Yeah, let's write 'build a tower.'"
+`, ask: true});
+
+slides.push({ type: 'Try it!', el:
+`Molly and DeShawn are at a desk together.
+
+DeShawn: "Here, let me see the blocks.  We can make them into a shape like a bridge."
+
+Molly listens and watches.  DeShawn starts putting pieces together.
+`, ask: true});
+
+slides.push({ type: 'Try it!', el:
+`Terrell and Dustin are sitting next to each other.
+
+Terrell: "So this is just like a programming language, we have to make our own language to describe how to put the legos together.  That includes how to describe the pieces and the ways we can combine them."
+
+Terrell sees you walk by and turns to ask a question.  Terrell: "Does our language need to describe all possible ways to combine the legos?"
+`, ask: true});
+
+
+slides.push({ type: 'Try it!', el:
+`Claire and Aaliyah are sitting next to each other.
+
+Claire: "What kind of shape should we make?"
+
+Aaliyah: "I don't know."
+
+Claire: "Maybe we could do a pattern?"
+
+Aaliyah: "Sure."
+`, ask: true});
+
+
+slides.push({ type: 'Try it!', el:
+`Terrell and Dustin are sitting next to each other.
+
+Terrell gets your attention.  Terrell: "Excuse me, but I know how to do this.  Can I just create my own language for this on my own?"
+`, ask: true});
+
+
+slides.push({ type: 'Try it!', el:
+`Claire and Aaliyah are sitting next to each other.
+
+Claire: "So put the red piece on the desk first.  Then put the yellow piece on... wait, I'm not sure how to say this."
+
+Aaliyah: "This is confusing."
+
+Claire: "Yeah, I could show you but I'm not sure how to describe it."
+`, ask: true});
+
+
+slides.push({ type: 'Try it!', el:
+`Greg and Jake are at desks next to each other.
+
+Jake: "Cool, we're finished.  Let's give our directions to someone else so they can build our tower."
+
+Greg: "Yeah, let's find DeShawn to trade with him."
+
+Jake: "Yeah I gotta ask him something too."
+`, ask: true});
+
+slides.push({ type: 'Try it!', el:
+`Molly and DeShawn are working together.
+
+Molly: "I wrote out all the directions you were saying."
+
+DeShawn: "Cool, our bridge is all set.  We're the best team in here."
+`, ask: true});
+
+slides.push({ type: 'Try it!', el:
+`Terrell is writing on a paper.  Dustin is watching what he is writing.
+`, ask: true});
+
+slides.push({ type: 'Try it!', el:
+`Claire and Aaliyah are sitting next to each other.
+
+Aaliyah: "So you're saying that we should do this, right?"
+
+Aaliyah moves the blocks around, showing Claire.
+
+Claire: "Yeah, but it seems weird to talk about it."
+
+Aaliyah: "We could try say that you go through the colors like across a color wheel.  But that's not quite the right order."
+`, ask: true});
+
+slides.push({ type: 'Try it!', el:
+`Greg and Jake walk up to DeShawn and Molly.
+
+Greg: "Ready to trade?  What did you make a bridge?"
+
+DeShawn: "Yeah and Molly wrote the directions for how you can copy it."
+
+Molly nods.
+`, ask: true});
+
+
+slides.push({ type: 'Try it!', el:
+`Terrell and Dustin are together.
+
+Terrell: "Okay, we're finished.  Let's trade with Molly and DeShawn."
+
+Dustin and Terrell walk up to Molly and DeShawn.  They notice Greg and Jake there as well.
+
+Dustin: "Are you guys ready to trade?"
+`, ask: true});
+
+
+
+// Reflect
+slides.push({ type: 'Reflect', el:
+`That's the end of the simulation.  Thanks!
+
+Let's shift to reflecting on the lesson.
+`});
+
+slides.push({ type: 'Reflect', el:
+`Before heading back to the group, we have three questions about what you experienced in this simulation.
+
+After that, you'll have a minute to think about the first group discussion question before heading back.
+
+Also, for now please hold questions or feedback about this activity itself.  We'll ask for that at the end.
+`});
+
+slides.push({ type: 'Reflect', el:
+`During the simulation, how did you think about your role as a teacher?
+`, ask: true, force: true});
+
+slides.push({ type: 'Reflect', el:
+`How did different students experience the class differently?
+`, ask: true, force: true});
+
+slides.push({ type: 'Reflect', el:
+`Did you notice any social dynamics between students related to race, ethnicity, gender or class?
+`, ask: true, force: true});
+
+slides.push({ type: 'Reflect', el:
+`Finally, pick one student group to talk about during the group discussion.
+
+In the group, you'll be asked to describe what you noticed, any assumptions you made, and how that shaped your interactions with students.
+
+Feel free to take a minute or two to think about that, and then head on back!
+`});
+
+
+
+export const PairsScenario = {
+  questionsFor(cohortKey) {
+    return slides;
+  }
+};


### PR DESCRIPTION
This adds a new experience for an internal playtest.  It's centered on substituting during a high school CS class, and circulating while students are doing pair work.  There's also some context in front, anticipation questions, and then reflect questions after.  The expectation is there's an in-person briefing, and an in-person group discussion to close.

This is mounted at `/teachermoments/sub`.  Using `?cohort=foo` will track cohorts, or bucket all users as `default` if none is set.

Here are some excerpts of the user flow:
![screen shot 2017-02-16 at 10 00 15 am](https://cloud.githubusercontent.com/assets/1056957/23026285/bd8c3cfa-f42e-11e6-8900-52c475ae48e0.png)

![screen shot 2017-02-16 at 9 36 08 am](https://cloud.githubusercontent.com/assets/1056957/23026247/a2581fee-f42e-11e6-9a30-2759acc27633.png)

![screen shot 2017-02-16 at 9 36 16 am](https://cloud.githubusercontent.com/assets/1056957/23026253/a498a0da-f42e-11e6-86f9-96254a2b4c0f.png)

![screen shot 2017-02-16 at 9 36 25 am](https://cloud.githubusercontent.com/assets/1056957/23026258/a8bc5a12-f42e-11e6-9dcd-2dc1a77cfdc3.png)

![screen shot 2017-02-16 at 9 36 31 am](https://cloud.githubusercontent.com/assets/1056957/23026260/aae21822-f42e-11e6-86b2-a61560b0584b.png)

![screen shot 2017-02-16 at 9 36 49 am](https://cloud.githubusercontent.com/assets/1056957/23026264/acfd3c18-f42e-11e6-9c0e-2254e08f1bb7.png)

![screen shot 2017-02-16 at 9 36 55 am](https://cloud.githubusercontent.com/assets/1056957/23026266/af145b26-f42e-11e6-85ab-462ce7efa5bf.png)
