### PR TITLE
Add audio and text summary screen to Jayden scenario

### DIFF
--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -125,19 +125,19 @@ export default React.createClass({
   },
 
   alphaPlaytest(query = {}) {
-    return <MessagePopup.InsubordinationPage query={{}}/>;
+    return <MessagePopup.InsubordinationPage query={query}/>;
   },
 
   disciplinePlaytest(query = {}) {
-    return <MessagePopup.DisciplinePage query={{}}/>;
+    return <MessagePopup.DisciplinePage query={query} />;
   },
 
   jaydenScenario(query = {}) {
-    return <MessagePopup.JaydenExperiencePage query={{}}/>;
+    return <MessagePopup.JaydenExperiencePage query={query} />;
   },
 
   messagePopupBubbleSort(query = {}) {
-    return <MessagePopup.BubbleSortExperiencePage query={{}}/>;
+    return <MessagePopup.BubbleSortExperiencePage query={query} />;
   },
 
   turk0000(query = {}) {

--- a/ui/src/message_popup/linear_session/linear_session.jsx
+++ b/ui/src/message_popup/linear_session/linear_session.jsx
@@ -32,20 +32,26 @@ export default React.createClass({
     return questions[responses.length];
   },
 
+  mergedResponse(rawResponse, question) {
+    return {...rawResponse, question};
+  },
+
   onResetSession() {
     this.setState(this.getInitialState());
   },
 
   // Mixes in question to payload
   onLogMessageWithQuestion(question, type, rawResponse) {
-    this.props.onLogMessage(type, {...rawResponse, question});
+    const mergedResponse = this.mergedResponse(rawResponse, question);
+    this.props.onLogMessage(type, mergedResponse);
   },
 
   // Logs and transitions
-  onResponseSubmitted(question, response) {
-    this.onLogMessageWithQuestion(question, 'on_response_submitted', response);
+  onResponseSubmitted(question, rawResponse) {
+    this.onLogMessageWithQuestion(question, 'on_response_submitted', rawResponse);
+    const mergedResponse = this.mergedResponse(rawResponse, question);
     this.setState({
-      responses: this.state.responses.concat(response)
+      responses: this.state.responses.concat(mergedResponse)
     });
   },
 

--- a/ui/src/message_popup/linear_session/linear_session_test.jsx
+++ b/ui/src/message_popup/linear_session/linear_session_test.jsx
@@ -56,7 +56,7 @@ describe('<LinearSession />', ()=>{
     expect(renderCall.args[0]).to.equal('bar');
   });
 
-  it('takes responses, logs them and updates state', ()=>{
+  it('takes responses, logs them with question merged, and updates state', ()=>{
     const props = {
       questions: InsubordinationScenarios.questionsFor(0),
       questionEl: sinon.spy(),
@@ -64,8 +64,11 @@ describe('<LinearSession />', ()=>{
       onLogMessage: sinon.spy()
     };
     const wrapper = shallow(<LinearSession {...props} />);
-    wrapper.instance().onResponseSubmitted({}, 'black_box_response');
-    expect(wrapper.instance().state.responses).to.deep.equal(['black_box_response']);
+    wrapper.instance().onResponseSubmitted({ q: 'bar' }, { foo: 'black_box_response' });
+    expect(wrapper.instance().state.responses).to.deep.equal([{
+      question: { q: 'bar' },
+      foo: 'black_box_response'
+    }]);
     expect(props.onLogMessage.callCount).to.equal(1);
   });
 });

--- a/ui/src/message_popup/playtest/jayden_experience_page.jsx
+++ b/ui/src/message_popup/playtest/jayden_experience_page.jsx
@@ -11,7 +11,7 @@ import IntroWithEmail from '../linear_session/intro_with_email.jsx';
 import QuestionInterpreter from '../renderers/question_interpreter.jsx';
 import type {QuestionT} from './pairs_scenario.jsx';
 import JaydenScenario from './jayden_scenario.jsx';
-import ResearchConsent from '../../components/research_consent.jsx';
+import AudioResponseSummary from '../renderers/audio_response_summary.jsx';
 
 type ResponseT = {
   choice:string,
@@ -123,7 +123,6 @@ export default React.createClass({
   },
 
   renderClosingEl(questions:[QuestionT], responses:[ResponseT]) {
-    const {email} = this.state;
-    return <ResearchConsent email={email} onLogMessage={this.onLogMessage} />;
+    return <AudioResponseSummary responses={responses} />;
   }
 });

--- a/ui/src/message_popup/playtest/jayden_scenario.jsx
+++ b/ui/src/message_popup/playtest/jayden_scenario.jsx
@@ -127,14 +127,6 @@ Before heading back to the group, let's shift to reflecting on what happened.
 `Would you do anything differently if a similar situation arose with another student?  Please elaborate.
 `, force: true, open: true});
 
-  slides.push({ type: 'Reflect', el:
-    <div>
-      <div>Finally, pick one moment to talk about during the group discussion.</div>
-      <br />
-      <div>Feel free to take a minute or two to think about that, and then head on back!  If you're working online you can connect with other folks at <a target="_blank" href="https://twitter.com/search?q=%23https://twitter.com/search?q=%23TeacherPracticeSpaces">#TeacherPracticeSpaces</a>.</div>
-    </div>
-  });
-
   return slides;
 }
 

--- a/ui/src/message_popup/renderers/question_interpreter.jsx
+++ b/ui/src/message_popup/renderers/question_interpreter.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import MixedQuestion from '../renderers/mixed_question.jsx';
 import ChoiceForBehaviorResponse from '../renderers/choice_for_behavior_response.jsx';
 import MinimalOpenResponse from '../renderers/minimal_open_response.jsx';
-
+import AudioCapture from '../../components/audio_capture.jsx';
 
 
 // This renders a question and an interaction.
@@ -29,11 +29,15 @@ export default React.createClass({
 
   renderInteractionEl(question, onLogMessage, onResponseSubmitted) {
     const key = JSON.stringify(question);
+
     if (question.open) {
+      const buttonText = AudioCapture.isAudioSupported()
+        ? "Click then speak"
+        : "Respond";
       return <MinimalOpenResponse
         key={key}
         responsePrompt=""
-        recordText="Click then speak"
+        recordText={buttonText}
         onLogMessage={onLogMessage}
         forceResponse={question.force || false}
         onResponseSubmitted={onResponseSubmitted}


### PR DESCRIPTION
The ending of the Jayden scenario is reworked for the playtest next week.

This also makes three other small fixes:
- `QuestionInterpreter` checks audio recording capabilities, and falls back to "Respond" when there's no audio recording.
- `LinearSession` always merges in the question as part of the `responses` it collects.
- query strings are passed along to Jayden and other pages in `app.jsx`

## Changes
<img width="371" alt="screen shot 2017-06-23 at 2 45 21 pm" src="https://user-images.githubusercontent.com/1056957/27496425-d7e58b3e-5823-11e7-99f6-9acd7853c060.png">

<img width="372" alt="screen shot 2017-06-23 at 2 32 17 pm" src="https://user-images.githubusercontent.com/1056957/27496436-e181d17a-5823-11e7-962a-654299706746.png">
