### PR TITLE
Update Rollbar

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -49,7 +49,7 @@
     "react-swipeable-views": "^0.6.3",
     "react-tap-event-plugin": "^2.0.0",
     "react-youtube": "^7.0.1",
-    "rollbar-browser": "^1.9.1",
+    "rollbar-browser": "^1.9.3",
     "superagent": "^2.0.0",
     "superagent-promise": "^1.1.0",
     "uglify": "^0.1.5",

--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -2,7 +2,7 @@
 import App from './app.jsx';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Rollbar from 'rollbar-browser';
+import rollbar from 'rollbar-browser';
 
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -18,7 +18,7 @@ function startRollbar() {
 
   // Don't log if hosted locally
   if (hostname === 'localhost') return;
-  window.rollbar = Rollbar.init({
+  window.Rollbar = rollbar.init({
     accessToken: "de42c0395e924afba679510bd16908a6",
     captureUncaught: true,
     captureUnhandledRejections: false,


### PR DESCRIPTION
And try swapping instance/class names.  I can't tell what's going on but there's a different between production and development, and it appears unable to find methods on Rollbar.  Changing this to exactly match the docs.