### PR TITLE
Prevent default for demos button

### DIFF
--- a/ui/src/home/home_page.jsx
+++ b/ui/src/home/home_page.jsx
@@ -11,6 +11,7 @@ export default React.createClass({
   displayName: 'HomePage',
 
   onTryItTapped(e) {
+    e.preventDefault();
     Routes.navigate('/demos');
   },
 


### PR DESCRIPTION
On mobile, the touch ripple leads to extra taps coming through after the re-rendering.