### PR TITLE
Add notice about consent inline, and component for consent inline after scenario

### DIFF
--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -10,6 +10,7 @@ import AuthContainer from './auth_container.jsx';
 import VirtualSchoolPage from './virtual_school/virtual_school_page.jsx';
 import HomePage from './home/home_page.jsx';
 import DemosPage from './home/demos_page.jsx';
+import ConsentPage from './home/consent_page.jsx';
 import * as MessagePopup from './message_popup/index.js';
 
 
@@ -35,6 +36,7 @@ export default React.createClass({
   routes: {
     '/': 'home',
     '/demos': 'demos',
+    '/consent': 'consent',
 
     // Included in /demos, shared externally, or used in playtests
     '/teachermoments/original': 'messagePopup',
@@ -93,6 +95,10 @@ export default React.createClass({
 
   demos(query = {}) {
     return <DemosPage />;
+  },
+
+  consent(query = {}) {
+    return <ConsentPage />;
   },
 
   messagePopup(query = {}) {

--- a/ui/src/components/research_consent.jsx
+++ b/ui/src/components/research_consent.jsx
@@ -1,0 +1,101 @@
+/* @flow weak */
+import React from 'react';
+import RaisedButton from 'material-ui/RaisedButton';
+
+import * as Routes from '../routes.js';
+
+
+const STATUS = {
+  EXPLAINING: 'EXPLAINING',
+  CONTINUED: 'CONTINUED',
+  DECLINED: 'DECLINED'
+};
+
+
+// Show information and ask for consent
+export default React.createClass({
+  displayName: 'ResearchConsent',
+
+  propTypes: {
+    onLogMessage: React.PropTypes.func.isRequired
+  },
+
+  getInitialState() {
+    return {
+      status: STATUS.EXPLAINING
+    };
+  },
+
+  onContinue() {
+    this.props.onLogMessage('research_consent_has_continued');
+    this.setState({ status: STATUS.CONTINUED });
+  },
+
+  onDecline() {
+    this.props.onLogMessage('research_consent_has_declined');
+    this.setState({ status: STATUS.DECLINED });
+  },
+
+  render() {
+    const {status} = this.state;
+
+    return (
+      <div>
+        {status === STATUS.EXPLAINING && this.renderAsk()}
+        {status === STATUS.CONTINUED && this.renderForm()}
+        {status === STATUS.DECLINED && this.renderThanks()}
+      </div>
+    );
+  },
+
+  renderAsk() {
+    return (
+      <div style={styles.container}>
+        <div style={styles.instructions}>
+          <b>Consent for research</b>
+          <p>Educators and researchers in the <a target="_blank" href="http://tsl.mit.edu/">MIT Teaching Systems Lab</a> would like to use your responses here to improve this experience and learn how to better prepare teachers.</p>
+          <p>All data you enter is protected by <a target="_blank" href={Routes.readMoreAboutConsent()}>MIT's IRB review procedures</a>.  None of your personal information will be shared.</p>
+        </div>
+        <form onSubmit={this.onSubmit}>
+          <div style={styles.buttonRow}>
+            <RaisedButton
+              onTouchTap={this.onContinue}
+              secondary={true}
+              label="Show consent form" />
+            <RaisedButton
+              onTouchTap={this.onDecline}
+              label="Decline" />
+          </div>    
+        </form>
+      </div>
+    );
+  },
+
+  renderForm() {
+    return <iframe
+      src="https://docs.google.com/forms/d/e/1FAIpQLSdsSuLuAEAvBhxtRDuHXDrP1jj_tbeYLd9u3_aBGbLjO3BNRg/viewform?embedded=true"
+      width="100%"
+      height={600}
+      frameBorder={0}
+      marginHeight={0}
+      marginWidth={0}>Loading...</iframe>;
+  },
+
+  renderThanks() {
+    return <div style={styles.container}>Thanks!  Your responses will not be used for any research.</div>;
+  }
+});
+
+const styles = {
+  container: {
+    padding: 20
+  },
+  instructions: {
+    paddingBottom: 20,
+  },
+  buttonRow: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'flex-end'
+  }
+};

--- a/ui/src/components/research_consent.jsx
+++ b/ui/src/components/research_consent.jsx
@@ -50,23 +50,21 @@ export default React.createClass({
 
   renderAsk() {
     return (
-      <div style={styles.container}>
+      <div className="explain-consent" style={styles.container}>
         <div style={styles.instructions}>
           <b>Consent for research</b>
           <p>Educators and researchers in the <a target="_blank" href="http://tsl.mit.edu/">MIT Teaching Systems Lab</a> would like to use your responses here to improve this experience and learn how to better prepare teachers.</p>
           <p>All data you enter is protected by <a target="_blank" href={Routes.readMoreAboutConsent()}>MIT's IRB review procedures</a>.  None of your personal information will be shared.</p>
         </div>
-        <form onSubmit={this.onSubmit}>
-          <div style={styles.buttonRow}>
-            <RaisedButton
-              onTouchTap={this.onContinue}
-              secondary={true}
-              label="Show consent form" />
-            <RaisedButton
-              onTouchTap={this.onDecline}
-              label="Decline" />
-          </div>    
-        </form>
+        <div style={styles.buttonRow}>
+          <RaisedButton
+            onTouchTap={this.onContinue}
+            secondary={true}
+            label="Show consent form" />
+          <RaisedButton
+            onTouchTap={this.onDecline}
+            label="Decline" />
+        </div>
       </div>
     );
   },

--- a/ui/src/components/research_consent_test.jsx
+++ b/ui/src/components/research_consent_test.jsx
@@ -1,0 +1,24 @@
+/* @flow weak */
+import React from 'react';
+
+import {shallow} from 'enzyme';
+import {expect} from 'chai';
+import sinon from 'sinon';
+
+import RaisedButton from 'material-ui/RaisedButton';
+import ResearchConsent from './research_consent.jsx';
+
+
+function createProps() {
+  return {
+    onLogMessage: sinon.spy()
+  };
+}
+
+describe('<ResearchConsent />', ()=>{
+  it('renders', ()=>{
+    const props = createProps();
+    const wrapper = shallow(<ResearchConsent {...props} />);
+    expect(wrapper.find('.explain-consent').length).to.equal(1);
+  });
+});

--- a/ui/src/components/research_consent_test.jsx
+++ b/ui/src/components/research_consent_test.jsx
@@ -20,5 +20,6 @@ describe('<ResearchConsent />', ()=>{
     const props = createProps();
     const wrapper = shallow(<ResearchConsent {...props} />);
     expect(wrapper.find('.explain-consent').length).to.equal(1);
+    expect(wrapper.find(RaisedButton).length).to.equal(2);
   });
 });

--- a/ui/src/home/consent_page.jsx
+++ b/ui/src/home/consent_page.jsx
@@ -1,0 +1,36 @@
+/* @flow weak */
+import React from 'react';
+import uuid from 'uuid';
+
+import * as Api from '../helpers/api.js';
+import SessionFrame from '../message_popup/linear_session/session_frame.jsx';
+import ResearchConsent from '../components/research_consent.jsx';
+
+
+// A standalone consent page, inline
+export default React.createClass({
+  displayName: 'ConsentPage',
+
+  onResetSession(e) {
+    window.location.reload();
+  },
+
+  onLogMessage(type, response) {
+    const email = 'unknown@mit.edu';
+    
+    Api.logEvidence(type, {
+      ...response,
+      sessionId: uuid.v4(),
+      email,
+      name: email
+    });
+  },
+
+  render() {
+    return (
+      <SessionFrame onResetSession={this.onResetSession}>
+        <ResearchConsent onLogMessage={this.onLogMessage} />
+      </SessionFrame>
+    );
+  }
+});

--- a/ui/src/home/consent_page_test.jsx
+++ b/ui/src/home/consent_page_test.jsx
@@ -1,0 +1,15 @@
+/* @flow weak */
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from 'chai';
+
+import ConsentPage from './consent_page.jsx';
+import ResearchConsent from '../components/research_consent.jsx';
+
+
+describe('<ConsentPage />', () => {
+  it('renders', () => {
+    const wrapper = shallow(<ConsentPage />);
+    expect(wrapper.find(ResearchConsent).length).to.equal(1);
+  });
+});

--- a/ui/src/home/demos_page.jsx
+++ b/ui/src/home/demos_page.jsx
@@ -30,16 +30,16 @@ export default React.createClass({
           {this.renderScenarioItem(<a href="/teachermoments/sub">Computer science substitute</a>)}
           {this.renderScenarioItem(<a href="/teachermoments/csfair">Computer science projects</a>)}
           {this.renderScenarioItem(<a href="/teachermoments/danson">Parent meeting</a>)}
-          {this.renderScenarioItem(<a href="/teachermoments/discipline">Middle school classroom management</a>)}
+        </List>
+        <h3 style={styles.header}>Earlier prototypes</h3>
+        <List>
           {this.renderScenarioItem(<a href="/teachermoments/original">Choose your skill</a>)}
           {this.renderScenarioItem(<a href="/teachermoments/darius">Darius</a>)}
-        </List>
-        <h3 style={styles.header}>Early prototypes</h3>
-        <List>
+          {this.renderScenarioItem(<a href="/teachermoments/discipline">Middle school classroom management</a>)}
           {this.renderScenarioItem(<a href="/teachermoments/mentoring">Mentoring session</a>)}
           {this.renderScenarioItem(<a href="/teachermoments/alpha">Mini: Tired in class</a>)}
           {this.renderScenarioItem(<a href="/teachermoments/mindset">Mini: New student</a>)}
-          {this.renderScenarioItem(<a href="/teachermoments/twine">Twine: Greeting students</a>)}
+          {this.renderScenarioItem(<a href="/teachermoments/twine">Twine integration: Greeting students</a>)}
           {this.renderScenarioItem(<a href="/teachermoments/demo">Technical demo</a>)}
           {this.renderScenarioItem(<a href="/teachermoments/chat">Chat-based interface</a>)}
         </List>

--- a/ui/src/home/demos_page.jsx
+++ b/ui/src/home/demos_page.jsx
@@ -30,16 +30,16 @@ export default React.createClass({
           {this.renderScenarioItem(<a href="/teachermoments/sub">Computer science substitute</a>)}
           {this.renderScenarioItem(<a href="/teachermoments/csfair">Computer science projects</a>)}
           {this.renderScenarioItem(<a href="/teachermoments/danson">Parent meeting</a>)}
-        </List>
-        <h3 style={styles.header}>Earlier prototypes</h3>
-        <List>
+          {this.renderScenarioItem(<a href="/teachermoments/discipline">Middle school classroom management</a>)}
           {this.renderScenarioItem(<a href="/teachermoments/original">Choose your skill</a>)}
           {this.renderScenarioItem(<a href="/teachermoments/darius">Darius</a>)}
-          {this.renderScenarioItem(<a href="/teachermoments/discipline">Middle school classroom management</a>)}
+        </List>
+        <h3 style={styles.header}>Early prototypes</h3>
+        <List>
           {this.renderScenarioItem(<a href="/teachermoments/mentoring">Mentoring session</a>)}
           {this.renderScenarioItem(<a href="/teachermoments/alpha">Mini: Tired in class</a>)}
           {this.renderScenarioItem(<a href="/teachermoments/mindset">Mini: New student</a>)}
-          {this.renderScenarioItem(<a href="/teachermoments/twine">Twine integration: Greeting students</a>)}
+          {this.renderScenarioItem(<a href="/teachermoments/twine">Twine: Greeting students</a>)}
           {this.renderScenarioItem(<a href="/teachermoments/demo">Technical demo</a>)}
           {this.renderScenarioItem(<a href="/teachermoments/chat">Chat-based interface</a>)}
         </List>

--- a/ui/src/message_popup/linear_session/intro_with_email.jsx
+++ b/ui/src/message_popup/linear_session/intro_with_email.jsx
@@ -7,8 +7,11 @@ import RaisedButton from 'material-ui/RaisedButton';
 import Divider from 'material-ui/Divider';
 import TextField from 'material-ui/TextField';
 
+import * as Routes from '../../routes.js';
 
-// Show some introduction elements, and ask for email to continue
+
+// Show some introduction elements, note about consent, and ask for email
+// to continue.  Actual content is provided by `children`.
 export default React.createClass({
   displayName: 'IntroWithEmail',
 
@@ -40,11 +43,12 @@ export default React.createClass({
   render() {
     return (
       <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
-        <div style={{...styles.container, ...styles.instructions}}>
+        <div style={styles.instructions}>
           {this.props.children}
         </div>
         <Divider />
         <div style={{padding: 20}}>
+          <div>All data you enter is protected by <a target="_blank" href={Routes.readMoreAboutConsent()}>MIT's IRB review procedures</a>.  No personal information will be shared, and your responses can only be used for research if you consent afterward.</div>
           <form onSubmit={this.onSubmit}>
             <TextField
               name="email"
@@ -71,15 +75,13 @@ export default React.createClass({
 });
 
 const styles = {
-  container: {
-    fontSize: 20,
+  instructions: {
+    fontSize: 18,
     padding: 0,
     margin:0,
-    paddingBottom: 20
-  },
-  instructions: {
     paddingLeft: 20,
     paddingRight: 20,
+    paddingBottom: 10
   },
   buttonRow: {
     display: 'flex',

--- a/ui/src/message_popup/playtest/pairs_experience_page.jsx
+++ b/ui/src/message_popup/playtest/pairs_experience_page.jsx
@@ -32,6 +32,7 @@ export default React.createClass({
 
   propTypes: {
     query: React.PropTypes.shape({
+      cohort: React.PropTypes.string,
       p: React.PropTypes.string
     }).isRequired,
     isForMeredith: React.PropTypes.bool

--- a/ui/src/message_popup/playtest/pairs_experience_page.jsx
+++ b/ui/src/message_popup/playtest/pairs_experience_page.jsx
@@ -13,7 +13,7 @@ import ChoiceForBehaviorResponse from '../renderers/choice_for_behavior_response
 import MinimalOpenResponse from '../renderers/minimal_open_response.jsx';
 import type {QuestionT} from './pairs_scenario.jsx';
 import {PairsScenario} from './pairs_scenario.jsx';
-
+import ResearchConsent from '../../components/research_consent.jsx';
 
 
 type ResponseT = {
@@ -106,7 +106,7 @@ export default React.createClass({
     return <LinearSession
       questions={questions}
       questionEl={this.renderQuestionEl}
-      summaryEl={this.renderSummaryEl}
+      summaryEl={this.renderClosingEl}
       onLogMessage={this.onLogMessage}
     />;
   },
@@ -153,14 +153,8 @@ export default React.createClass({
     );
   },
 
-  renderSummaryEl(questions:[QuestionT], responses:[ResponseT]) {
-    const {isForMeredith} = this.props;
-
-    return (
-      <div style={{padding: 20}}>
-        <div>Thanks!</div>
-        {!isForMeredith && <div style={{paddingTop: 20}}>You can close the computer and head on back to the group.</div>}
-      </div>
-    );
+  renderClosingEl(questions:[QuestionT], responses:[ResponseT]) {
+    const {email} = this.state;
+    return <ResearchConsent email={email} onLogMessage={this.onLogMessage} />;
   }
 });

--- a/ui/src/message_popup/playtest/pairs_experience_page.jsx
+++ b/ui/src/message_popup/playtest/pairs_experience_page.jsx
@@ -31,8 +31,10 @@ export default React.createClass({
   displayName: 'PairsExperiencePage',
 
   propTypes: {
-    query: React.PropTypes.object.isRequired,
-    isForMeredith: React.PropTypes.bool,
+    query: React.PropTypes.shape({
+      p: React.PropTypes.string
+    }).isRequired,
+    isForMeredith: React.PropTypes.bool
   },
 
   contextTypes: {
@@ -63,9 +65,12 @@ export default React.createClass({
   onStart(email) {
     const {cohortKey} = this.state;
     const {isForMeredith} = this.props;
-    const questions = (isForMeredith)
+    const allQuestions = (isForMeredith)
       ? PairsScenario.meredithQuestionsFor(cohortKey)
       : PairsScenario.questionsFor(cohortKey);
+
+    const startQuestionIndex = this.props.query.p || 0; // for testing or demoing
+    const questions = allQuestions.slice(startQuestionIndex);
     const questionsHash = hash(JSON.stringify(questions));
     this.setState({
       email,

--- a/ui/src/routes.js
+++ b/ui/src/routes.js
@@ -54,6 +54,10 @@ export function messagePopupUploadWavPath() {
   return '/teachermoments/wav';
 }
 
+export function readMoreAboutConsent() {
+  return 'https://couhes.mit.edu/';
+}
+
 
 /* Services */
 type EvidencePathT = {app:string, type:string, version:number};


### PR DESCRIPTION
This adds a notice about consent to `IntroWithEmail`, so that this is shown to all participants even if they arrive to the experience self-serve or inbound from an article or elsewhere.  It adds `ResearchConsent` that shows the consent form inline and adds that to the end of the CS substitute scenario.

Finally, it also adds an inline consent form that can be used standalone, if this conflicts with the flow of doing the experience, reflecting and then rejoining the group.  In that case, the check at the end can be an additional reminder.

## Notice shown up front
![screen shot 2017-04-12 at 9 47 27 am](https://cloud.githubusercontent.com/assets/1056957/24964131/66e19420-1f6e-11e7-922b-1e8c6cee8723.png)

## Explanation at the end of the scenario
![screen shot 2017-04-12 at 10 43 20 am](https://cloud.githubusercontent.com/assets/1056957/24964118/5ca3b600-1f6e-11e7-9d65-f5bf7ea6e101.png)

## Completing consent form inline
![screen shot 2017-04-12 at 10 44 51 am](https://cloud.githubusercontent.com/assets/1056957/24964098/51e26ffe-1f6e-11e7-8370-2d50de862624.png)
![screen shot 2017-04-12 at 10 44 33 am](https://cloud.githubusercontent.com/assets/1056957/24964102/5493ac7c-1f6e-11e7-9c6e-41d62b416938.png)

## If the user declines
![screen shot 2017-04-12 at 10 44 42 am](https://cloud.githubusercontent.com/assets/1056957/24964107/56b55564-1f6e-11e7-8194-f48e369e4778.png)

## Standalone at /consent
![screen shot 2017-04-12 at 11 06 37 am](https://cloud.githubusercontent.com/assets/1056957/24964831/4dda30ca-1f70-11e7-84d1-3dc0def7eaac.png)
