### PR TITLE
Add more lesson plan context to CS sub

### DIFF
--- a/ui/src/message_popup/linear_session/intro_with_email.jsx
+++ b/ui/src/message_popup/linear_session/intro_with_email.jsx
@@ -32,6 +32,11 @@ export default React.createClass({
     this.props.onDone(this.state.email);
   },
 
+  onSubmit(e) {
+    e.preventDefault();
+    this.onDone();
+  },
+
   render() {
     return (
       <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
@@ -40,23 +45,25 @@ export default React.createClass({
         </div>
         <Divider />
         <div style={{padding: 20}}>
-          <TextField
-          name="email"
-          style={{width: '100%'}}
-          underlineShow={false}
-          floatingLabelText="What's your email address?"
-          value={this.state.email}
-          onChange={this.onTextChanged}
-          multiLine={true}
-          rows={2}/>
-          <div style={styles.buttonRow}>
-            <RaisedButton
-              disabled={this.state.email === ''}
-              onTouchTap={this.onDone}
-              style={styles.button}
-              secondary={true}
-              label="Start" />
-          </div>    
+          <form onSubmit={this.onSubmit}>
+            <TextField
+              name="email"
+              style={{width: '100%'}}
+              underlineShow={false}
+              floatingLabelText="What's your email address?"
+              value={this.state.email}
+              onChange={this.onTextChanged}
+              rows={2} />
+            <div style={styles.buttonRow}>
+              <RaisedButton
+                disabled={this.state.email === ''}
+                onTouchTap={this.onDone}
+                type="submit"
+                style={styles.button}
+                secondary={true}
+                label="Start" />
+            </div>    
+          </form>
         </div>
       </VelocityTransitionGroup>
     );

--- a/ui/src/message_popup/playtest/pairs_experience_page.jsx
+++ b/ui/src/message_popup/playtest/pairs_experience_page.jsx
@@ -7,10 +7,12 @@ import LinearSession from '../linear_session/linear_session.jsx';
 import SessionFrame from '../linear_session/session_frame.jsx';
 import IntroWithEmail from '../linear_session/intro_with_email.jsx';
 import PlainTextQuestion from '../renderers/plain_text_question.jsx';
+import ReactQuestion from '../renderers/react_question.jsx';
+
 import ChoiceForBehaviorResponse from '../renderers/choice_for_behavior_response.jsx';
 import MinimalOpenResponse from '../renderers/minimal_open_response.jsx';
-import type {QuestionT} from './pairs_scenario.js';
-import {PairsScenario} from './pairs_scenario.js';
+import type {QuestionT} from './pairs_scenario.jsx';
+import {PairsScenario} from './pairs_scenario.jsx';
 
 
 
@@ -133,7 +135,10 @@ export default React.createClass({
           background: '#09407d',
           color: 'white'
         }}>{question.type}</b>
-        <PlainTextQuestion question={{text: question.el}} />
+        {(question.el)
+          ? <ReactQuestion el={question.el} />
+          : <PlainTextQuestion question={question} />
+        }
         {interactionEl}
       </div>
     );

--- a/ui/src/message_popup/playtest/pairs_experience_page.jsx
+++ b/ui/src/message_popup/playtest/pairs_experience_page.jsx
@@ -104,7 +104,7 @@ export default React.createClass({
         <div>
           <p>Welcome!</p>
           <p>This is an interactive case study simulating a small part of a high school computer science lesson.</p>
-          <p>You'll review the context of the lesson briefly, share what you anticipate about the lesson, and then try it out!  Afterward you'll reflect before heading back to debrief with the group.</p>
+          <p>You'll review the context of the lesson briefly, share what you anticipate about the lesson, and then try it out!  Afterward you'll reflect before heading back to debrief with the group or share online.</p>
         </div>
       </IntroWithEmail>
     );

--- a/ui/src/message_popup/playtest/pairs_experience_page.jsx
+++ b/ui/src/message_popup/playtest/pairs_experience_page.jsx
@@ -135,10 +135,8 @@ export default React.createClass({
           background: '#09407d',
           color: 'white'
         }}>{question.type}</b>
-        {(question.el)
-          ? <ReactQuestion el={question.el} />
-          : <PlainTextQuestion question={question} />
-        }
+        {question.el && <ReactQuestion el={question.el} />}
+        {question.text && <PlainTextQuestion question={{text: question.text}} />}
         {interactionEl}
       </div>
     );

--- a/ui/src/message_popup/playtest/pairs_scenario.jsx
+++ b/ui/src/message_popup/playtest/pairs_scenario.jsx
@@ -264,13 +264,15 @@ slides.push({ type: 'Reflect', text:
 `Did you notice any social dynamics between students related to race, ethnicity, gender or class?
 `, ask: true, force: true});
 
-slides.push({ type: 'Reflect', text:
-`Finally, pick one student group to talk about during the group discussion.
-
-In the group, you'll be asked to describe what you noticed, any assumptions you made, and how that shaped your interactions with students.
-
-Feel free to take a minute or two to think about that, and then head on back!
-`});
+slides.push({ type: 'Reflect', el:
+<div>
+  <div>Finally, pick one student group to talk about during the group discussion.</div>
+  <br />
+  <div>In the group, you'll be asked to describe what you noticed, any assumptions you made, and how that shaped your interactions with students.</div>
+  <br />
+  <div>Feel free to take a minute or two to think about that, and then head on back!  If you're working online you can connect with other folks at <a target="_blank" href="https://twitter.com/search?q=%23CSforAllCaseStudies">#CSForAllCaseStudies</a>.</div>
+</div>
+});
 
 
 

--- a/ui/src/message_popup/playtest/pairs_scenario.jsx
+++ b/ui/src/message_popup/playtest/pairs_scenario.jsx
@@ -5,13 +5,20 @@ import React from 'react';
 This file defines the content for the scenario around substituting a CS class.
 */
 
-export type QuestionT = {
+type TextQuestionT = {
   type:string, // Used as a label
-  text:?string, // Contents of slide
-  el:?any, // Contents of slide
+  text:string,
   ask:?bool, // Ask for open-ended user response?
   force:?bool // Force the user to respond?
 };
+type ReactQuestionT = {
+  type:string, // Used as a label
+  el:any, // React node
+  ask:?bool, // Ask for open-ended user response?
+  force:?bool // Force the user to respond?
+};
+export type QuestionT = TextQuestionT | ReactQuestionT;
+
 
 const slides:[QuestionT] = [];
 

--- a/ui/src/message_popup/playtest/pairs_scenario.jsx
+++ b/ui/src/message_popup/playtest/pairs_scenario.jsx
@@ -1,4 +1,5 @@
 /* @flow weak */
+import React from 'react';
 
 /*
 This file defines the content for the scenario around substituting a CS class.
@@ -6,7 +7,8 @@ This file defines the content for the scenario around substituting a CS class.
 
 export type QuestionT = {
   type:string, // Used as a label
-  el:string, // Contents of slide
+  text:?string, // Contents of slide
+  el:?any, // Contents of slide
   ask:?bool, // Ask for open-ended user response?
   force:?bool // Force the user to respond?
 };
@@ -14,25 +16,27 @@ export type QuestionT = {
 const slides:[QuestionT] = [];
 
 slides.push({ type: 'Overview', el:
-`1. Review context
-Imagine yourself being given a subsitute assignment in a particular school and classroom.  You won't know all the answers, and will have to improvise and adapt to make the best of the situation.
-
-2. Anticipate
-Skim the lesson plan and materials.  You shouldn't have an in-depth understanding of the lesson, but do your best to anticipate what might happen, before trying it out and adapting to what happens.
-
-3. Try it!
-When you're ready, you'll go through a set of short scenes that simulate interactions between you and some students in the class.
-
-4. Reflect
-Finally, you'll reflect on your experience.
-
-5. Discussion
-When you're all done here, head back to the classroom to rejoin the group.
-`});
+<div>
+  <div>1. Review context</div>
+  <div>Imagine yourself being given a subsitute assignment in a particular school and classroom.  You won't know all the answers, and will have to improvise and adapt to make the best of the situation.</div>
+  <br />
+  <div>2. Anticipate</div>
+  <div>Skim the lesson plan and materials.  You shouldn't have an in-depth understanding, but do your best to anticipate what might happen.</div>
+  <br />
+  <div>3. Try it!</div>
+  <div>When you're ready, you'll go through a set of short scenes that simulate interactions between you and some students in the class.</div>
+  <br />
+  <div>4. Reflect</div>
+  <div>Finally, you'll reflect on your experience.</div>
+  <br />
+  <div>5. Discussion</div>
+  <div>When you're all done here, head back to the classroom to rejoin the group.  If you're online, connect with others at <a target="_blank" href="https://twitter.com/search?q=%23CSforAllCaseStudies">#CSForAllCaseStudies</a>.</div>
+</div>
+});
 
 
 // Context
-slides.push({ type: 'Context', el:
+slides.push({ type: 'Context', text:
 `For this assignment, you've been asked to substitute for Ms. Ada, who unexpectedly needed to take a personal day to attend to some family matters.
 
 Ms. Ada works in an urban public high school, and teaches several computer science courses.
@@ -40,7 +44,7 @@ Ms. Ada works in an urban public high school, and teaches several computer scien
 You'll be substituting for one lesson, so you won't have all the answers and will have to improvise and make the best of the situation.
 `});
 
-slides.push({ type: 'Context', el:
+slides.push({ type: 'Context', text:
 `Today, Ms. Ada's first lesson is a computer science principles course based on the code.org curriculum.  Here's the overall course sequence:
 
 1. The Internet
@@ -49,10 +53,21 @@ slides.push({ type: 'Context', el:
 4. Big data and privacy
 5. Building apps
 
-You're about to kick off Unit 3, which is about Algorithms and Programming.
+You're about to kick off Unit 3, and the first lesson is about The Need for Programming Languages.
 `});
 
-slides.push({ type: 'Context', el:
+slides.push({ type: 'Context', text:
+`You don't need to memorize or remember the lesson plan exactly, but here's the general idea.
+
+First, students work in pairs to create something small with Lego blocks.  Then they write instructions that a classmate could follow to recreate it.
+
+Next, groups trade instructions and students see what happens when another group tries to use their instructions.
+
+Finally, there's a wrap-up discussion to highlight the ambiguities in natural language, and how this experience connects to programming languages.
+`});
+
+
+slides.push({ type: 'Context', text:
 `The classroom layout has students at individual desks that they can move around easily to form pairs or groups.  Each student has a laptop with internet connectivity.
 
 Classroom materials like paper, pens, etc. are readily available.
@@ -61,7 +76,7 @@ There's a projector that can show any computer screen on the front wall of the c
 `});
 
 
-slides.push({ type: 'Context', el:
+slides.push({ type: 'Context', text:
 `There are eight students in this class section:
 
 - Aaliyah
@@ -78,25 +93,25 @@ One challenge in being a substitute is that you'll start the lesson without know
 
 
 // Anticipate
-slides.push({ type: 'Anticipate', el:
+slides.push({ type: 'Anticipate', text:
 `Before you being, we have three questions about what you anticipate.
 `});
 
-slides.push({ type: 'Anticipate', el:
+slides.push({ type: 'Anticipate', text:
 `After skimming the lesson plan, what do you anticipate might happen during this class?
 `, ask: true, force: true});
 
-slides.push({ type: 'Anticipate', el:
+slides.push({ type: 'Anticipate', text:
 `What's are some best case and worst case scenarios for students during this lesson?
 `, ask: true, force: true});
 
-slides.push({ type: 'Anticipate', el:
+slides.push({ type: 'Anticipate', text:
 `What would success for students look like during this period?
 `, ask: true, force: true});
 
 
 // Try it!
-slides.push({ type: 'Try it!', el:
+slides.push({ type: 'Try it!', text:
 `When you're ready, you'll go through a set of scenes.
 
 We'll fast forward to where students have already come in, you've launched the lesson successfully, and students are now working on the main activity.
@@ -109,7 +124,7 @@ Improvise how you would act as a substitute teacher in those moments.  Click and
 Ready to start?
 `});
 
-slides.push({ type: 'Try it!', el:
+slides.push({ type: 'Try it!', text:
 `Greg and Jake are at desks next to each other.
 
 Jake: "Okay, so the first step is to stack our legos on top of each other."
@@ -117,7 +132,7 @@ Jake: "Okay, so the first step is to stack our legos on top of each other."
 Greg: "Yeah, let's write 'build a tower.'"
 `, ask: true});
 
-slides.push({ type: 'Try it!', el:
+slides.push({ type: 'Try it!', text:
 `Molly and DeShawn are at a desk together.
 
 DeShawn: "Here, let me see the blocks.  We can make them into a shape like a bridge."
@@ -125,7 +140,7 @@ DeShawn: "Here, let me see the blocks.  We can make them into a shape like a bri
 Molly listens and watches.  DeShawn starts putting pieces together.
 `, ask: true});
 
-slides.push({ type: 'Try it!', el:
+slides.push({ type: 'Try it!', text:
 `Terrell and Dustin are sitting next to each other.
 
 Terrell: "So this is just like a programming language, we have to make our own language to describe how to put the legos together.  That includes how to describe the pieces and the ways we can combine them."
@@ -134,7 +149,7 @@ Terrell sees you walk by and turns to ask a question.  Terrell: "Does our langua
 `, ask: true});
 
 
-slides.push({ type: 'Try it!', el:
+slides.push({ type: 'Try it!', text:
 `Claire and Aaliyah are sitting next to each other.
 
 Claire: "What kind of shape should we make?"
@@ -147,14 +162,14 @@ Aaliyah: "Sure."
 `, ask: true});
 
 
-slides.push({ type: 'Try it!', el:
+slides.push({ type: 'Try it!', text:
 `Terrell and Dustin are sitting next to each other.
 
 Terrell gets your attention.  Terrell: "Excuse me, but I know how to do this.  Can I just create my own language for this on my own?"
 `, ask: true});
 
 
-slides.push({ type: 'Try it!', el:
+slides.push({ type: 'Try it!', text:
 `Claire and Aaliyah are sitting next to each other.
 
 Claire: "So put the red piece on the desk first.  Then put the yellow piece on... wait, I'm not sure how to say this."
@@ -165,7 +180,7 @@ Claire: "Yeah, I could show you but I'm not sure how to describe it."
 `, ask: true});
 
 
-slides.push({ type: 'Try it!', el:
+slides.push({ type: 'Try it!', text:
 `Greg and Jake are at desks next to each other.
 
 Jake: "Cool, we're finished.  Let's give our directions to someone else so they can build our tower."
@@ -175,7 +190,7 @@ Greg: "Yeah, let's find DeShawn to trade with him."
 Jake: "Yeah I gotta ask him something too."
 `, ask: true});
 
-slides.push({ type: 'Try it!', el:
+slides.push({ type: 'Try it!', text:
 `Molly and DeShawn are working together.
 
 Molly: "I wrote out all the directions you were saying."
@@ -183,11 +198,11 @@ Molly: "I wrote out all the directions you were saying."
 DeShawn: "Cool, our bridge is all set.  We're the best team in here."
 `, ask: true});
 
-slides.push({ type: 'Try it!', el:
+slides.push({ type: 'Try it!', text:
 `Terrell is writing on a paper.  Dustin is watching what he is writing.
 `, ask: true});
 
-slides.push({ type: 'Try it!', el:
+slides.push({ type: 'Try it!', text:
 `Claire and Aaliyah are sitting next to each other.
 
 Aaliyah: "So you're saying that we should do this, right?"
@@ -199,7 +214,7 @@ Claire: "Yeah, but it seems weird to talk about it."
 Aaliyah: "We could try say that you go through the colors like across a color wheel.  But that's not quite the right order."
 `, ask: true});
 
-slides.push({ type: 'Try it!', el:
+slides.push({ type: 'Try it!', text:
 `Greg and Jake walk up to DeShawn and Molly.
 
 Greg: "Ready to trade?  What did you make a bridge?"
@@ -210,7 +225,7 @@ Molly nods.
 `, ask: true});
 
 
-slides.push({ type: 'Try it!', el:
+slides.push({ type: 'Try it!', text:
 `Terrell and Dustin are together.
 
 Terrell: "Okay, we're finished.  Let's trade with Molly and DeShawn."
@@ -223,13 +238,13 @@ Dustin: "Are you guys ready to trade?"
 
 
 // Reflect
-slides.push({ type: 'Reflect', el:
+slides.push({ type: 'Reflect', text:
 `That's the end of the simulation.  Thanks!
 
 Let's shift to reflecting on the lesson.
 `});
 
-slides.push({ type: 'Reflect', el:
+slides.push({ type: 'Reflect', text:
 `Before heading back to the group, we have three questions about what you experienced in this simulation.
 
 After that, you'll have a minute to think about the first group discussion question before heading back.
@@ -237,19 +252,19 @@ After that, you'll have a minute to think about the first group discussion quest
 Also, for now please hold questions or feedback about this activity itself.  We'll ask for that at the end.
 `});
 
-slides.push({ type: 'Reflect', el:
+slides.push({ type: 'Reflect', text:
 `During the simulation, how did you think about your role as a teacher?
 `, ask: true, force: true});
 
-slides.push({ type: 'Reflect', el:
+slides.push({ type: 'Reflect', text:
 `How did different students experience the class differently?
 `, ask: true, force: true});
 
-slides.push({ type: 'Reflect', el:
+slides.push({ type: 'Reflect', text:
 `Did you notice any social dynamics between students related to race, ethnicity, gender or class?
 `, ask: true, force: true});
 
-slides.push({ type: 'Reflect', el:
+slides.push({ type: 'Reflect', text:
 `Finally, pick one student group to talk about during the group discussion.
 
 In the group, you'll be asked to describe what you noticed, any assumptions you made, and how that shaped your interactions with students.

--- a/ui/src/message_popup/renderers/plain_text_question.jsx
+++ b/ui/src/message_popup/renderers/plain_text_question.jsx
@@ -1,5 +1,6 @@
 /* @flow weak */
 import React from 'react';
+import ReactQuestion from './react_question.jsx';
 
 
 // Render a plain text question, nothing else.
@@ -7,21 +8,13 @@ export default React.createClass({
   displayName: 'PlainTextQuestion',
 
   propTypes: {
-    question: React.PropTypes.object.isRequired,
+    question: React.PropTypes.shape({
+      text: React.PropTypes.string.isRequired
+    }).isRequired
   },
 
   render() {
     const {question} = this.props;
-
-    return <div style={styles.textQuestion}>{question.text}</div>;
+    return <ReactQuestion el={<div>{question.text}</div>} />;
   }
 });
-
-const styles = {
-  textQuestion: {
-    whiteSpace: 'pre-wrap',
-    fontSize: 16,
-    lineHeight: 1.2,
-    padding: 20
-  }
-};

--- a/ui/src/message_popup/renderers/react_question.jsx
+++ b/ui/src/message_popup/renderers/react_question.jsx
@@ -1,0 +1,27 @@
+/* @flow weak */
+import React from 'react';
+
+
+// Render a React component
+export default React.createClass({
+  displayName: 'ReactQuestion',
+
+  propTypes: {
+    el: React.PropTypes.node.isRequired
+  },
+
+  render() {
+    const {el} = this.props;
+
+    return React.cloneElement(el, {style: styles.textQuestion});
+  }
+});
+
+const styles = {
+  textQuestion: {
+    whiteSpace: 'pre-wrap',
+    fontSize: 16,
+    lineHeight: 1.2,
+    padding: 20
+  }
+};


### PR DESCRIPTION
So this would make sense in a self-serve way, without ![screen shot 2017-02-17 at 10 54 06 am](https://cloud.githubusercontent.com/assets/1056957/23072365/6d39892a-f4ff-11e6-87d8-f4a143f75e2b.png)

Also remove multiline text on email sign-up.