### PR TITLE
Adds rosa counseling Scenario

### DIFF
--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -56,6 +56,7 @@ export default React.createClass({
     '/teachermoments/csfair': 'messagePopupCsFair',
     '/teachermoments/bubblesort': 'messagePopupBubbleSort',
     '/teachermoments/jayden': 'jaydenScenario',
+    '/teachermoments/rosa': 'rosaScenario',
     '/teachermoments/smithA': 'smithScenarioA',
     '/teachermoments/smithB': 'smithScenarioB',
     '/teachermoments/smith': 'smithScenario',
@@ -142,6 +143,9 @@ export default React.createClass({
     return <MessagePopup.JaydenExperiencePage query={query} />;
   },
 
+  rosaScenario(query = {}) {
+    return <MessagePopup.RosaExperiencePage query={query} />;
+  },
 
   smithScenarioA(query = {}) {
     return <MessagePopup.SmithExperiencePageA query={{}}/>;

--- a/ui/src/message_popup/index.js
+++ b/ui/src/message_popup/index.js
@@ -16,6 +16,7 @@ import DariusExperiencePage from './playtest/darius_experience_page.jsx';
 import CsFairExperiencePage from './playtest/cs_fair_experience_page.jsx';
 import BubbleSortExperiencePage from './playtest/bubble_sort_experience_page.jsx';
 import JaydenExperiencePage from './playtest/jayden_experience_page.jsx';
+import RosaExperiencePage from './playtest/rosa_experience_page.jsx';
 import SmithExperiencePageA from './playtest/smithA_experience_page.jsx';
 import SmithExperiencePageB from './playtest/smithB_experience_page.jsx';
 import SmithExperiencePage from './playtest/smith_experience_page.jsx';
@@ -42,6 +43,7 @@ export {
   MindsetPage,
   BubbleSortExperiencePage,
   JaydenExperiencePage,
+  RosaExperiencePage,
   SmithExperiencePageA,
   SmithExperiencePageB,
   SmithExperiencePage,

--- a/ui/src/message_popup/playtest/rosa_experience_page.jsx
+++ b/ui/src/message_popup/playtest/rosa_experience_page.jsx
@@ -1,0 +1,132 @@
+/* @flow weak */
+import React from 'react';
+import uuid from 'uuid';
+
+import * as Api from '../../helpers/api.js';
+import hash from '../../helpers/hash.js';
+import LinearSession from '../linear_session/linear_session.jsx';
+import SessionFrame from '../linear_session/session_frame.jsx';
+import IntroWithEmail from '../linear_session/intro_with_email.jsx';
+
+import QuestionInterpreter from '../renderers/question_interpreter.jsx';
+import type {QuestionT} from './pairs_scenario.jsx';
+import RosaScenario from './rosa_scenario.jsx';
+import AudioResponseSummary from '../renderers/audio_response_summary.jsx';
+
+type ResponseT = {
+  choice:string,
+  question:QuestionT
+};
+
+
+
+// This is a scenario around bubble sort and classroom management.
+export default React.createClass({
+  displayName: 'RosaExperiencePage',
+
+  propTypes: {
+    query: React.PropTypes.shape({
+      cohort: React.PropTypes.string,
+      p: React.PropTypes.string
+    }).isRequired
+  },
+
+  contextTypes: {
+    auth: React.PropTypes.object.isRequired
+  },
+
+  // Cohort comes from URL
+  getInitialState() {
+    const contextEmail = this.context.auth.userProfile.email;
+    const email = contextEmail === "unknown@mit.edu" ? '' : contextEmail;
+    const cohortKey = this.props.query.cohort || 'default';
+
+    return {
+      email,
+      cohortKey,
+      questions: null,
+      sessionId: uuid.v4()
+    };
+  },
+
+  // Making questions from the cohort
+  onStart(email) {
+    const {cohortKey} = this.state;
+    const allQuestions = RosaScenario.questionsFor(cohortKey);
+
+    const startQuestionIndex = this.props.query.p || 0; // for testing or demoing
+    const questions = allQuestions.slice(startQuestionIndex);
+    const questionsHash = hash(JSON.stringify(questions));
+    this.setState({
+      email,
+      questions,
+      questionsHash
+    });
+  },
+
+  onResetSession() {
+    this.setState(this.getInitialState());
+  },
+
+  onLogMessage(type, response:ResponseT) {
+    const {email, cohortKey, sessionId, questionsHash} = this.state;
+    
+    Api.logEvidence(type, {
+      ...response,
+      sessionId,
+      email,
+      cohortKey,
+      questionsHash,
+      name: email
+    });
+  },
+
+  render() {
+    return (
+      <SessionFrame onResetSession={this.onResetSession}>
+        {this.renderContent()}
+      </SessionFrame>
+    );
+  },
+
+  renderContent() {
+    const {questions} = this.state;
+    if (!questions) return this.renderIntro();
+
+    return <LinearSession
+      questions={questions}
+      questionEl={this.renderQuestionEl}
+      summaryEl={this.renderClosingEl}
+      onLogMessage={this.onLogMessage}
+    />;
+  },
+
+
+  renderIntro() {
+    return (
+      <IntroWithEmail defaultEmail={this.state.email} onDone={this.onStart}>
+        <div>
+          <p>Welcome!</p>
+          <p>This is an interactive case study simulating a conversation with a high school computer science student.</p>
+          <p>You'll review the context on the scenario, share what you anticipate will happen, and then try it out!  Afterward you'll reflect before heading back to debrief with the group or share online.</p>
+          <p>Please use <a href="https://www.google.com/chrome/">Chrome</a> on a laptop or desktop computer.</p>
+        </div>
+      </IntroWithEmail>
+    );
+  },
+
+  renderQuestionEl(question:QuestionT, onLog, onResponseSubmitted) {
+    return <QuestionInterpreter
+      question={question}
+      onLog={onLog}
+      onResponseSubmitted={onResponseSubmitted} />;
+  },
+
+  renderClosingEl(questions:[QuestionT], responses:[ResponseT]) {
+    return (
+      <AudioResponseSummary responses={responses}>
+        You've finished the simulation. Congrats! Below, you'll find your responses to the anticipate questions, the scenes with Rosa, and the reflection questions. Take time now to review your responses before returning to group discussion.
+      </AudioResponseSummary>
+    );
+  }
+});

--- a/ui/src/message_popup/playtest/rosa_scenario.jsx
+++ b/ui/src/message_popup/playtest/rosa_scenario.jsx
@@ -1,0 +1,139 @@
+/* @flow weak */
+import React from 'react';
+
+/*
+This file defines the content for the counseling scenario around talking to Rosa
+*/
+
+export type QuestionT = {
+  type:string, // Used as a label
+  text:string,
+  open:?bool, // Ask for open-ended user response
+  choices:?bool // Forced-choice response
+};
+
+
+function slidesFor(cohortKey) {
+  const slides:[QuestionT] = [];
+
+  slides.push({ type: 'Overview', el:
+  <div>
+    <div>1. Review context</div>
+    <div>Imagine yourself situated in the context of the particular school, classroom, and subject.</div>
+    <br />
+    <div>2. Anticipate</div>
+    <div>Before starting the simulation, you will answer a few questions in anticipation of what may happen.</div>
+    <br />
+    <div>3. Try it!</div>
+    <div>When you're ready you'll go through a set of scenarios that simulate interactions between you and a student in the class.</div>
+    <br />
+    <div>4. Reflect</div>
+    <div>Finally, you'll reflect on your experience.</div>
+  </div>
+  });
+
+
+// Context
+  slides.push({ type: 'Context', text:
+`In this scenario, you are teaching AP Computer Science Principles in a suburban high school where the students are predominantly white.
+
+Before the semester, initial enrollments for your class showed that more boys than girls had signed up for your class. Upon seeing this, you decided to make a concerted effort to recruit more girls for your class. 
+`});
+
+  slides.push({ type: 'Context', text:
+`Your efforts succeeded in getting more girls to enroll, but you ended up having an imbalance of girls to boys in the class. Out of 15 total students in your class, 10 of them are girls. 
+`});
+
+  slides.push({ type: 'Context', text:
+`The semester has started and the deadline for students to make changes to their class schedule is a couple days away. Before the start of class one day, you overhear Rosa tell one of her classmates that she wants to switch out of your class. You are disappointed to hear this because Rosa is a strong student, excels at math, and is one of the few students of color in your class.
+`});
+
+  slides.push({ type: 'Context', text:
+`At the end of class, you find Rosa before she leaves for her lunch break and ask her to stay after class to talk.
+`});
+
+
+
+// Anticipate
+  slides.push({ type: 'Anticipate', text:
+`Before you begin interacting with Rosa, we have three questions about what you anticipate may happen during your interaction with Rosa.
+`});
+
+  slides.push({ type: 'Anticipate', text:
+`What are your thoughts about why Rosa wants to switch out of your class?
+`, force: true, open: true});
+
+  slides.push({ type: 'Anticipate', text:
+`What do you hope to accomplish in your conversation with Rosa?
+`, force: true, open: true});
+
+  slides.push({ type: 'Anticipate', text:
+`What do you anticipate will actually happen during the one-on-one?
+`, force: true, open: true});
+
+
+// Try it!
+  slides.push({ type: 'Try it!', text:
+`When you're ready, you'll go through a set of scenes that simulate the conversation between you and Rosa.
+
+Improvise how you would act as a teacher, even if you don't have all the right answers or know the perfect thing to say.
+
+Click and speak aloud the words you'd say to the student.
+
+
+Ready to start?
+`});
+
+  slides.push({ type: 'Try it!', text:
+`Rosa: “Is everything ok?”
+`, open: true, force: true});
+
+  slides.push({ type: 'Try it!', text:
+`Rosa: “Ok you got me - I want to switch into another class.”
+`, open: true, force: true});
+
+  slides.push({ type: 'Try it!', text:
+`Rosa: “Well, the only reason I took this class is because you really sold me on it, but I really don’t see myself working in tech.”
+`, open: true, force: true});
+
+  slides.push({ type: 'Try it!', text:
+`Rosa: “I mean, it’s nice that there are more girls than guys in this class, but that doesn’t change the fact that mostly nerdy white dudes and Asian dudes work in computer science.”
+`, open: true, force: true});
+
+  slides.push({ type: 'Try it!', text:
+`Rosa: “Sure, there may be women in tech, but they’re still mostly white women.”
+`, open: true, force: true});
+
+  slides.push({ type: 'Try it!', text:
+`Rosa: “Well… I kinda feel like people are always surprised that I’m good at coding. It’s like when Juanita and I did well on the first assignment, you made it feel like a big deal, but you didn’t really say anything to anyone else. Brown girls can code, too, you know.”
+`, open: true, force: true});
+
+
+// Reflect
+  slides.push({ type: 'Reflect', text:
+`That's the end of the simulation.  Thanks!
+
+Before heading back to the group, let's shift to reflecting on what happened.
+`});
+
+  slides.push({ type: 'Reflect', text:
+`What are your initial thoughts and feelings about your one-on-one with Rosa?
+`, force: true, open: true});
+
+  slides.push({ type: 'Reflect', text:
+`How effective do you think you were in achieving your goals for your interaction with Rosa?
+`, force: true, open: true});
+
+  slides.push({ type: 'Reflect', text:
+`Would you do anything differently if a similar situation arose with another student? Please elaborate.
+`, force: true, open: true});
+
+  return slides;
+}
+
+
+export default {
+  questionsFor(cohortKey) {
+    return slidesFor(cohortKey);
+  }
+};


### PR DESCRIPTION
Adds the rosa counseling scenarios to teacher moments under teachermoments/rosa.

The code is based off of the jayden scenario. The only changes for the experience page is the replacement of all "Jaydens" (lines 13, 25, 55) with "rosa's". The rosa_scenario page follows the form of the jayden scenario but with new text. 
![screen shot 2017-07-25 at 2 57 34 pm](https://user-images.githubusercontent.com/25137921/28588806-bbd4991e-7149-11e7-985d-b716f9f50078.png)
