### PR TITLE
Fix version numbers on react-addons-test-utils

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -38,6 +38,7 @@
     "lodash": "^4.13.1",
     "material-ui": "^0.16.3",
     "react": "15.4.2",
+    "react-addons-test-utils": "15.4.2",
     "react-dom": "15.4.2",
     "react-media": "^1.3.2",
     "react-mini-router": "mit-teaching-systems-lab/react-mini-router",
@@ -66,7 +67,6 @@
     "flow-bin": "^0.30.0",
     "livereactload": "^2.2.3",
     "mocha": "^3.0.2",
-    "react-addons-test-utils": "^15.4.0",
     "react-proxy": "^1.1.8",
     "sinon": "^1.17.5",
     "watchify": "^3.7.0"


### PR DESCRIPTION
Fixing dependency issue that came up in https://travis-ci.org/mit-teaching-systems-lab/threeflows/builds/221351953#L137 merging https://github.com/mit-teaching-systems-lab/threeflows/pull/240.