### PR TITLE
Simplify AudioRecorder state transitions

### DIFF
--- a/ui/src/components/audio_capture.jsx
+++ b/ui/src/components/audio_capture.jsx
@@ -50,7 +50,6 @@ export default React.createClass({
 
   onBlobReady(blob) {
     this.props.onDoneCapture(blob);
-    if (this.recorder) this.recorder.destroy();
     delete this.recorder;
   },
 

--- a/ui/src/components/audio_recorder.js
+++ b/ui/src/components/audio_recorder.js
@@ -15,6 +15,7 @@ const STATES = {
   ERROR: 'error'
 };
 export default class AudioRecorder {
+  // flow is disabled
   state: string;
   buffers: ?[[number]];
   bufferLength: number;

--- a/ui/src/components/audio_recorder.js
+++ b/ui/src/components/audio_recorder.js
@@ -2,36 +2,78 @@ import encodeWAV from './encode_wav.js';
 
 
 // Audio recorder class for one-time use recording.  Only works on Chrome and Firefox.
+// The public API is record/stop, with other internal states hidden from the caller.
 // Adapted from https://github.com/danrouse/react-audio-recorder
+const STATES = {
+  CREATING: 'creating',
+  READY: 'ready',
+  ACQUIRING: 'acquiring',
+  RECORDING: 'recording',
+  ENCODING: 'encoding',
+  STOPPING: 'stopping',
+  RESETTING: 'resetting',
+  ERROR: 'error'
+};
 export default class AudioRecorder {
+  state: string;
   buffers: ?[[number]];
   bufferLength: number;
   bufferSize: number;
   audioContext: ?AudioContext;
   sampleRate: number;
-  recorder: ?Object;
+  processor: ?Object;
   recordingStream: ?Object;
   getUserMedia: ?Object;
 
   constructor() {
-    this.buffers = [[], []];
-    this.bufferLength = 0;
+    this._setCurrentState(STATES.CREATING);
     this.bufferSize = 4096; // tuned up since we care about throughput and capturing all frames, not latency
-    this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
-    this.sampleRate = this.audioContext.sampleRate;
-    this.recordingStream = null;
     this.getUserMedia = (window.navigator.getUserMedia ||
                          window.navigator.webkitGetUserMedia ||
                          window.navigator.mozGetUserMedia ||
                          window.navigator.msGetUserMedia).bind(window.navigator);
+    this._toReady();
   }
 
+  // Debugging hook
+  _setCurrentState(nextState) {
+    this.state = nextState;
+  }
+
+  // Regardless of what state we're in, reset any internal state.
+  _toReady() {
+    this._setCurrentState(STATES.RESETTING);
+
+    // recordingStream
+    if (this.recordingStream && this.recordingStream.stop) this.recordingStream.stop();
+    this.recordingStream = null;
+
+    // audioContext
+    if (this.audioContext && this.audioContext.close) this.audioContext.close();
+    this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
+    this.sampleRate = this.audioContext.sampleRate;
+
+    // processor
+    if (this.processor) delete this.processor;
+
+    // buffer
+    this.buffers = [[], []];
+    this.bufferLength = 0;
+    
+    this._setCurrentState(STATES.READY);
+  }
+
+  // public
   record() {
+    this._setCurrentState(STATES.ACQUIRING);
     this.getUserMedia({ audio: true }, this._onStreamReady.bind(this), this._onStreamError.bind(this));
   }
 
+  // Log and try to reset
   _onStreamError(err) {
+    this._setCurrentState(STATES.ERROR);
     console.error('AudioRecorder._onStreamError', err); // eslint-disable-line no-console
+    this._toReady();
   }
 
   _onStreamReady(stream) {
@@ -40,13 +82,14 @@ export default class AudioRecorder {
     const audioSource = audioContext.createMediaStreamSource(stream);
     audioSource.connect(gain);
 
-    const recorder = audioContext.createScriptProcessor(bufferSize, 2, 2);
-    recorder.onaudioprocess = this._onAudioProcess.bind(this);
-    gain.connect(recorder);
-    recorder.connect(audioContext.destination);
+    const processor = audioContext.createScriptProcessor(bufferSize, 2, 2);
+    processor.onaudioprocess = this._onAudioProcess.bind(this);
+    gain.connect(processor);
+    processor.connect(audioContext.destination);
 
-    this.recorder = recorder;
+    this.processor = processor;
     this.recordingStream = stream;
+    this._setCurrentState(STATES.RECORDING);
   }
 
   _onAudioProcess(event) {
@@ -60,20 +103,23 @@ export default class AudioRecorder {
     }
   }
 
+  // public
   stop(onBlobReady) {
-    this.recordingStream.getTracks()[0].stop();
+    this._stopTracks();
+
+    this._setCurrentState(STATES.ENCODING);
     const audioData = encodeWAV(this.buffers, this.bufferLength, this.sampleRate);
     onBlobReady(audioData);
+
+    this._toReady();
   }
 
-  destroy() {
-    if (this.recordingStream.stop) this.recordingStream.stop();
-    if (this.audioContext.close) this.audioContext.close();
-
-    delete this.buffers;
-    delete this.bufferLength;
-    delete this.bufferSize;
-    delete this.audioContext;
-    delete this.recordingStream;
+  // Guard for if the various stages of initialization aren't completed yet
+  _stopTracks() {
+    if (!this.processor) return;
+    if (!this.recordingStream) return;
+    this._setCurrentState(STATES.STOPPING);
+    const audioTracks = this.recordingStream.getTracks();
+    audioTracks.forEach(audioTrack => audioTrack.stop());
   }
 }


### PR DESCRIPTION
Follow-on from https://github.com/mit-teaching-systems-lab/threeflows/pull/213, trying to address the underlying issue by removing the `destroy` API and make the state transitions more explicit.