### PR TITLE
Revisions for Thursday class copy

### DIFF
--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -49,6 +49,7 @@ export default React.createClass({
     '/teachermoments/sub': 'messagePopupPairs',
     '/teachermoments/darius': 'messagePopupDarius',
     '/teachermoments/chat': 'chatPrototype',
+    '/teachermoments/thursday': 'messagePopupMeredith',
 
     // Deprecated experiences
     '/playtest/:cohortKey': 'messagePopupPlaytest',
@@ -141,7 +142,11 @@ export default React.createClass({
   },
 
   messagePopupPairs(query = {}) {
-    return <MessagePopup.PairsExperiencePage query={{}}/>;
+    return <MessagePopup.PairsExperiencePage query={query} />;
+  },
+
+  messagePopupMeredith(query = {}) {
+    return <MessagePopup.PairsExperiencePage query={query} isForMeredith={true} />;
   },
 
   messagePopupDarius(query = {}) {

--- a/ui/src/helpers/api.js
+++ b/ui/src/helpers/api.js
@@ -29,15 +29,23 @@ export function logEvaluation(type, record) {
 
 // For now, this fires and forgets and does not retry or
 // notify the user on success or failure.
+// It also mixes in some global params.
 export function logEvidence(type, record) {
+  const extendedRecord = {
+    ...record,
+    GLOBAL: {
+      clientTimestampMs: new Date().getTime(),
+      location: window.location.toString()
+    }
+  };
   request
     .post(Routes.evidencePath({
       app: 'threeflows',
       type: type,
-      version: 2
+      version: 3
     }))
     .set('Content-Type', 'application/json')
-    .send(record)
+    .send(extendedRecord)
     .end();
 }
 

--- a/ui/src/message_popup/linear_session/intro_with_email.jsx
+++ b/ui/src/message_popup/linear_session/intro_with_email.jsx
@@ -75,7 +75,7 @@ const styles = {
     fontSize: 20,
     padding: 0,
     margin:0,
-    paddingBottom: 45
+    paddingBottom: 20
   },
   instructions: {
     paddingLeft: 20,

--- a/ui/src/message_popup/playtest/pairs_scenario.jsx
+++ b/ui/src/message_popup/playtest/pairs_scenario.jsx
@@ -20,30 +20,34 @@ type ReactQuestionT = {
 export type QuestionT = TextQuestionT | ReactQuestionT;
 
 
-const slides:[QuestionT] = [];
+export type SettingT = 'mixed' | 'meredith';
+function slidesForSetting(setting:SettingT) {
+  const slides:[QuestionT] = [];
 
-slides.push({ type: 'Overview', el:
-<div>
-  <div>1. Review context</div>
-  <div>Imagine yourself being given a subsitute assignment in a particular school and classroom.  You won't know all the answers, and will have to improvise and adapt to make the best of the situation.</div>
-  <br />
-  <div>2. Anticipate</div>
-  <div>Skim the lesson plan and materials.  You shouldn't have an in-depth understanding, but do your best to anticipate what might happen.</div>
-  <br />
-  <div>3. Try it!</div>
-  <div>When you're ready, you'll go through a set of short scenes that simulate interactions between you and some students in the class.</div>
-  <br />
-  <div>4. Reflect</div>
-  <div>Finally, you'll reflect on your experience.</div>
-  <br />
-  <div>5. Discussion</div>
-  <div>When you're all done here, head back to the classroom to rejoin the group.  If you're online, connect with others at <a target="_blank" href="https://twitter.com/search?q=%23https://twitter.com/search?q=%23TeacherPracticeSpaces">#TeacherPracticeSpaces</a>.</div>
-</div>
-});
+  slides.push({ type: 'Overview', el:
+  <div>
+    <div>1. Review context</div>
+    <div>Imagine yourself being given a subsitute assignment in a particular school and classroom.  You won't know all the answers, and will have to improvise and adapt to make the best of the situation.</div>
+    <br />
+    <div>2. Anticipate</div>
+    <div>Skim the lesson plan and materials.  You shouldn't have an in-depth understanding, but do your best to anticipate what might happen.</div>
+    <br />
+    <div>3. Try it!</div>
+    <div>When you're ready, you'll go through a set of short scenes that simulate interactions between you and some students in the class.</div>
+    <br />
+    <div>4. Reflect</div>
+    <div>Finally, you'll reflect on your experience.</div>
+    <br />
+    <div>5. Discussion</div>
+      {(setting === 'meredith')
+        ? <div>For Thursday, you'll bring one part of the reflection to share in class.</div>
+        : <div>When you're all done here, head back to the classroom to rejoin the group.  If you're online, connect with others at <a target="_blank" href="https://twitter.com/search?q=%23https://twitter.com/search?q=%23TeacherPracticeSpaces">#TeacherPracticeSpaces</a>.</div>}
+  </div>
+  });
 
 
 // Context
-slides.push({ type: 'Context', text:
+  slides.push({ type: 'Context', text:
 `For this assignment, you've been asked to substitute for Ms. Ada, who unexpectedly needed to take a personal day to attend to some family matters.
 
 Ms. Ada works in an urban public high school, and teaches several computer science courses.
@@ -51,7 +55,7 @@ Ms. Ada works in an urban public high school, and teaches several computer scien
 You'll be substituting for one lesson, so you won't have all the answers and will have to improvise and make the best of the situation.
 `});
 
-slides.push({ type: 'Context', text:
+  slides.push({ type: 'Context', text:
 `Today, Ms. Ada's first lesson is a computer science principles course based on the code.org curriculum.  Here's the overall course sequence:
 
 1. The Internet
@@ -63,7 +67,7 @@ slides.push({ type: 'Context', text:
 You're about to kick off Unit 3, and the first lesson is about The Need for Programming Languages.
 `});
 
-slides.push({ type: 'Context', text:
+  slides.push({ type: 'Context', text:
 `You don't need to memorize or remember the lesson plan exactly, but here's the general idea.
 
 First, students work in pairs to create something small with Lego blocks.  Then they write instructions that a classmate could follow to recreate it.
@@ -74,7 +78,7 @@ Finally, there's a wrap-up discussion to highlight the ambiguities in natural la
 `});
 
 
-slides.push({ type: 'Context', text:
+  slides.push({ type: 'Context', text:
 `The classroom layout has students at individual desks that they can move around easily to form pairs or groups.  Each student has a laptop with internet connectivity.
 
 Classroom materials like paper, pens, etc. are readily available.
@@ -83,7 +87,7 @@ There's a projector that can show any computer screen on the front wall of the c
 `});
 
 
-slides.push({ type: 'Context', text:
+  slides.push({ type: 'Context', text:
 `There are eight students in this class section:
 
 - Aaliyah
@@ -100,25 +104,25 @@ One challenge in being a substitute is that you'll start the lesson without know
 
 
 // Anticipate
-slides.push({ type: 'Anticipate', text:
+  slides.push({ type: 'Anticipate', text:
 `Before you being, we have three questions about what you anticipate.
 `});
 
-slides.push({ type: 'Anticipate', text:
+  slides.push({ type: 'Anticipate', text:
 `After skimming the lesson plan, what do you anticipate might happen during this class?
 `, ask: true, force: true});
 
-slides.push({ type: 'Anticipate', text:
+  slides.push({ type: 'Anticipate', text:
 `What's are some best case and worst case scenarios for students during this lesson?
 `, ask: true, force: true});
 
-slides.push({ type: 'Anticipate', text:
+  slides.push({ type: 'Anticipate', text:
 `What would success for students look like during this period?
 `, ask: true, force: true});
 
 
 // Try it!
-slides.push({ type: 'Try it!', text:
+  slides.push({ type: 'Try it!', text:
 `When you're ready, you'll go through a set of scenes.
 
 We'll fast forward to where students have already come in, you've launched the lesson successfully, and students are now working on the main activity.
@@ -131,7 +135,7 @@ Improvise how you would act as a substitute teacher in those moments.  Click and
 Ready to start?
 `});
 
-slides.push({ type: 'Try it!', text:
+  slides.push({ type: 'Try it!', text:
 `Greg and Jake are at desks next to each other.
 
 Jake: "Okay, so the first step is to stack our legos on top of each other."
@@ -139,7 +143,7 @@ Jake: "Okay, so the first step is to stack our legos on top of each other."
 Greg: "Yeah, let's write 'build a tower.'"
 `, ask: true});
 
-slides.push({ type: 'Try it!', text:
+  slides.push({ type: 'Try it!', text:
 `Molly and DeShawn are at a desk together.
 
 DeShawn: "Here, let me see the blocks.  We can make them into a shape like a bridge."
@@ -147,7 +151,7 @@ DeShawn: "Here, let me see the blocks.  We can make them into a shape like a bri
 Molly listens and watches.  DeShawn starts putting pieces together.
 `, ask: true});
 
-slides.push({ type: 'Try it!', text:
+  slides.push({ type: 'Try it!', text:
 `Terrell and Dustin are sitting next to each other.
 
 Terrell: "So this is just like a programming language, we have to make our own language to describe how to put the legos together.  That includes how to describe the pieces and the ways we can combine them."
@@ -156,7 +160,7 @@ Terrell sees you walk by and turns to ask a question.  Terrell: "Does our langua
 `, ask: true});
 
 
-slides.push({ type: 'Try it!', text:
+  slides.push({ type: 'Try it!', text:
 `Claire and Aaliyah are sitting next to each other.
 
 Claire: "What kind of shape should we make?"
@@ -169,14 +173,14 @@ Aaliyah: "Sure."
 `, ask: true});
 
 
-slides.push({ type: 'Try it!', text:
+  slides.push({ type: 'Try it!', text:
 `Terrell and Dustin are sitting next to each other.
 
 Terrell gets your attention.  Terrell: "Excuse me, but I know how to do this.  Can I just create my own language for this on my own?"
 `, ask: true});
 
 
-slides.push({ type: 'Try it!', text:
+  slides.push({ type: 'Try it!', text:
 `Claire and Aaliyah are sitting next to each other.
 
 Claire: "So put the red piece on the desk first.  Then put the yellow piece on... wait, I'm not sure how to say this."
@@ -187,7 +191,7 @@ Claire: "Yeah, I could show you but I'm not sure how to describe it."
 `, ask: true});
 
 
-slides.push({ type: 'Try it!', text:
+  slides.push({ type: 'Try it!', text:
 `Greg and Jake are at desks next to each other.
 
 Jake: "Cool, we're finished.  Let's give our directions to someone else so they can build our tower."
@@ -197,7 +201,7 @@ Greg: "Yeah, let's find DeShawn to trade with him."
 Jake: "Yeah I gotta ask him something too."
 `, ask: true});
 
-slides.push({ type: 'Try it!', text:
+  slides.push({ type: 'Try it!', text:
 `Molly and DeShawn are working together.
 
 Molly: "I wrote out all the directions you were saying."
@@ -205,11 +209,11 @@ Molly: "I wrote out all the directions you were saying."
 DeShawn: "Cool, our bridge is all set.  We're the best team in here."
 `, ask: true});
 
-slides.push({ type: 'Try it!', text:
+  slides.push({ type: 'Try it!', text:
 `Terrell is writing on a paper.  Dustin is watching what he is writing.
 `, ask: true});
 
-slides.push({ type: 'Try it!', text:
+  slides.push({ type: 'Try it!', text:
 `Claire and Aaliyah are sitting next to each other.
 
 Aaliyah: "So you're saying that we should do this, right?"
@@ -221,7 +225,7 @@ Claire: "Yeah, but it seems weird to talk about it."
 Aaliyah: "We could try say that you go through the colors like across a color wheel.  But that's not quite the right order."
 `, ask: true});
 
-slides.push({ type: 'Try it!', text:
+  slides.push({ type: 'Try it!', text:
 `Greg and Jake walk up to DeShawn and Molly.
 
 Greg: "Ready to trade?  What did you make a bridge?"
@@ -232,7 +236,7 @@ Molly nods.
 `, ask: true});
 
 
-slides.push({ type: 'Try it!', text:
+  slides.push({ type: 'Try it!', text:
 `Terrell and Dustin are together.
 
 Terrell: "Okay, we're finished.  Let's trade with Molly and DeShawn."
@@ -245,46 +249,73 @@ Dustin: "Are you guys ready to trade?"
 
 
 // Reflect
-slides.push({ type: 'Reflect', text:
+  slides.push({ type: 'Reflect', text:
 `That's the end of the simulation.  Thanks!
 
 Let's shift to reflecting on the lesson.
 `});
 
-slides.push({ type: 'Reflect', text:
+  if (setting === 'meredith') {
+    slides.push({ type: 'Reflect', text:
+`Before you finish, we have three questions about what you experienced in this simulation.
+
+After that, take a minute to write down what you'll share in class on Thursday.
+
+Also, for now please hold questions or feedback about this activity itself.
+`});
+  } else {
+    slides.push({ type: 'Reflect', text:
 `Before heading back to the group, we have three questions about what you experienced in this simulation.
 
 After that, you'll have a minute to think about the first group discussion question before heading back.
 
 Also, for now please hold questions or feedback about this activity itself.  We'll ask for that at the end.
 `});
+  } 
 
-slides.push({ type: 'Reflect', text:
+  slides.push({ type: 'Reflect', text:
 `During the simulation, how did you think about your role as a teacher?
 `, ask: true, force: true});
 
-slides.push({ type: 'Reflect', text:
+  slides.push({ type: 'Reflect', text:
 `How did different students experience the class differently?
 `, ask: true, force: true});
 
-slides.push({ type: 'Reflect', text:
+  slides.push({ type: 'Reflect', text:
 `Did you notice any social dynamics between students related to race, ethnicity, gender or class?
 `, ask: true, force: true});
 
-slides.push({ type: 'Reflect', el:
-<div>
-  <div>Finally, pick one student group to talk about during the group discussion.</div>
-  <br />
-  <div>In the group, you'll be asked to describe what you noticed, any assumptions you made, and how that shaped your interactions with students.</div>
-  <br />
-  <div>Feel free to take a minute or two to think about that, and then head on back!  If you're working online you can connect with other folks at <a target="_blank" href="https://twitter.com/search?q=%23https://twitter.com/search?q=%23TeacherPracticeSpaces">#TeacherPracticeSpaces</a>.</div>
-</div>
-});
+  if (setting === 'meredith') {
+    slides.push({ type: 'Reflect', el:
+      <div>
+        <div>Finally, pick one student group to talk about during the group discussion in class.</div>
+        <br />
+        <div>In class, you'll be asked to describe what you noticed, any assumptions you made, and how that shaped your interactions with those students.</div>
+        <br />
+        <div>Feel free to take a minute or two to think about that, write it down somewhere in preparation for class.  If you'd like, you can share online at <a target="_blank" href="https://twitter.com/search?q=%23https://twitter.com/search?q=%23TeacherPracticeSpaces">#TeacherPracticeSpaces</a>.</div>
+      </div>
+    });
+  } else {
+    slides.push({ type: 'Reflect', el:
+      <div>
+        <div>Finally, pick one student group to talk about during the group discussion.</div>
+        <br />
+        <div>In the group, you'll be asked to describe what you noticed, any assumptions you made, and how that shaped your interactions with students.</div>
+        <br />
+        <div>Feel free to take a minute or two to think about that, and then head on back!  If you're working online you can connect with other folks at <a target="_blank" href="https://twitter.com/search?q=%23https://twitter.com/search?q=%23TeacherPracticeSpaces">#TeacherPracticeSpaces</a>.</div>
+      </div>
+    });
+  }
 
+  return slides;
+}
 
 
 export const PairsScenario = {
   questionsFor(cohortKey) {
-    return slides;
+    return slidesForSetting('mixed');
+  },
+  meredithQuestionsFor(cohortKey) {
+    return slidesForSetting('meredith');
   }
 };

--- a/ui/src/message_popup/playtest/pairs_scenario_test.jsx
+++ b/ui/src/message_popup/playtest/pairs_scenario_test.jsx
@@ -1,0 +1,17 @@
+/* @flow weak */
+import {expect} from 'chai';
+
+import {PairsScenario} from './pairs_scenario.jsx';
+
+describe('PairsScenario', () => {
+  it('questionsFor', () => {    
+    expect(PairsScenario.questionsFor('foo').length).to.equal(29);
+  });
+
+  it('meredithQuestionsFor are different', () => {    
+    const meredithQuestions = PairsScenario.meredithQuestionsFor('foo');
+    const playtestQuestions = PairsScenario.questionsFor('foo');
+    expect(meredithQuestions.length).to.equal(29);
+    expect(JSON.stringify(meredithQuestions)).not.to.equal(JSON.stringify(playtestQuestions));
+  });
+});


### PR DESCRIPTION
This changes some of the context around the scenario for a class Thursday.  It's accessible at `/teachermoments/thursday`.  It also adds URL and client timestamp logging in `Api.logEvidence`.

# At the beginning
![screen shot 2017-03-21 at 4 46 02 pm](https://cloud.githubusercontent.com/assets/1056957/24170223/9374f028-0e56-11e7-91e2-724442cf3c94.png)
![screen shot 2017-03-21 at 4 46 30 pm](https://cloud.githubusercontent.com/assets/1056957/24170224/9375d506-0e56-11e7-969f-2ff97faf1c3e.png)

## At the end
![screen shot 2017-03-21 at 4 49 21 pm](https://cloud.githubusercontent.com/assets/1056957/24170226/937cb556-0e56-11e7-9443-f082d16f56ba.png)
![screen shot 2017-03-21 at 4 50 04 pm](https://cloud.githubusercontent.com/assets/1056957/24170225/937829e6-0e56-11e7-8532-b7099faf4664.png)
