### PR TITLE
Tweak consent copy

### DIFF
--- a/ui/src/components/research_consent.jsx
+++ b/ui/src/components/research_consent.jsx
@@ -53,8 +53,9 @@ export default React.createClass({
       <div className="explain-consent" style={styles.container}>
         <div style={styles.instructions}>
           <b>Consent for research</b>
-          <p>Educators and researchers in the <a target="_blank" href="http://tsl.mit.edu/">MIT Teaching Systems Lab</a> would like to use your responses here to improve this experience and learn how to better prepare teachers.</p>
+          <p>Educators and researchers in the <a target="_blank" href="http://tsl.mit.edu/">MIT Teaching Systems Lab</a> would like to include your responses in research about improving this experience and learning how to better prepare teachers for the classroom.</p>
           <p>All data you enter is protected by <a target="_blank" href={Routes.readMoreAboutConsent()}>MIT's IRB review procedures</a>.  None of your personal information will be shared.</p>
+          <p>More details are available in the consent form itself.</p>
         </div>
         <div style={styles.buttonRow}>
           <RaisedButton

--- a/ui/src/message_popup/linear_session/intro_with_email.jsx
+++ b/ui/src/message_popup/linear_session/intro_with_email.jsx
@@ -47,7 +47,7 @@ export default React.createClass({
           {this.props.children}
         </div>
         <Divider />
-        <div style={{padding: 20}}>
+        <div style={{...styles.instructions, padding: 20}}>
           <div>All data you enter is protected by <a target="_blank" href={Routes.readMoreAboutConsent()}>MIT's IRB review procedures</a>.  No personal information will be shared, and your responses can only be used for research if you consent afterward.</div>
           <form onSubmit={this.onSubmit}>
             <TextField

--- a/ui/src/message_popup/linear_session/intro_with_email.jsx
+++ b/ui/src/message_popup/linear_session/intro_with_email.jsx
@@ -43,31 +43,33 @@ export default React.createClass({
   render() {
     return (
       <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
-        <div style={styles.instructions}>
-          {this.props.children}
-        </div>
-        <Divider />
-        <div style={{...styles.instructions, padding: 20}}>
-          <div>All data you enter is protected by <a target="_blank" href={Routes.readMoreAboutConsent()}>MIT's IRB review procedures</a>.  No personal information will be shared, and your responses can only be used for research if you consent afterward.</div>
-          <form onSubmit={this.onSubmit}>
-            <TextField
-              name="email"
-              style={{width: '100%'}}
-              underlineShow={false}
-              floatingLabelText="What's your email address?"
-              value={this.state.email}
-              onChange={this.onTextChanged}
-              rows={2} />
-            <div style={styles.buttonRow}>
-              <RaisedButton
-                disabled={this.state.email === ''}
-                onTouchTap={this.onDone}
-                type="submit"
-                style={styles.button}
-                secondary={true}
-                label="Start" />
-            </div>    
-          </form>
+        <div>
+          <div style={styles.instructions}>
+            {this.props.children}
+          </div>
+          <Divider />
+          <div style={{...styles.instructions, padding: 20}}>
+            <div>All data you enter is protected by <a target="_blank" href={Routes.readMoreAboutConsent()}>MIT's IRB review procedures</a>.  No personal information will be shared, and your responses can only be used for research if you consent afterward.</div>
+            <form onSubmit={this.onSubmit}>
+              <TextField
+                name="email"
+                style={{width: '100%'}}
+                underlineShow={false}
+                floatingLabelText="What's your email address?"
+                value={this.state.email}
+                onChange={this.onTextChanged}
+                rows={2} />
+              <div style={styles.buttonRow}>
+                <RaisedButton
+                  disabled={this.state.email === ''}
+                  onTouchTap={this.onDone}
+                  type="submit"
+                  style={styles.button}
+                  secondary={true}
+                  label="Start" />
+              </div>    
+            </form>
+          </div>
         </div>
       </VelocityTransitionGroup>
     );


### PR DESCRIPTION
Also wrap `IntroWithEmail` so there's only one element on the page that animates, not two independent elements.

<img width="372" alt="screen shot 2017-04-12 at 12 30 35 pm" src="https://cloud.githubusercontent.com/assets/1056957/24968683/045a2cf0-1f7c-11e7-8a59-3839d192ffff.png">


