### PR TITLE
Add initial Jayden counseling prototype

### DIFF
--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -54,6 +54,7 @@ export default React.createClass({
     '/teachermoments/chat': 'chatPrototype',
     '/teachermoments/csfair': 'messagePopupCsFair',
     '/teachermoments/bubblesort': 'messagePopupBubbleSort',
+    '/teachermoments/jayden': 'jaydenScenario',
 
     // Specific cohorts
     '/teachermoments/csp': 'messagePopupCSP',
@@ -129,6 +130,10 @@ export default React.createClass({
 
   disciplinePlaytest(query = {}) {
     return <MessagePopup.DisciplinePage query={{}}/>;
+  },
+
+  jaydenScenario(query = {}) {
+    return <MessagePopup.JaydenExperiencePage query={{}}/>;
   },
 
   messagePopupBubbleSort(query = {}) {

--- a/ui/src/message_popup/index.js
+++ b/ui/src/message_popup/index.js
@@ -15,6 +15,7 @@ import PairsExperiencePage from './playtest/pairs_experience_page.jsx';
 import DariusExperiencePage from './playtest/darius_experience_page.jsx';
 import CsFairExperiencePage from './playtest/cs_fair_experience_page.jsx';
 import BubbleSortExperiencePage from './playtest/bubble_sort_experience_page.jsx';
+import JaydenExperiencePage from './playtest/jayden_experience_page.jsx';
 
 import QuestionsPage from './author/questions_page.jsx';
 import EditQuestionPage from './author/edit_question_page.jsx';
@@ -35,6 +36,7 @@ export {
   MentoringPage,
   MindsetPage,
   BubbleSortExperiencePage,
+  JaydenExperiencePage,
   InsubordinationExperiment,
   PairsExperiencePage,
   DariusExperiencePage,

--- a/ui/src/message_popup/playtest/bubble_sort_experience_page.jsx
+++ b/ui/src/message_popup/playtest/bubble_sort_experience_page.jsx
@@ -8,9 +8,7 @@ import LinearSession from '../linear_session/linear_session.jsx';
 import SessionFrame from '../linear_session/session_frame.jsx';
 import IntroWithEmail from '../linear_session/intro_with_email.jsx';
 
-import MixedQuestion from '../renderers/mixed_question.jsx';
-import ChoiceForBehaviorResponse from '../renderers/choice_for_behavior_response.jsx';
-import MinimalOpenResponse from '../renderers/minimal_open_response.jsx';
+import QuestionInterpreter from '../renderers/question_interpreter.jsx';
 import type {QuestionT} from './pairs_scenario.jsx';
 import {BubbleSortScenario} from './bubble_sort_scenario.jsx';
 import ResearchConsent from '../../components/research_consent.jsx';
@@ -117,44 +115,11 @@ export default React.createClass({
     );
   },
 
-  // Show overview and context, ask for open response for scenario.
   renderQuestionEl(question:QuestionT, onLog, onResponseSubmitted) {
-    return (
-      <div>
-        <MixedQuestion question={question} />
-        {this.renderInteractionEl(question, onLog, onResponseSubmitted)}
-      </div>
-    );
-  },
-
-  renderInteractionEl(question, onLog, onResponseSubmitted) {
-    const key = JSON.stringify(question);
-    if (question.open) {
-      return <MinimalOpenResponse
-        key={key}
-        responsePrompt=""
-        recordText="Click then speak"
-        onLogMessage={onLog}
-        forceResponse={question.force || false}
-        onResponseSubmitted={onResponseSubmitted}
-      />;
-    }
-
-    if (question.choices && question.choices.length > 0) {
-      return <ChoiceForBehaviorResponse
-        key={key}
-        choices={question.choices}
-        onLogMessage={onLog}
-        onResponseSubmitted={onResponseSubmitted}
-      />;
-    }
-
-    return <ChoiceForBehaviorResponse
-      key={key}
-      choices={['OK']}
-      onLogMessage={onLog}
-      onResponseSubmitted={onResponseSubmitted}
-    />;
+    return <QuestionInterpreter
+      question={question}
+      onLog={onLog}
+      onResponseSubmitted={onResponseSubmitted} />;
   },
 
   renderClosingEl(questions:[QuestionT], responses:[ResponseT]) {

--- a/ui/src/message_popup/playtest/danson_experience_page.jsx
+++ b/ui/src/message_popup/playtest/danson_experience_page.jsx
@@ -121,7 +121,7 @@ export default React.createClass({
           <p>You will go through a couple of activities that are designed to make you better prepared for a potentially difficult parent-teacher conference you might experience as a new teacher.</p>
           <p>You need to use a computer/laptop that has a mic because you will need to do audio recordings.</p>
           <p>This simulation is based on work that has been done by Professor Benjamin Dotger at Syracuse University as documented in his book: "I Had No Idea" Clinical Simulations for Teacher Development.</p>
-          <p>This activity would take about 30minutes.</p>
+          <p>This activity would take about 30 minutes.</p>
         </div>
       </IntroWithEmail>
     );

--- a/ui/src/message_popup/playtest/jayden_experience_page.jsx
+++ b/ui/src/message_popup/playtest/jayden_experience_page.jsx
@@ -1,0 +1,130 @@
+/* @flow weak */
+import React from 'react';
+import uuid from 'uuid';
+
+import * as Api from '../../helpers/api.js';
+import hash from '../../helpers/hash.js';
+import LinearSession from '../linear_session/linear_session.jsx';
+import SessionFrame from '../linear_session/session_frame.jsx';
+import IntroWithEmail from '../linear_session/intro_with_email.jsx';
+
+import QuestionInterpreter from '../renderers/question_interpreter.jsx';
+import type {QuestionT} from './pairs_scenario.jsx';
+import JaydenScenario from './jayden_scenario.jsx';
+import ResearchConsent from '../../components/research_consent.jsx';
+
+type ResponseT = {
+  choice:string,
+  question:QuestionT
+};
+
+
+
+// This is a scenario around bubble sort and classroom management.
+export default React.createClass({
+  displayName: 'JaydenExperiencePage',
+
+  propTypes: {
+    query: React.PropTypes.shape({
+      cohort: React.PropTypes.string,
+      p: React.PropTypes.string
+    }).isRequired
+  },
+
+  contextTypes: {
+    auth: React.PropTypes.object.isRequired
+  },
+
+  // Cohort comes from URL
+  getInitialState() {
+    const contextEmail = this.context.auth.userProfile.email;
+    const email = contextEmail === "unknown@mit.edu" ? '' : contextEmail;
+    const cohortKey = this.props.query.cohort || 'default';
+
+    return {
+      email,
+      cohortKey,
+      questions: null,
+      sessionId: uuid.v4()
+    };
+  },
+
+  // Making questions from the cohort
+  onStart(email) {
+    const {cohortKey} = this.state;
+    const allQuestions = JaydenScenario.questionsFor(cohortKey);
+
+    const startQuestionIndex = this.props.query.p || 0; // for testing or demoing
+    const questions = allQuestions.slice(startQuestionIndex);
+    const questionsHash = hash(JSON.stringify(questions));
+    this.setState({
+      email,
+      questions,
+      questionsHash
+    });
+  },
+
+  onResetSession() {
+    this.setState(this.getInitialState());
+  },
+
+  onLogMessage(type, response:ResponseT) {
+    const {email, cohortKey, sessionId, questionsHash} = this.state;
+    
+    Api.logEvidence(type, {
+      ...response,
+      sessionId,
+      email,
+      cohortKey,
+      questionsHash,
+      name: email
+    });
+  },
+
+  render() {
+    return (
+      <SessionFrame onResetSession={this.onResetSession}>
+        {this.renderContent()}
+      </SessionFrame>
+    );
+  },
+
+  renderContent() {
+    const {questions} = this.state;
+    if (!questions) return this.renderIntro();
+
+    return <LinearSession
+      questions={questions}
+      questionEl={this.renderQuestionEl}
+      summaryEl={this.renderClosingEl}
+      onLogMessage={this.onLogMessage}
+    />;
+  },
+
+
+  renderIntro() {
+    return (
+      <IntroWithEmail defaultEmail={this.state.email} onDone={this.onStart}>
+        <div>
+          <p>Welcome!</p>
+          <p>This is an interactive case study simulating a conversation with a high school computer science student.</p>
+          <p>You'll review the context on the scenario, share what you anticipate will happen, and then try it out!  Afterward you'll reflect before heading back to debrief with the group or share online.</p>
+          <p>Please use <a href="https://www.google.com/chrome/">Chrome</a> on a laptop or desktop computer.</p>
+        </div>
+      </IntroWithEmail>
+    );
+  },
+
+  // Show overview and context, ask for open response for scenario.
+  renderQuestionEl(question:QuestionT, onLog, onResponseSubmitted) {
+    return <QuestionInterpreter
+        question={question}
+        onLog={onLog}
+        onResponseSubmitted={onResponseSubmitted} />;
+  },
+
+  renderClosingEl(questions:[QuestionT], responses:[ResponseT]) {
+    const {email} = this.state;
+    return <ResearchConsent email={email} onLogMessage={this.onLogMessage} />;
+  }
+});

--- a/ui/src/message_popup/playtest/jayden_experience_page.jsx
+++ b/ui/src/message_popup/playtest/jayden_experience_page.jsx
@@ -115,12 +115,11 @@ export default React.createClass({
     );
   },
 
-  // Show overview and context, ask for open response for scenario.
   renderQuestionEl(question:QuestionT, onLog, onResponseSubmitted) {
     return <QuestionInterpreter
-        question={question}
-        onLog={onLog}
-        onResponseSubmitted={onResponseSubmitted} />;
+      question={question}
+      onLog={onLog}
+      onResponseSubmitted={onResponseSubmitted} />;
   },
 
   renderClosingEl(questions:[QuestionT], responses:[ResponseT]) {

--- a/ui/src/message_popup/playtest/jayden_scenario.jsx
+++ b/ui/src/message_popup/playtest/jayden_scenario.jsx
@@ -1,0 +1,145 @@
+/* @flow weak */
+import React from 'react';
+
+/*
+This file defines the content for the counseling scenario around talking to Jayden.
+*/
+
+export type QuestionT = {
+  type:string, // Used as a label
+  text:string,
+  open:?bool, // Ask for open-ended user response
+  choices:?bool // Forced-choice response
+};
+
+
+function slidesFor(cohortKey) {
+  const slides:[QuestionT] = [];
+
+  slides.push({ type: 'Overview', el:
+  <div>
+    <div>1. Review context</div>
+    <div>Imagine yourself in the particular school and classroom.  You won't know all the answers, and will have to improvise and adapt to make the best of the situation.</div>
+    <br />
+    <div>2. Anticipate</div>
+    <div>Before starting the simulation, answer a few questions about what might happen.  You shouldn't have an in-depth understanding, but do your best to anticipate what might happen.</div>
+    <br />
+    <div>3. Try it!</div>
+    <div>When you're ready, you'll go through a set of short scenes that simulate interactions between you and a student.</div>
+    <br />
+    <div>4. Reflect</div>
+    <div>Finally, you'll reflect on your experience.</div>
+    <br />
+    <div>5. Discussion</div>
+    <div>When you're all done here, head back to the classroom to rejoin the group.  If you're online, connect with others at <a target="_blank" href="https://twitter.com/search?q=%23https://twitter.com/search?q=%23TeacherPracticeSpaces">#TeacherPracticeSpaces</a>.</div>
+  </div>
+  });
+
+
+// Context
+  slides.push({ type: 'Context', text:
+`In this scenario, you are teaching AP Computer Science Principles in high school.
+`});
+
+  slides.push({ type: 'Context', text:
+`You're currently in the middle of the semester.
+
+You've noticed one of your students, Jayden, is not participating in class discussion as much as they used to and has taken on passive roles during in-class activities.
+
+Over the past month, Jayden has submitted homework assignments late and incomplete, causing their overall grade to drop from a B to a low C.
+
+`});
+
+  slides.push({ type: 'Context', text:
+`In response to Jayden's recent behavior and academic performance, you've decided to engage Jayden'in a one-on-one discussion outside of class to learn more about what's going on.
+`});
+
+
+// Anticipate
+  slides.push({ type: 'Anticipate', text:
+`Before you begin, we have three questions about what you anticipate.
+`});
+
+  slides.push({ type: 'Anticipate', text:
+`What do you anticipate will actually happen during the one-on-one?
+`, force: true, open: true});
+
+  slides.push({ type: 'Anticipate', text:
+`What would be the first thing you’d say to Jayden?
+`, force: true, open: true});
+
+
+// Try it!
+  slides.push({ type: 'Try it!', text:
+`When you're ready, you'll go through a set of scenes that simulate the conversation between you and Jayden.
+
+Improvise how you would act as a teacher, even if you don't have all the right answers or know the perfect thing to say.
+
+Click and speak aloud the words you'd say to the student.
+
+
+Ready to start?
+`});
+
+  slides.push({ type: 'Try it!', text:
+`Jayden: "So what's up?"
+`, open: true, force: true});
+
+  slides.push({ type: 'Try it!', text:
+`Jayden: "I only took this class because nothing else worked in my schedule, which is why I didn’t switch into another class at the beginning of the semester."
+`, open: true, force: true});
+
+  slides.push({ type: 'Try it!', text:
+`Jayden: "I want to go to college and be a Music Studies major. I don’t see how that’s related to computer science."
+`, open: true, force: true});
+
+  slides.push({ type: 'Try it!', text:
+`Jayden: "I really want to be a singer. What does computer science have to do with singing?"
+`, open: true, force: true});
+
+  slides.push({ type: 'Try it!', text:
+`Jayden: "I don’t really see people like me working with computers anyways."
+`, open: true, force: true});
+
+
+
+// Reflect
+  slides.push({ type: 'Reflect', text:
+`That's the end of the simulation.  Thanks!
+
+Before heading back to the group, let's shift to reflecting on what happened.
+`});
+
+  slides.push({ type: 'Reflect', text:
+`What are your initial thoughts and feelings about your one-on-one with Jayden?
+`, force: true, open: true});
+
+  slides.push({ type: 'Reflect', text:
+`How effective do you think you were in responding to Jayden's statements?
+`, force: true, open: true});
+
+  slides.push({ type: 'Reflect', text:
+`How would you support Jayden following this conversation?
+`, force: true, open: true});
+
+  slides.push({ type: 'Reflect', text:
+`Would you do anything differently if a similar situation arose with another student?  Please elaborate.
+`, force: true, open: true});
+
+  slides.push({ type: 'Reflect', el:
+    <div>
+      <div>Finally, pick one moment to talk about during the group discussion.</div>
+      <br />
+      <div>Feel free to take a minute or two to think about that, and then head on back!  If you're working online you can connect with other folks at <a target="_blank" href="https://twitter.com/search?q=%23https://twitter.com/search?q=%23TeacherPracticeSpaces">#TeacherPracticeSpaces</a>.</div>
+    </div>
+  });
+
+  return slides;
+}
+
+
+export default {
+  questionsFor(cohortKey) {
+    return slidesFor(cohortKey);
+  }
+};

--- a/ui/src/message_popup/playtest/jayden_scenario.jsx
+++ b/ui/src/message_popup/playtest/jayden_scenario.jsx
@@ -42,11 +42,11 @@ function slidesFor(cohortKey) {
 `});
 
   slides.push({ type: 'Context', text:
-`You're currently in the middle of the semester.
+`You're currently in the fourth week of the semester.
 
-You've noticed one of your students, Jayden, is not participating in class discussion as much as they used to and has taken on passive roles during in-class activities.
+You've noticed one of your students, Jayden, is not participating in class discussion as much as they did at first and has taken on passive roles during in-class activities.
 
-Over the past month, Jayden has submitted homework assignments late and incomplete, causing their overall grade to drop from a B to a low C.
+Jayden has also submitted a few homework assignments late and incomplete, causing their overall grade to drop from a B to a low C.
 
 `});
 

--- a/ui/src/message_popup/playtest/turner_experience_page.jsx
+++ b/ui/src/message_popup/playtest/turner_experience_page.jsx
@@ -117,7 +117,7 @@ export default React.createClass({
           <p>You will go through a couple of activities that are designed to make you better prepared for a potentially difficult parent-teacher conference you might experience as a new teacher.</p>
           <p>You need to use a computer/laptop that has a mic because you will need to do audio recordings.</p>
           <p>This simulation is based on work that has been done by Professor Benjamin Dotger at Syracuse University as documented in his book: "I Had No Idea" Clinical Simulations for Teacher Development.</p>
-          <p>This activity would take about 30minutes.</p>
+          <p>This activity would take about 30 minutes.</p>
         </div>
       </IntroWithEmail>
     );

--- a/ui/src/message_popup/renderers/question_interpreter.jsx
+++ b/ui/src/message_popup/renderers/question_interpreter.jsx
@@ -1,0 +1,59 @@
+/* @flow weak */
+import React from 'react';
+
+import MixedQuestion from '../renderers/mixed_question.jsx';
+import ChoiceForBehaviorResponse from '../renderers/choice_for_behavior_response.jsx';
+import MinimalOpenResponse from '../renderers/minimal_open_response.jsx';
+
+
+
+// This renders a question and an interaction.
+export default React.createClass({
+  displayName: 'QuestionInterpreter',
+  
+  propTypes: {
+    question: React.PropTypes.object.isRequired,
+    onLog: React.PropTypes.func.isRequired,
+    onResponseSubmitted: React.PropTypes.func.isRequired
+  },
+
+  render() {
+    const {question, onLog, onResponseSubmitted} = this.props;
+    return (
+      <div>
+        <MixedQuestion question={question} />
+        {this.renderInteractionEl(question, onLog, onResponseSubmitted)}
+      </div>
+    );
+  },
+
+  renderInteractionEl(question, onLog, onResponseSubmitted) {
+    const key = JSON.stringify(question);
+    if (question.open) {
+      return <MinimalOpenResponse
+        key={key}
+        responsePrompt=""
+        recordText="Click then speak"
+        onLogMessage={onLog}
+        forceResponse={question.force || false}
+        onResponseSubmitted={onResponseSubmitted}
+      />;
+    }
+
+    if (question.choices && question.choices.length > 0) {
+      return <ChoiceForBehaviorResponse
+        key={key}
+        choices={question.choices}
+        onLogMessage={onLog}
+        onResponseSubmitted={onResponseSubmitted}
+      />;
+    }
+
+    return <ChoiceForBehaviorResponse
+      key={key}
+      choices={['OK']}
+      onLogMessage={onLog}
+      onResponseSubmitted={onResponseSubmitted}
+    />;
+  }
+});


### PR DESCRIPTION
Adds the initial counseling prototype from KJ's slides.  Also factor out `QuestionInterpreter` for re-use to standardize some of the question formats.

Excerpt:
<img width="372" alt="screen shot 2017-06-19 at 6 29 15 pm" src="https://user-images.githubusercontent.com/1056957/27308652-cac8db8a-551d-11e7-9575-4280c0eba320.png">
