### PR TITLE
Improving home and /demos pages for better communicating about different prototypes

### DIFF
--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -8,7 +8,8 @@ import injectTapEventPlugin from 'react-tap-event-plugin';
 
 import AuthContainer from './auth_container.jsx';
 import VirtualSchoolPage from './virtual_school/virtual_school_page.jsx';
-import HomePage from './home_page.jsx';
+import HomePage from './home/home_page.jsx';
+import DemosPage from './home/demos_page.jsx';
 import * as MessagePopup from './message_popup/index.js';
 
 
@@ -33,30 +34,35 @@ export default React.createClass({
 
   routes: {
     '/': 'home',
+    '/demos': 'demos',
 
-    // Variations on learning experiences
-    '/message_popup*': 'messagePopupRedirect',
-    '/teachermoments': 'messagePopup',
-    '/playtest/:cohortKey': 'messagePopupPlaytest',
+    // Included in /demos, shared externally, or used in playtests
+    '/teachermoments/original': 'messagePopup',
     '/teachermoments/bias': 'biasHome',
     '/teachermoments/alpha': 'alphaPlaytest',
-    '/teachermoments/turk-0000': 'turk0000',
     '/teachermoments/mentoring': 'mentoringPlaytest',
     '/teachermoments/mindset': 'mindsetPlaytest',
-    '/teachermoments/danson': 'dansonPlaytest',
     '/teachermoments/danson2': 'dansonPlaytest2',
     '/teachermoments/twine': 'messagePopupTwine',
     '/teachermoments/demo': 'messagePopupDemo',
     '/teachermoments/sub': 'messagePopupPairs',
     '/teachermoments/darius': 'messagePopupDarius',
+    '/teachermoments/chat': 'chatPrototype',
+
+    // Deprecated experiences
+    '/playtest/:cohortKey': 'messagePopupPlaytest',
+    '/teachermoments/danson': 'dansonPlaytest',
+
+    // Mechanical Turk experiment
+    '/teachermoments/turk-0000': 'turk0000',
 
     // Prototype authoring UIs
     '/teachermoments/author/questions' : 'messagePopupAuthorQuestions',
     '/teachermoments/author/questions/new' : 'messagePopupAuthorQuestionsNew',
     '/teachermoments/author/questions/:id' : 'messagePopupAuthorQuestionsEdit',
 
-    // Other stuff
-    '/virtual_school': 'virtualSchool',
+    // Other
+    '/virtual_school': 'virtualSchool'
   },
 
   /*eslint-disable react/sort-comp */
@@ -75,17 +81,21 @@ export default React.createClass({
   },
 
   notFound(path) {
-    return <HomePage />;
+    window.location = '/';
   },
 
-  messagePopupRedirect(remainingPath, query = {}) {
-    window.location = `/teachermoments${remainingPath}`;
+  demos(query = {}) {
+    return <DemosPage />;
   },
 
   messagePopup(query = {}) {
     // Uses a unique key per query string so that navigating between
     // rebuilds the page.
     return <MessagePopup.ExperiencePage key={JSON.stringify(query)} query={query} />;
+  },
+
+  chatPrototype(query = {}) {
+    return this.messagePopup({...query, mobilePrototype: true});
   },
 
   messagePopupTwine(query = {}) {

--- a/ui/src/components/navigation_app_bar.jsx
+++ b/ui/src/components/navigation_app_bar.jsx
@@ -7,9 +7,7 @@ import MenuItem from 'material-ui/MenuItem';
 import AppBar from 'material-ui/AppBar';
 import IconButton from 'material-ui/IconButton';
 import HomeIcon from 'material-ui/svg-icons/action/home';
-import ChatBubble from 'material-ui/svg-icons/communication/chat-bubble-outline';
 import MenuIcon from 'material-ui/svg-icons/navigation/menu';
-import SchoolIcon from 'material-ui/svg-icons/social/school';
 
 import * as Routes from '../routes.js';
 
@@ -23,8 +21,7 @@ export default React.createClass({
     title: React.PropTypes.string.isRequired,
     style: React.PropTypes.object,
     iconElementLeft: React.PropTypes.element,
-    iconElementRight: React.PropTypes.element,
-    prependMenuItems: React.PropTypes.element
+    iconElementRight: React.PropTypes.element
   },
 
   contextTypes: {
@@ -52,7 +49,7 @@ export default React.createClass({
 
   render() {
     const {userProfile, doLogout} = this.context.auth;
-    const {iconElementLeft, iconElementRight, prependMenuItems} = this.props;
+    const {iconElementLeft, iconElementRight} = this.props;
 
     return (
       <div>
@@ -71,12 +68,7 @@ export default React.createClass({
           open={this.state.isOpen}
           onRequestChange={(isOpen) => this.setState({isOpen})}
         >
-          {<MenuItem leftIcon={<HomeIcon />} onTouchTap={this.onNavigationTapped.bind(this, '/')} primaryText="Home" />}
-          <MenuItem onTouchTap={this.onNavigationTapped.bind(this, Routes.virtualSchoolPath())} leftIcon={<SchoolIcon />} primaryText="Virtual school" />
-          {prependMenuItems && <div onClick={this.doCloseDrawer}>{prependMenuItems}</div>}
-          <Divider />
-          <MenuItem onTouchTap={this.onNavigationTapped.bind(this, Routes.messagePopupPracticePath())} leftIcon={<ChatBubble />} primaryText="Practice" />
-          <MenuItem onTouchTap={this.onNavigationTapped.bind(this, Routes.messagePopupSolutionPath())} leftIcon={<ChatBubble />} primaryText="Solution" />
+          <MenuItem leftIcon={<HomeIcon />} onTouchTap={this.onNavigationTapped.bind(this, '/')} primaryText="Home" />
           <Divider />
           {userProfile &&
             <div>

--- a/ui/src/home/demos_page.jsx
+++ b/ui/src/home/demos_page.jsx
@@ -1,0 +1,67 @@
+/* @flow weak */
+import React from 'react';
+
+import {List, ListItem} from 'material-ui/List';
+import HomeFrame from './home_frame.jsx';
+import * as Routes from '../routes.js';
+
+
+// A list of demos to try.
+export default React.createClass({
+  displayName: 'DemosPage',
+
+  onTappedMenu(e) {
+    window.location.reload();
+  },
+
+  onTappedItem(linkEl) {
+    Routes.navigate(linkEl.props.href);
+  },
+
+  render() {
+    return <HomeFrame>{this.renderScenarios()}</HomeFrame>;
+  },
+
+  renderScenarios() {
+    return (
+      <div>
+        <h3 style={styles.header}>Scenarios</h3>
+        <List>
+          {this.renderScenarioItem(<a href="/teachermoments/sub">Computer science substitute</a>)}
+          {this.renderScenarioItem(<a href="/teachermoments/danson2">Parent meeting</a>)}
+          {this.renderScenarioItem(<a href="/teachermoments/original">Choose your skill</a>)}
+          {this.renderScenarioItem(<a href="/teachermoments/darius">Darius</a>)}
+        </List>
+        <h3 style={styles.header}>Early prototypes</h3>
+        <List>
+          {this.renderScenarioItem(<a href="/teachermoments/mentoring">Mentoring session</a>)}
+          {this.renderScenarioItem(<a href="/teachermoments/alpha">Mini: Tired in class</a>)}
+          {this.renderScenarioItem(<a href="/teachermoments/mindset">Mini: New student</a>)}
+          {this.renderScenarioItem(<a href="/teachermoments/twine">Twine: Greeting students</a>)}
+          {this.renderScenarioItem(<a href="/teachermoments/demo">Technical demo</a>)}
+          {this.renderScenarioItem(<a href="/teachermoments/chat">Chat-based interface</a>)}
+        </List>
+        <div style={{marginTop: 20}}>New idea?  Reach out at <a href="https://twitter.com/mit_tsl">@mit_tsl</a>.</div>
+      </div>
+    );
+  },
+
+  renderScenarioItem(linkEl) {
+    return (
+      <ListItem
+        innerDivStyle={styles.listItem}
+        onTouchTap={this.onTappedItem.bind(this, linkEl)}
+        primaryText={linkEl} />
+    );
+  }
+});
+
+const styles = {
+  header: {
+    margin: 0,
+    marginTop: 25
+  },
+  listItem: {
+    padding: 5
+  }
+};

--- a/ui/src/home/demos_page_test.jsx
+++ b/ui/src/home/demos_page_test.jsx
@@ -1,0 +1,16 @@
+/* @flow weak */
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from 'chai';
+
+import DemosPage from './demos_page.jsx';
+import {List, ListItem} from 'material-ui/List';
+
+
+describe('<DemosPage />', () => {
+  it('renders', () => {
+    const wrapper = shallow(<DemosPage />);
+    expect(wrapper.find(List).length).to.equal(2);
+    expect(wrapper.find(ListItem).length).to.equal(10);
+  });
+});

--- a/ui/src/home/home_frame.jsx
+++ b/ui/src/home/home_frame.jsx
@@ -2,30 +2,36 @@
 import React from 'react';
 
 import IconButton from 'material-ui/IconButton';
-import DescriptionIcon from 'material-ui/svg-icons/action/description';
+import RefreshIcon from 'material-ui/svg-icons/navigation/refresh';
 
-import NavigationAppBar from './components/navigation_app_bar.jsx';
-import ResponsiveFrame from './components/responsive_frame.jsx';
+import NavigationAppBar from '../components/navigation_app_bar.jsx';
+import ResponsiveFrame from '../components/responsive_frame.jsx';
+import * as Routes from '../routes.js';
 
 
 
+// Frame for the Home page screens, with nav bar, logo and layout.
 export default React.createClass({
-  displayName: 'HomePage',
+  displayName: 'HomeFrame',
 
-  onTappedDoc(e) {
-    window.location = 'http://tsl.mit.edu';
+  propTypes: {
+    children: React.PropTypes.node
+  },
+
+  onTappedMenu(e) {
+    Routes.navigate('/');
   },
 
   render() {
     return (
-      <div className="HomePage">
+      <div className="HomeFrame">
         <ResponsiveFrame>
           <div style={styles.page}>
             <NavigationAppBar
               title="Teacher Moments"
               iconElementLeft={
-                <IconButton onTouchTap={this.onTappedDoc} >
-                  <DescriptionIcon />
+                <IconButton onTouchTap={this.onTappedMenu} >
+                  <RefreshIcon />
                 </IconButton>
               }
             />
@@ -37,18 +43,13 @@ export default React.createClass({
   },
 
   renderContent() {
+    const {children} = this.props;
+
     return (
       <div style={styles.content}>
         <div style={styles.textBlock}>
           <h2><a style={styles.nolink} href="http://tsl.mit.edu/practice-spaces-for-teacher-preparation/">Practice spaces for teacher preparation programs</a></h2>
-          <div style={styles.quote}>
-            "We conclude that, in the program we studied, prospective teachers have fewer opportunities to engage in approximations that focus on contingent, interactive practice than do novices in the other two professions we studied."
-          </div>
-          <div>Grossman et al. (<a target="_blank" href="https://cset.stanford.edu/sites/default/files/files/documents/publications/Grossman-TeachingPracticeACross-ProfessionalPerspective.pdf">2009</a>)</div>
-          <div style={styles.links}>
-            <div><a href="http://tsl.mit.edu">Lab website</a></div>
-            <div><a href="https://github.com/mit-teaching-systems-lab">Source code</a></div>
-          </div>
+          {children}
         </div>
         <div style={styles.logoBlock}>
           <a href="http://tsl.mit.edu">
@@ -79,17 +80,9 @@ const styles = {
     margin: 20,
     marginTop: 0
   },
-  logoBlock: {
-  },
   logo: {
     width: '80%',
     margin: 20
-  },
-  quote: {
-    fontStyle: 'italic'
-  },
-  links: {
-    marginTop: 20
   },
   nolink: {
     textDecoration: 'none',

--- a/ui/src/home/home_page.jsx
+++ b/ui/src/home/home_page.jsx
@@ -1,0 +1,51 @@
+/* @flow weak */
+import React from 'react';
+
+import RaisedButton from 'material-ui/RaisedButton';
+import * as Routes from '../routes.js';
+import HomeFrame from './home_frame.jsx';
+
+
+// The home page for the whole site.
+export default React.createClass({
+  displayName: 'HomePage',
+
+  onTryItTapped(e) {
+    Routes.navigate('/demos');
+  },
+
+  render() {
+    return <HomeFrame>{this.renderQuoteAndLinks()}</HomeFrame>;
+  },
+
+  renderQuoteAndLinks() {
+    return (
+      <div>
+        <div style={styles.quote}>
+          "We conclude that, in the program we studied, prospective teachers have fewer opportunities to engage in approximations that focus on contingent, interactive practice than do novices in the other two professions we studied."
+        </div>
+        <div>Grossman et al. (<a target="_blank" href="https://cset.stanford.edu/sites/default/files/files/documents/publications/Grossman-TeachingPracticeACross-ProfessionalPerspective.pdf">2009</a>)</div>
+        <div style={styles.links}>
+          <RaisedButton
+            onTouchTap={this.onTryItTapped}
+            type="submit"
+            style={{marginTop: 20, marginRight: 10}}
+            secondary={true}
+            label="Demos" />
+          <a style={{padding: 10}} href="http://tsl.mit.edu/practice-spaces-for-teacher-preparation/">Learn more</a>
+          <a style={{padding: 10}} href="https://github.com/mit-teaching-systems-lab/threeflows">Source code</a>
+
+        </div>
+      </div>
+    );
+  }
+});
+
+const styles = {
+  quote: {
+    fontStyle: 'italic'
+  },
+  links: {
+    marginTop: 20
+  }
+};

--- a/ui/src/home/home_page_test.jsx
+++ b/ui/src/home/home_page_test.jsx
@@ -1,0 +1,16 @@
+/* @flow weak */
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from 'chai';
+
+import HomePage from './home_page.jsx';
+import RaisedButton from 'material-ui/RaisedButton';
+
+
+describe('<HomePage />', () => {
+  it('renders', () => {
+    const wrapper = shallow(<HomePage />);
+    expect(wrapper.find('a').length).to.equal(3);
+    expect(wrapper.find(RaisedButton).length).to.equal(1);
+  });
+});

--- a/ui/src/message_popup/author/questions_page.jsx
+++ b/ui/src/message_popup/author/questions_page.jsx
@@ -8,7 +8,6 @@ import Divider from 'material-ui/Divider';
 import IconButton from 'material-ui/IconButton';
 import FlatButton from 'material-ui/FlatButton';
 import Paper from 'material-ui/Paper';
-import MenuItem from 'material-ui/MenuItem';
 import Dialog from 'material-ui/Dialog';
 import {Card, CardHeader, CardText} from 'material-ui/Card';
 
@@ -140,15 +139,12 @@ export default React.createClass({
       <div>
         <NavigationAppBar
           title="Message PopUp Questions"
-          iconElementRight={<IconButton onTouchTap={this.onNewQuestion}><AddIcon /></IconButton>}
-          prependMenuItems={
-            <div>
-              <MenuItem
-                onTouchTap={this.onNewQuestion}
-                leftIcon={<ChatBubbleOutlineIcon />}
-                primaryText="New Question" />
-            </div>
+          iconElementLeft={
+            <IconButton onTouchTap={this.onNewQuestion} >
+              <ChatBubbleOutlineIcon />
+            </IconButton>
           }
+          iconElementRight={<IconButton onTouchTap={this.onNewQuestion}><AddIcon /></IconButton>}
           />
         <div style={styles.container}>
           <div style={styles.searchbar}>

--- a/ui/src/message_popup/experience_page.jsx
+++ b/ui/src/message_popup/experience_page.jsx
@@ -9,13 +9,12 @@ import RaisedButton from 'material-ui/RaisedButton';
 import Divider from 'material-ui/Divider';
 import LinearProgress from 'material-ui/LinearProgress';
 import Snackbar from 'material-ui/Snackbar';
-import MenuItem from 'material-ui/MenuItem';
+import IconButton from 'material-ui/IconButton';
+import RefreshIcon from 'material-ui/svg-icons/navigation/refresh';
 
 import PopupQuestion from './popup_question.jsx';
 import * as Routes from '../routes';
 import type {ResponseT} from './popup_question.jsx';
-
-import RefreshIcon from 'material-ui/svg-icons/navigation/refresh';
 
 import {withStudents} from './transformations.jsx';
 
@@ -25,11 +24,12 @@ import InstructionsCard from './instructions_card.jsx';
 import NavigationAppBar from '../components/navigation_app_bar.jsx';
 
 import MobileInterface from './mobile_prototype/mobile_interface.jsx';
-
 import ScaffoldingCard from './scaffolding_card.jsx';
+import ResponsiveFrame from '../components/responsive_frame.jsx';
+
 
 /*
-Shows the MessagePopup game
+Shows the MessagePopup game, supporting options for the chat-based interface as well.
 */
 export default React.createClass({
   displayName: 'MessagePopupExperiencePage',
@@ -123,18 +123,19 @@ export default React.createClass({
 
   render() {
     return (
-      <div style={{backgroundColor: 'white'}}>
-        <NavigationAppBar
-          title="Teacher Moments"
-          prependMenuItems={
-            <MenuItem
-              onTouchTap={this.resetExperience}
-              leftIcon={<RefreshIcon />}
-              primaryText="Restart game" />
-          }
-        />
-        {this.renderMainScreen()}
-      </div>
+      <ResponsiveFrame>
+        <div style={{display: 'flex', flexDirection: 'column', height: 667}}>
+          <NavigationAppBar
+            title="Teacher Moments"
+            iconElementLeft={
+              <IconButton onTouchTap={this.resetExperience} >
+                <RefreshIcon />
+              </IconButton>
+            }
+          />
+          {this.renderMainScreen()}
+        </div>
+      </ResponsiveFrame>
     );
   },
 
@@ -237,7 +238,7 @@ export default React.createClass({
     const sessionLength = questions.length;
     const question = withStudents(questions)[questionsAnswered];
     return ( 
-      <div className="prototype">
+      <div className="prototype" style={{flex: 1}}>
         <LinearProgress color="#EC407A" mode="determinate" value={questionsAnswered} max={sessionLength} />
         <MobileInterface
           key={JSON.stringify(question)}

--- a/ui/src/message_popup/mobile_prototype/mobile_interface.jsx
+++ b/ui/src/message_popup/mobile_prototype/mobile_interface.jsx
@@ -211,7 +211,7 @@ export default React.createClass({
     const {scaffolding, question} = this.props;
     const {helpType} = scaffolding;
     return (
-      <div>
+      <div className="MobileInterface" style={styles.container}>
         <div style={styles.textBody}>
           <TextBody 
             question={this.props.question}
@@ -292,19 +292,22 @@ export default React.createClass({
 
 
 const styles = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%'
+  },
   textBody: {
-    position: 'absolute',
     top: 69,
     bottom: 144,
     width: '100%',
-    overflowY: 'scroll'
+    flex: 5
   },
   textFooter:{
-    position: 'absolute',
-    bottom: 0,
     paddingBottom: 15,
+    backgroundColor: '#ffffff',
     width: '100%',
-    backgroundColor: '#ffffff'
+    flex: 1
   },    
   studentAttribute: {
     fontSize: 14,

--- a/ui/src/message_popup/playtest/danson_experience_page.jsx
+++ b/ui/src/message_popup/playtest/danson_experience_page.jsx
@@ -9,13 +9,13 @@ import RaisedButton from 'material-ui/RaisedButton';
 import Divider from 'material-ui/Divider';
 import LinearProgress from 'material-ui/LinearProgress';
 import Snackbar from 'material-ui/Snackbar';
-import MenuItem from 'material-ui/MenuItem';
+import IconButton from 'material-ui/IconButton';
+import RefreshIcon from 'material-ui/svg-icons/navigation/refresh';
 import TextField from 'material-ui/TextField';
 
 import PopupQuestion from '../popup_question.jsx';
 import type {ResponseT} from '../popup_question.jsx';
 
-import RefreshIcon from 'material-ui/svg-icons/navigation/refresh';
 import ResponsiveFrame from '../../components/responsive_frame.jsx';
 
 import {withStudents} from '../transformations.jsx';
@@ -152,11 +152,10 @@ export default React.createClass({
         <div>
           <NavigationAppBar
             title="Teacher Moments"
-            prependMenuItems={
-              <MenuItem
-                onTouchTap={this.resetExperience}
-                leftIcon={<RefreshIcon />}
-                primaryText="Restart game" />
+            iconElementLeft={
+              <IconButton onTouchTap={this.resetExperience} >
+                <RefreshIcon />
+              </IconButton>
             }
           />
           {this.renderMainScreen()}

--- a/ui/src/message_popup/playtest/playtest_experience_page.jsx
+++ b/ui/src/message_popup/playtest/playtest_experience_page.jsx
@@ -9,7 +9,7 @@ import RaisedButton from 'material-ui/RaisedButton';
 import Divider from 'material-ui/Divider';
 import LinearProgress from 'material-ui/LinearProgress';
 import Snackbar from 'material-ui/Snackbar';
-import MenuItem from 'material-ui/MenuItem';
+import IconButton from 'material-ui/IconButton';
 import TextField from 'material-ui/TextField';
 
 import PopupQuestion from '../popup_question.jsx';
@@ -146,11 +146,10 @@ export default React.createClass({
       <div>
         <NavigationAppBar
           title="Teacher Moments"
-          prependMenuItems={
-            <MenuItem
-              onTouchTap={this.resetExperience}
-              leftIcon={<RefreshIcon />}
-              primaryText="Restart game" />
+          iconElementLeft={
+            <IconButton onTouchTap={this.resetExperience} >
+              <RefreshIcon />
+            </IconButton>
           }
         />
         {this.renderMainScreen()}

--- a/ui/src/message_popup/twine/twine_viewer.jsx
+++ b/ui/src/message_popup/twine/twine_viewer.jsx
@@ -57,11 +57,29 @@ export default class TwineViewer extends React.Component {
     // and also as data in `links`, so we'll just use `links`.
     const strippedRaw = passage.text.replace(/\[\[[^\]]*\]\]/g, '');
 
+    // Look for the magic "end of thread" string and replace it with a more inviting one.
+    if (strippedRaw === 'Double-click this passage to edit it.') {
+      return this.renderEndOfThreadMessage();
+    }
+
     // Since Twine supports embedding HTML tags,
     // allow using its contents as untrusted HTML.
     return (allowUnsafeHtml)
       ? <div dangerouslySetInnerHTML={{__html: strippedRaw}} /> // eslint-disable-line react/no-danger
       : strippedRaw; 
+  }
+
+  renderEndOfThreadMessage() {
+    return (
+      <div>
+        <div>Write more scenarios using <a href='https://twinery.org/'>Twine's</a> visual editor, and then view them in Teacher Moments!</div>
+        <div style={{marginTop: 20}}>
+          <a href='https://twinery.org/'>
+            <img src='https://s3-us-west-2.amazonaws.com/tsl-public/threeflows/twine-diagram.png' width='100%' />
+          </a>
+        </div>
+      </div>
+    );
   }
 }
 


### PR DESCRIPTION
This changes the public home page to allow better discovery of different scenarios and playtest iterations, and early prototypes.  It also adds some comments to the app routes, with the intent that we make more iterations discoverable and deprecate and remove older iterations.

In the process, this cleans up some layout problems with the original version and chat-based prototype.  It also removes some older menu options related to things like "practice" and "solution" mode.

## Home page
![screen shot 2017-03-01 at 3 54 40 pm](https://cloud.githubusercontent.com/assets/1056957/23480904/9611d464-fe97-11e6-91f6-83ea41a331c3.png)

## Demos
![screen shot 2017-03-01 at 3 55 49 pm](https://cloud.githubusercontent.com/assets/1056957/23480897/912fc992-fe97-11e6-8929-06ad919c1602.png)

## Chat-based interface
![screen shot 2017-03-01 at 3 55 01 pm](https://cloud.githubusercontent.com/assets/1056957/23480910/994172d4-fe97-11e6-8a06-da154dded6f4.png)

## Twine changes
![screen shot 2017-03-01 at 3 44 30 pm](https://cloud.githubusercontent.com/assets/1056957/23480919/a06f1e80-fe97-11e6-8e13-c0d3495405d8.png)