### PR TITLE
Add global kill switch for reviewing responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "main": "server/index.js",
   "scripts": {
-    "dev": "READ_LOCAL_EVIDENCE=true DATABASE_URL=http://localhost:5432 NODE_ENV=development npm run start",
+    "dev": "READ_LOCAL_EVIDENCE=true IS_SENSITIVE_REVIEWING_ENABLED=true DATABASE_URL=http://localhost:5432 NODE_ENV=development npm run start",
     "start": "node server/index.js",
     "watch": "cd ui && npm run watch && cd ..",
     "heroku-prebuild": "cd ui && mkdir build && npm install",


### PR DESCRIPTION
Add `IS_SENSITIVE_REVIEWING_ENABLED` env variable to allow global kill switch disabling any reviewing capabilities.  The database rows can control this at a more granular level, but this is an additional layer since we typically only open reviews for very limited time windows right now.

Also adds some more server logging.