### PR TITLE
Move Uglify to dependencies

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -46,6 +46,7 @@
     "rollbar-browser": "^1.9.3",
     "superagent": "^2.0.0",
     "superagent-promise": "^1.1.0",
+    "uglifyify": "^3.0.4",
     "velocity-animate": "^1.2.3",
     "velocity-react": "^1.1.5"
   },
@@ -67,8 +68,6 @@
     "react-addons-test-utils": "^15.4.0",
     "react-proxy": "^1.1.8",
     "sinon": "^1.17.5",
-    "uglify-js": "^2.8.4",
-    "uglifyify": "^3.0.4",
     "watchify": "^3.7.0"
   }
 }


### PR DESCRIPTION
One more for https://github.com/mit-teaching-systems-lab/threeflows/pull/209, moving this into dependencies so it's installed in a Heroku deploy and available to then build the UI code.