### PR TITLE
Polyfill Promise for IE

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -34,6 +34,7 @@
     "browserify": "^13.0.1",
     "clipboard": "^1.6.1",
     "envify": "^4.0.0",
+    "es6-promise": "^4.1.1",
     "jsdom": "^9.8.0",
     "lodash": "^4.13.1",
     "material-ui": "^0.16.3",

--- a/ui/src/helpers/api.js
+++ b/ui/src/helpers/api.js
@@ -2,6 +2,9 @@
 import * as Routes from '../routes.js';
 import superagent from 'superagent';
 import SuperagentPromise from 'superagent-promise';
+
+import ES6Promise from 'es6-promise';
+ES6Promise.polyfill();
 const request = SuperagentPromise(superagent, Promise);
 import crypto from 'crypto';
 import qs from 'querystring';


### PR DESCRIPTION
In an older version of IE, Promise is undefined and so this leads JS execution to stop on boot - no page is rendered and the error isn't reported to Rollbar.  This polyfills that.
