### PR TITLE
Update QuestionInterpreter to allow forcing text, enable for Rosa

### DIFF
--- a/ui/src/message_popup/playtest/rosa_experience_page.jsx
+++ b/ui/src/message_popup/playtest/rosa_experience_page.jsx
@@ -1,6 +1,7 @@
 /* @flow weak */
 import React from 'react';
 import uuid from 'uuid';
+import _ from 'lodash';
 
 import * as Api from '../../helpers/api.js';
 import hash from '../../helpers/hash.js';
@@ -27,7 +28,8 @@ export default React.createClass({
   propTypes: {
     query: React.PropTypes.shape({
       cohort: React.PropTypes.string,
-      p: React.PropTypes.string
+      p: React.PropTypes.string,
+      text: React.PropTypes.string
     }).isRequired
   },
 
@@ -116,9 +118,11 @@ export default React.createClass({
   },
 
   renderQuestionEl(question:QuestionT, onLog, onResponseSubmitted) {
+    const forceText = _.has(this.props.query, 'text');
     return <QuestionInterpreter
       question={question}
       onLog={onLog}
+      forceText={forceText}
       onResponseSubmitted={onResponseSubmitted} />;
   },
 

--- a/ui/src/message_popup/renderers/question_interpreter.jsx
+++ b/ui/src/message_popup/renderers/question_interpreter.jsx
@@ -8,14 +8,23 @@ import MinimalTextResponse from '../renderers/minimal_text_response.jsx';
 import AudioCapture from '../../components/audio_capture.jsx';
 
 
-// This renders a question and an interaction.
+// This renders a question and an interaction, and strives towards being a
+// general-purpose interpreter that over time ends up converging towards shared
+// data structures/components across different scenarios.
 export default React.createClass({
   displayName: 'QuestionInterpreter',
   
   propTypes: {
     question: React.PropTypes.object.isRequired,
     onLog: React.PropTypes.func.isRequired,
-    onResponseSubmitted: React.PropTypes.func.isRequired
+    onResponseSubmitted: React.PropTypes.func.isRequired,
+    forceText: React.PropTypes.bool
+  },
+
+  getDefaultProps() {
+    return {
+      forceText: false
+    };
   },
 
   render() {
@@ -30,19 +39,35 @@ export default React.createClass({
 
   renderInteractionEl(question, onLogMessage, onResponseSubmitted) {
     const key = JSON.stringify(question);
+    const {forceText} = this.props;
 
+    // Open response with audio by default, falling back to text if unavailable, and
+    // allowing text responses to be forced.
     if (question.open) {
-      const buttonText = AudioCapture.isAudioSupported()
-        ? "Click then speak"
-        : "Respond";
-      return <MinimalOpenResponse
-        key={key}
-        responsePrompt=""
-        recordText={buttonText}
-        onLogMessage={onLogMessage}
-        forceResponse={question.force || false}
-        onResponseSubmitted={onResponseSubmitted}
-      />;
+      if (forceText) {
+        return <MinimalTextResponse
+          key={key}
+          forceResponse={question.force || false}
+          responsePrompt=""
+          recordText="Respond"
+          ignoreText="Move on"
+          onLogMessage={onLogMessage}
+          onResponseSubmitted={onResponseSubmitted}
+          />;
+      } else {
+        const buttonText = AudioCapture.isAudioSupported()
+          ? "Click then speak"
+          : "Respond";
+        return <MinimalOpenResponse
+          key={key}
+          forceResponse={question.force || false}
+          responsePrompt=""
+          recordText={buttonText}
+          ignoreText="Move on"
+          onLogMessage={onLogMessage}
+          onResponseSubmitted={onResponseSubmitted}
+          />;
+      }
     }
 
     if (question.write) {


### PR DESCRIPTION
This updates `QuestionInterpreter` to allow a prop forcing text responses, aimed at supporting folks who have audio recording capabilities but no microphone (the current check for audio recording capabilities can't detect this).

It adds a `text` query string to the Rosa scenario passing this through.