### PR TITLE
Fix bug in linear_session, add test to confirm fix

### DIFF
--- a/ui/src/message_popup/linear_session/linear_session.jsx
+++ b/ui/src/message_popup/linear_session/linear_session.jsx
@@ -14,13 +14,9 @@ export default React.createClass({
   propTypes: {
     questions: React.PropTypes.array.isRequired,
     questionEl: React.PropTypes.func.isRequired,
-    getNextQuestion: React.PropTypes.func,
     summaryEl: React.PropTypes.func.isRequired,
-    onLogMessage: React.PropTypes.func.isRequired
-  },
-
-  getDefaultProps() {
-    return {getNextQuestion: this.getNextQuestion};
+    onLogMessage: React.PropTypes.func.isRequired,
+    getNextQuestion: React.PropTypes.func
   },
 
   getInitialState() {
@@ -29,7 +25,7 @@ export default React.createClass({
     };
   },
 
-  getNextQuestion(questions, responses) {
+  defaultGetNextQuestion(questions, responses) {
     if (responses.length >= questions.length) {
       return null;
     }
@@ -70,7 +66,9 @@ export default React.createClass({
     const {questions} = this.props;
     const {responses} = this.state;
 
-    const question = this.props.getNextQuestion && this.props.getNextQuestion(questions, responses);
+    const question = (this.props.getNextQuestion)
+      ? this.props.getNextQuestion(questions, responses)
+      : this.defaultGetNextQuestion(questions, responses);
 
     if (!question) {
       return this.props.summaryEl(questions, responses);

--- a/ui/src/message_popup/linear_session/linear_session_test.jsx
+++ b/ui/src/message_popup/linear_session/linear_session_test.jsx
@@ -21,6 +21,41 @@ describe('<LinearSession />', ()=>{
     expect(wrapper.find(VelocityTransitionGroup)).to.have.length(1);
   });
 
+  it('respects getNextQuestion prop and passes that through to questionEl', ()=>{
+    const props = {
+      questions: InsubordinationScenarios.questionsFor(0),
+      questionEl: sinon.spy(),
+      summaryEl: sinon.spy(),
+      getNextQuestion: (questions, responses) => {
+        return 'foo';
+      },
+      onLogMessage: sinon.spy()
+    };
+    const wrapper = shallow(<LinearSession {...props} />);
+    expect(wrapper.find(VelocityTransitionGroup)).to.have.length(1);
+
+    expect(props.questionEl.getCalls().length).to.equal(1);
+    const renderCall = props.questionEl.getCall(0);
+    expect(renderCall.args.length).to.equal(3);
+    expect(renderCall.args[0]).to.equal('foo');
+  });
+
+  it('provides default getNextQuestion', ()=>{
+    const props = {
+      questions: ['bar', 'baz'],
+      questionEl: sinon.spy(),
+      summaryEl: sinon.spy(),
+      onLogMessage: sinon.spy()
+    };
+    const wrapper = shallow(<LinearSession {...props} />);
+    expect(wrapper.find(VelocityTransitionGroup)).to.have.length(1);
+
+    expect(props.questionEl.getCalls().length).to.equal(1);
+    const renderCall = props.questionEl.getCall(0);
+    expect(renderCall.args.length).to.equal(3);
+    expect(renderCall.args[0]).to.equal('bar');
+  });
+
   it('takes responses, logs them and updates state', ()=>{
     const props = {
       questions: InsubordinationScenarios.questionsFor(0),


### PR DESCRIPTION
This fixes a bug in https://github.com/mit-teaching-systems-lab/threeflows/pull/225, which affects all experience pages that don't provide `getNextQuestion` (eg., `/sub` endpoint).

@kesiena115 This is my bad, I think I gave you bad advice in the PR, this essentially restores it to the way you had done it originally where if there's no prop a default method is called.  I also added tests verifying this.