### PR TITLE
Switch to Uglify2 to address Rollbar mangling

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -46,7 +46,6 @@
     "rollbar-browser": "^1.9.3",
     "superagent": "^2.0.0",
     "superagent-promise": "^1.1.0",
-    "uglify": "^0.1.5",
     "velocity-animate": "^1.2.3",
     "velocity-react": "^1.1.5"
   },
@@ -68,6 +67,7 @@
     "react-addons-test-utils": "^15.4.0",
     "react-proxy": "^1.1.8",
     "sinon": "^1.17.5",
+    "uglify-js": "^2.8.4",
     "watchify": "^3.7.0"
   }
 }


### PR DESCRIPTION
Rollbar isn't working in production.  It works locally, and the code is failing within Rollbar's code while trying to do a property lookup, so the problems appears to be introduced in the production build process.

In looking at that, I realized this was using Uglify so updated it to Uglify2, and that appears to resolve the problem in a production build locally.