### PR TITLE
Add CS bias page for ECS follow-on

### DIFF
--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -10,6 +10,7 @@ import AuthContainer from './auth_container.jsx';
 import VirtualSchoolPage from './virtual_school/virtual_school_page.jsx';
 import HomePage from './home/home_page.jsx';
 import DemosPage from './home/demos_page.jsx';
+import CsBiasPage from './home/cs_bias_page.jsx';
 import ConsentPage from './home/consent_page.jsx';
 import * as MessagePopup from './message_popup/index.js';
 
@@ -37,10 +38,10 @@ export default React.createClass({
     '/': 'home',
     '/demos': 'demos',
     '/consent': 'consent',
+    '/bias': 'biasHome',
 
     // Included in /demos, shared externally, or used in playtests
     '/teachermoments/original': 'messagePopup',
-    '/teachermoments/bias': 'biasHome',
     '/teachermoments/alpha': 'alphaPlaytest',
     '/teachermoments/discipline': 'disciplinePlaytest',
     '/teachermoments/mentoring': 'mentoringPlaytest',
@@ -159,7 +160,7 @@ export default React.createClass({
 
   // Home page for bias project, from website, reachout, etc.
   biasHome(query = {}) {
-    return this.messagePopupPairs(query);
+    return <CsBiasPage />;
   },
 
   mentoringPlaytest(query = {}) {

--- a/ui/src/home/cs_bias_page.jsx
+++ b/ui/src/home/cs_bias_page.jsx
@@ -1,0 +1,66 @@
+/* @flow weak */
+import React from 'react';
+
+import {List, ListItem} from 'material-ui/List';
+import HomeFrame from './home_frame.jsx';
+import * as Routes from '../routes.js';
+
+
+// A list of demos to try, aimed to CS bias folks.
+export default React.createClass({
+  displayName: 'CsBiasPage',
+
+  onTappedMenu(e) {
+    window.location.reload();
+  },
+
+  onTappedItem(linkEl) {
+    Routes.navigate(linkEl.props.href);
+  },
+
+  render() {
+    return <HomeFrame>{this.renderScenarios()}</HomeFrame>;
+  },
+
+  renderScenarios() {
+    return (
+      <div>
+        <p>These interactive case studies can be used to seed conversation during in-person workshops, as homework to see class discussions, or within online PLCs.</p>
+        <img width="95%" style={{padding: 10}} src="https://mit-teaching-systems-lab.github.io/unconscious-bias/assets/cycle.jpg" />
+        <h3 style={styles.header}>Equity in computer science</h3>
+        <List>
+          {this.renderScenarioItem(<a href="/teachermoments/original">Bias in facilitating pair work</a>)}
+          {this.renderScenarioItem(<a href="/teachermoments/darius">Talking with a student considering dropping</a>)}
+          {this.renderScenarioItem(<a href="/teachermoments/discipline">Noticing student belonging in class</a>)}
+        </List>
+        <h3 style={styles.header}>Parent conversations</h3>
+        <List>
+          {this.renderScenarioItem(<a href="/teachermoments/danson">Supporting a special needs student</a>)}
+          {this.renderScenarioItem(<a href="/teachermoments/turner">Parent doesn't value school</a>)}
+        </List>
+        <div style={{marginTop: 50}}>New idea?  Reach out at <a href="https://twitter.com/mit_tsl">@mit_tsl</a>.</div>
+      </div>
+    );
+  },
+
+  renderScenarioItem(linkEl) {
+    return (
+      <ListItem
+        innerDivStyle={styles.listItem}
+        onTouchTap={this.onTappedItem.bind(this, linkEl)}
+        primaryText={linkEl} />
+    );
+  }
+});
+
+const styles = {
+  header: {
+    margin: 0,
+    marginTop: 30,
+    marginBottom: 5
+  },
+  listItem: {
+    padding: 5,
+    paddingLeft: 10
+  }
+};


### PR DESCRIPTION
Slightly different framing than "demos" page, which is practice-space focused.

<img width="371" alt="screen shot 2017-06-27 at 9 47 20 am" src="https://user-images.githubusercontent.com/1056957/27590793-c351aef8-5b1d-11e7-9732-11ec49437e08.png">
