### PR TITLE
Add command line scripts for working with audio IDs

### DIFF
--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -1,0 +1,2 @@
+# Fetch data about the last few audio responses from Heroku on the command line (requires credentials).
+heroku pg:psql --command "SELECT json->'name', json->'audioUrl' FROM evidence WHERE type='message_popup_audio_response' ORDER BY id DESC LIMIT 10;"

--- a/scripts/listen.sh
+++ b/scripts/listen.sh
@@ -1,0 +1,10 @@
+# Fetch an audio ID from S3 on the command line (requires credentials).
+AUDIO_ID=$1
+TARGET_FOLDER=~/Desktop/wav-responses/
+
+mkdir -p $TARGET_FOLDER
+
+echo Fetching $AUDIO_ID into $TARGET_FOLDER...
+aws s3 cp s3://message-popup/production_threeflows.herokuapp.com/wav-responses/$AUDIO_ID.wav $TARGET_FOLDER
+open $TARGET_FOLDER/$1.wav
+echo Opening...


### PR DESCRIPTION
Since for now we've removed HTTPS access to audio files altogether (https://github.com/mit-teaching-systems-lab/threeflows/pull/203), this adds a script for an authorized developer or researcher to grab data with command line tools.  These require separate Heroku and AWS credentials which are more strictly controlled.