### PR TITLE
Add HMTCA with reviewing page, endpoints for reviewing, add server linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "watch": "cd ui && npm run watch && cd ..",
     "heroku-prebuild": "cd ui && mkdir build && npm install",
     "heroku-postbuild": "cd ui && npm run build",
-    "test": "cd ui && npm run test"
+    "lint": "eslint --ext jsx --ext js -c server/.eslintrc server",
+    "test": "npm run lint && cd ui && npm run test"
   },
   "dependencies": {
     "aws-sdk": "^2.4.8",
@@ -30,6 +31,8 @@
   "license": "MIT",
   "devDependencies": {
     "babel-plugin-react-transform": "^2.0.2",
+    "eslint": "^4.3.0",
+    "eslint-plugin-node": "^5.1.1",
     "livereactload": "^2.2.3",
     "react-proxy": "^1.1.8"
   }

--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -1,0 +1,24 @@
+{
+  "env": {
+    "browser": false,
+    "es6": true,
+    "mocha": false
+  },
+  "plugins": ["node"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:node/recommended"
+  ],
+  "rules": {
+    "no-console": "off",
+    "indent": ["error", 2],
+    "semi": ["error", "always"],
+    "comma-dangle": ["error", "only-multiline"],
+    "no-unused-vars": ["error", {
+      "args": "none"
+    }],
+    "camelcase": ["error",  { "properties": "always" }],
+    "no-use-before-define": "off",
+    "eol-last": "off"
+  }
+}

--- a/server/endpoints/apples.js
+++ b/server/endpoints/apples.js
@@ -1,0 +1,55 @@
+// Get all sorted responses that fit this particular type for a particular
+// `applesKey`.  This only pulls out the anonymized text responses.
+function getAnonymizedApples(params, cb) {
+  const {queryDatabase, applesKey} = params;
+
+  const sql = `
+    SELECT
+      json->'anonymizedText' as anonymized_text,
+      json->'sceneNumber' as scene_number,
+      json->'sceneText' as scene_text
+    FROM evidence
+    WHERE 1=1
+      AND type = 'anonymized_apples_to_apples'
+      AND json->>'applesKey' = $1
+    ORDER BY
+      scene_number ASC,
+      scene_text ASC,
+      anonymized_text ASC;`;
+  const values = [applesKey];
+  queryDatabase(sql, values, (err, result) => {
+    if (err) {
+      console.log('getAnonymizedApples: error', JSON.stringify(err));
+      return cb(err);
+    }
+
+    const {rows} = result;
+    return cb(null, {rows});
+  });
+}
+
+
+module.exports = {
+  // Queries database for anonymized responses to a particular Apples-to-Apples key
+  sensitiveGetApples({queryDatabase}) {
+    return (request, response) => {
+      const applesKey = request.params.key;
+      console.log('sensitiveGetApples: applesKey = ' + applesKey);
+      getAnonymizedApples({queryDatabase, applesKey}, (err, result) => {
+        if (err) {
+          console.log('sensitiveGetApples: error', JSON.stringify(err));
+          response.status(500);
+          response.json({ status: 'error' });
+          return;
+        }
+
+        const {rows} = result;
+        console.log(`sensitiveGetApples: returning ${rows.length} rows...`);
+        response.status(200);
+        response.json(rows);
+        return;
+      });
+    };
+  }
+};
+

--- a/server/endpoints/audio.js
+++ b/server/endpoints/audio.js
@@ -14,7 +14,7 @@ function getAudioKey(request, id) {
 function getUrl(request, id) {
   const domain = getDomain(request);
   return `${domain}/teachermoments/wav/${id}.wav`;
-};
+}
 
 function post(s3) {
   return (request, response) => {
@@ -42,7 +42,7 @@ function post(s3) {
       response.status(201);
       return response.json({ url, id });
     });
-  }
+  };
 }
 
 // There's no authorization check here

--- a/server/endpoints/review.js
+++ b/server/endpoints/review.js
@@ -1,11 +1,3 @@
-const dateFns = require('date-fns');
-const uuid = require('uuid');
-const Mustache = require('mustache');
-const fs = require('fs');
-const path = require('path');
-const qs = require('querystring');
-const request = require('superagent');
-const crypto = require('crypto');
 const {getDomain} = require('../domain.js');
 const {insecureStreamAudioFileFromS3} = require('./audio.js');
 
@@ -123,7 +115,7 @@ module.exports = {
           if (err) {
             console.log('getReview: error', JSON.stringify(err));
             response.status(500);
-            reponse.json({ status: 'error' });
+            response.json({ status: 'error' });
             return;
           }
 
@@ -134,7 +126,7 @@ module.exports = {
           return;
         });
       });
-    }
+    };
   },
 
   // Streams an audio file of user recordings from S3, if (token, hid) pair
@@ -164,6 +156,6 @@ module.exports = {
         const {id} = request.params;
         insecureStreamAudioFileFromS3({s3, id}, request, response);
       });
-    }
+    };
   }
 };

--- a/server/endpoints/review_login.js
+++ b/server/endpoints/review_login.js
@@ -1,5 +1,4 @@
 const {getDomain} = require('../domain.js');
-const dateFns = require('date-fns');
 const uuid = require('uuid');
 const Mustache = require('mustache');
 const fs = require('fs');
@@ -170,6 +169,6 @@ module.exports = {
           });
         });
       });
-    }
+    };
   }
 };

--- a/server/mailgun_env.js
+++ b/server/mailgun_env.js
@@ -1,5 +1,4 @@
 var fs = require('fs');
-var AWS = require('aws-sdk');
 
 module.exports = function createMailgunEnv() {
   if (process.env.NODE_ENV === 'development') {
@@ -13,4 +12,4 @@ module.exports = function createMailgunEnv() {
     MAILGUN_API_KEY: process.env.MAILGUN_API_KEY,
     MAILGUN_DOMAIN: process.env.MAILGUN_DOMAIN
   };
-}
+};

--- a/server/migrations/20160718-001-insert-evaluations.js
+++ b/server/migrations/20160718-001-insert-evaluations.js
@@ -19,7 +19,7 @@ function queryDatabase(text, values, cb) {
       cb(err, result);
     });
   });
-};
+}
 
 
 // read dump from disk
@@ -47,7 +47,7 @@ function insertEach(rows, callback) {
       if (err) return callback(err);
       console.log('Inserted.');
       callback(null, result);
-    })
+    });
   });
 }
 
@@ -65,8 +65,7 @@ function main() {
 
       if (remaining === 0) {
         console.log('Done.');
-        process.exit(0);
-        return;
+        process.exit(0); // eslint-disable-line no-process-exit
       }
     });
   });

--- a/server/s3_client.js
+++ b/server/s3_client.js
@@ -6,4 +6,4 @@ module.exports = function createS3Client() {
     ? JSON.parse(fs.readFileSync('./tmp/aws_message_popup.json'))
     : JSON.parse(process.env.MESSAGE_POPUP_S3_CONFIG_JSON);
   return new AWS.S3(awsConfig); 
-}
+};

--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -65,7 +65,6 @@ export default React.createClass({
     // For HMTCA, with practice space and reviewing UI
     '/teachermoments/hmtca': 'hmtcaScenario',
 
-
     // Specific cohorts
     '/teachermoments/csp': 'messagePopupCSP',
     '/teachermoments/tuesday': 'messagePopupMeredith',

--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -62,6 +62,9 @@ export default React.createClass({
     '/teachermoments/smithFacilitated': 'smithScenario',
     '/teachermoments/ecs': 'ecsScenario',
 
+    // For HMTCA, with practice space and reviewing UI
+    '/teachermoments/hmtca': 'hmtcaScenario',
+
 
     // Specific cohorts
     '/teachermoments/csp': 'messagePopupCSP',
@@ -214,6 +217,10 @@ export default React.createClass({
 
   messagePopupDarius(query = {}) {
     return <MessagePopup.DariusExperiencePage query={{}}/>;
+  },
+
+  hmtcaScenario(query = {}) {
+    return <MessagePopup.HMTCAExperiencePage query={query} />;
   },
 
   messagePopupPlaytest(cohortKey, query = {}) {

--- a/ui/src/helpers/api.js
+++ b/ui/src/helpers/api.js
@@ -54,8 +54,21 @@ export function logEvidence(type, record) {
     .end();
 }
 
+// Log evidence for an Apples-to-Apples style response, just plain text
+// associated with a particular key.
+export function logApplesText(params) {
+  const {applesKey, sceneNumber, sceneText, anonymizedText} = params;
+  return logEvidence('anonymized_apples_to_apples', {applesKey, sceneNumber, sceneText, anonymizedText});
+}
 
-//Query for questions
+// Query for responses for doing Apples-to-Apples style reviewing for a particular `applesKey`
+export function getApples(applesKey) {
+  return request
+    .get(`/server/apples/${applesKey}`)
+    .set('Content-Type', 'application/json');
+}
+
+// Query for questions
 export function questionsQuery() {
   return request
     .get('/server/questions')

--- a/ui/src/message_popup/index.js
+++ b/ui/src/message_popup/index.js
@@ -21,6 +21,7 @@ import SmithExperiencePageA from './playtest/smithA_experience_page.jsx';
 import SmithExperiencePageB from './playtest/smithB_experience_page.jsx';
 import SmithExperiencePage from './playtest/smith_experience_page.jsx';
 import EcsExperiencePage from './playtest/ecs_experience_page.jsx';
+import HMTCAExperiencePage from './playtest/hmtca_experience_page.jsx';
 
 
 import QuestionsPage from './author/questions_page.jsx';
@@ -57,5 +58,6 @@ export {
   EditQuestionPage,
   NewQuestionPage,
   ReviewLoginPage,
-  ReviewPage
+  ReviewPage,
+  HMTCAExperiencePage
 };

--- a/ui/src/message_popup/linear_session/session_frame.jsx
+++ b/ui/src/message_popup/linear_session/session_frame.jsx
@@ -18,6 +18,7 @@ export default React.createClass({
   },
 
   render() {
+    const {children, onResetSession} = this.props;
     return (
       <div className="SessionFrame">
         <ResponsiveFrame>
@@ -25,12 +26,12 @@ export default React.createClass({
             <NavigationAppBar
               title="Teacher Moments"
               iconElementLeft={
-                <IconButton onTouchTap={this.props.onResetSession} >
+                <IconButton onTouchTap={onResetSession} >
                   <RefreshIcon />
                 </IconButton>
               }
             />
-            {this.props.children}
+            {children}
           </div>
         </ResponsiveFrame>
       </div>

--- a/ui/src/message_popup/playtest/hmtca_experience_page.jsx
+++ b/ui/src/message_popup/playtest/hmtca_experience_page.jsx
@@ -1,0 +1,191 @@
+/* @flow weak */
+import React from 'react';
+import uuid from 'uuid';
+import _ from 'lodash';
+
+import * as Api from '../../helpers/api.js';
+import hash from '../../helpers/hash.js';
+import LinearSession from '../linear_session/linear_session.jsx';
+import SessionFrame from '../linear_session/session_frame.jsx';
+import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
+import 'velocity-animate/velocity.ui';
+import RaisedButton from 'material-ui/RaisedButton';
+import Divider from 'material-ui/Divider';
+import TextField from 'material-ui/TextField';
+
+
+import QuestionInterpreter from '../renderers/question_interpreter.jsx';
+import type {QuestionT} from './pairs_scenario.jsx';
+import HMTCAScenarios from './hmtca_scenario.jsx';
+import HMTCAGroupReview from './hmtca_group_review.jsx';
+
+type ResponseT = {
+  choice:string,
+  question:QuestionT,
+  sceneNumber?:number,
+  anonymizedText?:string
+};
+
+
+
+// This is the flow for the HMTCA breakout session
+export default React.createClass({
+  displayName: 'HMTCAExperiencePage',
+
+  propTypes: {
+    query: React.PropTypes.shape({
+      cohort: React.PropTypes.string,
+      p: React.PropTypes.string,
+      text: React.PropTypes.string,
+      review: React.PropTypes.string
+    }).isRequired
+  },
+
+  // Cohort comes from URL
+  getInitialState() {
+    const isReviewing = this.props.query.review === 'true' || false;
+
+    return {
+      cohortKey: '',
+      isReviewing,
+      questions: null,
+      sessionId: uuid.v4()
+    };
+  },
+
+  onCohortKeyChanged(e) {
+    this.setState({ cohortKey: e.target.value });
+  },
+
+  // Making questions from the cohort
+  onStart(e) {
+    e.preventDefault();
+    const {cohortKey} = this.state;
+    const allQuestions = HMTCAScenarios.questionsFor(cohortKey);
+
+    const startQuestionIndex = this.props.query.p || 0; // for testing or demoing
+    const questions = allQuestions.slice(startQuestionIndex);
+    const questionsHash = hash(JSON.stringify(questions));
+    this.setState({
+      questions,
+      questionsHash
+    });
+  },
+
+  onResetSession() {
+    this.setState(this.getInitialState());
+  },
+
+  onLogMessage(type, response) {
+    const {cohortKey, sessionId, questionsHash} = this.state;
+    
+    // Watch for a particular message, then add in the applesKey and double-log
+    // it, stripping out all the identifiers from the log message so we can read it
+    // back later safely anonymized.
+    if (type === 'anonymized_apples_to_apples_partial') {
+      Api.logApplesText({
+        applesKey: cohortKey,
+        sceneNumber: response.sceneNumber,
+        sceneText: response.question.text,
+        anonymizedText: response.anonymizedText
+      });
+    }
+
+    Api.logEvidence(type, {
+      ...response,
+      sessionId,
+      cohortKey,
+      questionsHash
+    });
+  },
+
+  render() {
+    return (
+      <SessionFrame onResetSession={this.onResetSession}>
+        {this.renderContent()}
+      </SessionFrame>
+    );
+  },
+
+  renderContent() {
+    const {questions} = this.state;
+    if (!questions) return this.renderIntro();
+
+    return <LinearSession
+      questions={questions}
+      questionEl={this.renderQuestionEl}
+      summaryEl={this.renderClosingEl}
+      onLogMessage={this.onLogMessage}
+    />;
+  },
+
+
+  renderIntro() {
+    return (
+      <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
+        <div>
+          <div style={styles.instructions}>
+            <p>Welcome!</p>
+            <p>...</p>
+          </div>
+          <Divider />
+          <div style={{...styles.instructions, padding: 20}}>
+            <div>... consent phrase and information goes here ...</div>
+            <form onSubmit={this.onStart}>
+              <div style={styles.buttonRow}>
+                <TextField
+                  name="cohortKey"
+                  style={{width: '100%'}}
+                  underlineShow={false}
+                  floatingLabelText="What's your team code?"
+                  value={this.state.cohortKey}
+                  onChange={this.onCohortKeyChanged}
+                  rows={2} />
+                <RaisedButton
+                  disabled={this.state.cohortKey === ''}
+                  onTouchTap={this.onStart}
+                  type="submit"
+                  style={styles.button}
+                  secondary={true}
+                  label="Start" />
+              </div>    
+            </form>
+          </div>
+        </div>
+      </VelocityTransitionGroup>
+    );
+  },
+
+  renderQuestionEl(question:QuestionT, onLog, onResponseSubmitted) {
+    const forceText = _.has(this.props.query, 'text');
+    return <QuestionInterpreter
+      question={question}
+      onLog={onLog}
+      forceText={forceText}
+      onResponseSubmitted={onResponseSubmitted} />;
+  },
+
+  renderClosingEl(questions:[QuestionT], responses:[ResponseT]) {
+    const {cohortKey} = this.state;
+    return <HMTCAGroupReview applesKey={cohortKey} />;
+  }
+});
+
+const styles = {
+  instructions: {
+    fontSize: 18,
+    padding: 0,
+    margin:0,
+    paddingLeft: 20,
+    paddingRight: 20,
+    paddingBottom: 10
+  },
+  buttonRow: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'flex-end'
+  },
+  button: {
+    marginTop: 20
+  }
+};

--- a/ui/src/message_popup/playtest/hmtca_experience_page.jsx
+++ b/ui/src/message_popup/playtest/hmtca_experience_page.jsx
@@ -10,8 +10,9 @@ import SessionFrame from '../linear_session/session_frame.jsx';
 import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
 import 'velocity-animate/velocity.ui';
 import RaisedButton from 'material-ui/RaisedButton';
-import TextField from 'material-ui/TextField';
 import {RadioButton, RadioButtonGroup} from 'material-ui/RadioButton';
+import SelectField from 'material-ui/SelectField';
+import MenuItem from 'material-ui/MenuItem';
 
 import QuestionInterpreter from '../renderers/question_interpreter.jsx';
 import type {QuestionT} from './pairs_scenario.jsx';
@@ -59,8 +60,8 @@ export default React.createClass({
     return [cohortKey, bucketId].join(':');
   },
 
-  onCohortKeyChanged(e) {
-    this.setState({ cohortKey: e.target.value });
+  onCohortKeyChanged(e, menuItemKey, cohortKey) {
+    this.setState({cohortKey});
   },
 
   onBucketChanged(e) {
@@ -141,17 +142,6 @@ export default React.createClass({
             <p>This is an online practice space made just for HMTCA.</p>
           </div>
           <div style={styles.instructions}>
-            <div>
-              <TextField
-                name="cohortKey"
-                style={{width: '100%', marginBottom: 15}}
-                underlineShow={true}
-                floatingLabelText="What's your team's code?"
-                floatingLabelFixed={true}
-                value={this.state.cohortKey}
-                onChange={this.onCohortKeyChanged}
-                rows={2} />
-            </div>
             <div>What would you like to practice?</div>
             <RadioButtonGroup
               style={{margin: 10}}
@@ -168,6 +158,20 @@ export default React.createClass({
                 />
               )}
             </RadioButtonGroup>
+          </div>
+          <div style={styles.instructions}>
+            <SelectField
+              maxHeight={250}
+              style={{width: '100%'}}
+              floatingLabelText="Select your team code"
+              value={this.state.cohortKey}
+              onChange={this.onCohortKeyChanged}
+            >
+              <MenuItem key={''} value={''} primaryText={''} />
+              {HMTCAScenarios.TEAM_CODES.map(code => <MenuItem key={code} value={code} primaryText={code} />)}
+            </SelectField>
+          </div>
+          <div style={styles.instructions}>
             <p>In this practice space, you'll have to improvise and adapt to make the best of the situation.  Some scenarios might not exactly match your grade level and subject.</p>
             <RaisedButton
               disabled={this.state.cohortKey === ''}

--- a/ui/src/message_popup/playtest/hmtca_experience_page.jsx
+++ b/ui/src/message_popup/playtest/hmtca_experience_page.jsx
@@ -13,9 +13,7 @@ import RaisedButton from 'material-ui/RaisedButton';
 import {RadioButton, RadioButtonGroup} from 'material-ui/RadioButton';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
-import PeopleIcon from 'material-ui/svg-icons/social/people';
-import Paper from 'material-ui/Paper';
-
+import Divider from 'material-ui/Divider';
 
 import QuestionInterpreter from '../renderers/question_interpreter.jsx';
 import type {QuestionT} from './pairs_scenario.jsx';
@@ -216,14 +214,13 @@ export default React.createClass({
   renderJumpAhead() {
     return (
       <div style={{marginTop: 200}}>
-        <Paper style={{margin: 5, padding: 20}} zDepth={1} >
-          <div>If the rest of your group has already finished, jump to the discussion round.</div>
-          <div style={{margin: 5}}><PeopleIcon /><PeopleIcon /><PeopleIcon /></div>
+        <Divider />
+        <div style={{margin: 35}}>
+          <div style={{paddingBottom: 20}}>If the rest of your group has already finished, jump to the discussion round.</div>
           <RaisedButton
             label="Start discussion round"
-            primary={true}
             onTouchTap={this.onReviewTapped} />
-        </Paper>
+        </div>
       </div>
     );
   },

--- a/ui/src/message_popup/playtest/hmtca_experience_page.jsx
+++ b/ui/src/message_popup/playtest/hmtca_experience_page.jsx
@@ -62,6 +62,8 @@ export default React.createClass({
     return [cohortKey, bucketId].join(':');
   },
 
+  // Could make this smarter and have it coordinate across different users to
+  // allow them all to advance n minutes after the first session started.
   shouldAllowJumpAhead() {
     return true;
   },

--- a/ui/src/message_popup/playtest/hmtca_experience_page.jsx
+++ b/ui/src/message_popup/playtest/hmtca_experience_page.jsx
@@ -48,6 +48,17 @@ export default React.createClass({
     };
   },
 
+  // This is the key for a "game session we want to later review."
+  // It's built from (cohort, bucket), so that each of those has its own
+  // scene number space (the number is used for ordering and is user-facing).
+  //
+  // This means that if the same team code plays again later, the number of
+  // responses will keep growing over time (as opposed to "start a new game").
+  applesKey() {
+    const {cohortKey, bucketId} = this.state;
+    return [cohortKey, bucketId].join(':');
+  },
+
   onCohortKeyChanged(e) {
     this.setState({ cohortKey: e.target.value });
   },
@@ -76,17 +87,15 @@ export default React.createClass({
   },
 
   onLogMessage(type, response) {
-    const {cohortKey, bucketId, sessionId, questionsHash} = this.state;
+    const {cohortKey, sessionId, questionsHash} = this.state;
     
     // Watch for a particular message, then add in the applesKey and double-log
     // it, stripping out all the identifiers from the log message so we can read it
     // back later safely anonymized.
     //
-    // The appleKey is built from (cohort, bucket), so that each of those has its own
-    // scene number space (the number is used for ordering and is user-facing).
     if (type === 'anonymized_apples_to_apples_partial') {
       Api.logApplesText({
-        applesKey: [cohortKey, bucketId].join(':'),
+        applesKey: this.applesKey(),
         sceneNumber: response.sceneNumber,
         sceneText: response.question.text,
         anonymizedText: response.anonymizedText
@@ -183,8 +192,7 @@ export default React.createClass({
   },
 
   renderClosingEl(questions:[QuestionT], responses:[ResponseT]) {
-    const {cohortKey} = this.state;
-    return <HMTCAGroupReview applesKey={cohortKey} />;
+    return <HMTCAGroupReview applesKey={this.applesKey()} />;
   }
 });
 

--- a/ui/src/message_popup/playtest/hmtca_group_review.jsx
+++ b/ui/src/message_popup/playtest/hmtca_group_review.jsx
@@ -1,0 +1,97 @@
+/* @flow weak */
+import React from 'react';
+import _ from 'lodash';
+
+import * as Api from '../../helpers/api.js';
+import Paper from 'material-ui/Paper';
+import {Card, CardTitle, CardText} from 'material-ui/Card';
+
+
+// For reviewing responses as a group.
+export default React.createClass({
+  displayName: 'HMTCAGroupReview',
+
+  propTypes: {
+    applesKey: React.PropTypes.string
+  },
+
+  getInitialState() {
+    return {
+      hasLoaded: false,
+      applesResponses: null
+    };
+  },
+
+  componentDidMount() {
+    const {applesKey} = this.props;
+    Api.getApples(applesKey).end(this.onResponsesReceived);
+  },
+
+  onResponsesReceived(err, response){
+    if (err){
+      this.setState({ hasLoaded: true });
+      return;
+    }
+    const applesResponses = JSON.parse(response.text);
+    this.setState({ hasLoaded: true, applesResponses });
+  },
+
+  render() {
+    const {hasLoaded, applesResponses} = this.state;
+    if (!hasLoaded) return <div>Loading...</div>;
+
+    const sceneToResponses = _.groupBy(applesResponses, 'scene_number');
+    return (
+      <div>
+        <div style={styles.instructions}>Scroll through and play!</div>
+        <div>{Object.keys(sceneToResponses).map((sceneNumber) => {
+          return (
+            <div key={sceneNumber}>
+              <Card>
+                <CardTitle
+                  title={`Scene #${sceneNumber}`}
+                  subtitle={sceneToResponses[sceneNumber][0]['scene_text']}
+                />
+                <CardText>
+              <div style={styles.cardContainer}>
+                {sceneToResponses[sceneNumber].map((applesResponse) => {
+                  const anonymizedText = applesResponse['anonymized_text'];
+                  return (
+                    <Paper
+                      key={anonymizedText}
+                      style={styles.responseCard}
+                      zDepth={3}>{anonymizedText}</Paper>
+                  );
+                })}
+              </div>
+              </CardText>
+              </Card>
+            </div>
+          );
+        })}</div>
+      </div>
+    );
+  }
+});
+
+const styles = {
+  instructions: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginLeft: 10,
+    marginTop: 30,
+    marginBottom: 30
+  },
+  cardContainer: {
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  responseCard: {
+    minHeight: 200,
+    flex: 1,
+    margin: 10,
+    textAlign: 'left',
+    padding: 5,
+    display: 'inline-block'
+  }
+};

--- a/ui/src/message_popup/playtest/hmtca_group_review.jsx
+++ b/ui/src/message_popup/playtest/hmtca_group_review.jsx
@@ -22,6 +22,8 @@ export default React.createClass({
     };
   },
 
+  // This is where we could add a timer using setInterval to repeatedly call the
+  // method that refreshes the responses (and then add a componentWillUnmount to cleanup).
   componentDidMount() {
     this.refreshResponses();
   },
@@ -60,15 +62,12 @@ export default React.createClass({
                 />
                 <CardText>
               <div style={styles.cardContainer}>
-                {sceneToResponses[sceneNumber].map((applesResponse) => {
-                  const anonymizedText = applesResponse['anonymized_text'];
-                  return (
-                    <Paper
-                      key={anonymizedText}
-                      style={styles.responseCard}
-                      zDepth={3}>{anonymizedText}</Paper>
-                  );
-                })}
+                {_.uniq(_.map(sceneToResponses[sceneNumber], 'anonymized_text')).map(anonymizedText => 
+                  <Paper
+                    key={anonymizedText}
+                    style={styles.responseCard}
+                    zDepth={3}>{anonymizedText}</Paper>
+                )}
               </div>
               </CardText>
               </Card>

--- a/ui/src/message_popup/playtest/hmtca_group_review.jsx
+++ b/ui/src/message_popup/playtest/hmtca_group_review.jsx
@@ -23,6 +23,10 @@ export default React.createClass({
   },
 
   componentDidMount() {
+    this.refreshResponses();
+  },
+
+  refreshResponses() {
     const {applesKey} = this.props;
     Api.getApples(applesKey).end(this.onResponsesReceived);
   },

--- a/ui/src/message_popup/playtest/hmtca_group_review.jsx
+++ b/ui/src/message_popup/playtest/hmtca_group_review.jsx
@@ -40,16 +40,18 @@ export default React.createClass({
     const {hasLoaded, applesResponses} = this.state;
     if (!hasLoaded) return <div>Loading...</div>;
 
+    // Use scene number for ordering, but then just number then naturally
     const sceneToResponses = _.groupBy(applesResponses, 'scene_number');
     return (
       <div>
         <div style={styles.instructions}>Scroll through and play!</div>
-        <div>{Object.keys(sceneToResponses).map((sceneNumber) => {
+        <div>{_.sortBy(Object.keys(sceneToResponses)).map((sceneNumber, index) => {
+          if (sceneNumber === 'null') return;
           return (
             <div key={sceneNumber}>
               <Card>
                 <CardTitle
-                  title={`Scene #${sceneNumber}`}
+                  title={`Scene #${index + 1}`}
                   subtitle={sceneToResponses[sceneNumber][0]['scene_text']}
                 />
                 <CardText>
@@ -76,9 +78,8 @@ export default React.createClass({
 
 const styles = {
   instructions: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    marginLeft: 10,
+    fontSize: 18,
+    marginLeft: 15,
     marginTop: 30,
     marginBottom: 30
   },
@@ -89,9 +90,10 @@ const styles = {
   responseCard: {
     minHeight: 200,
     flex: 1,
-    margin: 10,
     textAlign: 'left',
-    padding: 5,
+    marginBottom: 15,
+    marginTop: 15,
+    padding: 15,
     display: 'inline-block'
   }
 };

--- a/ui/src/message_popup/playtest/hmtca_scenario.jsx
+++ b/ui/src/message_popup/playtest/hmtca_scenario.jsx
@@ -1,4 +1,6 @@
 /* @flow weak */
+import _ from 'lodash';
+
 
 // This file defines the content for the HMTCA scenarios.
 // Note: This only supports text scenes right now.
@@ -16,6 +18,27 @@ const BUCKETS = [
   { id: 203, text: 'Disrespect towards females' },
   { id: 204, text: 'Combination of the above' }
 ];
+
+const TEAM_CODES = _.sortBy([
+  'mango',
+  'lemon',
+  'papaya',
+  'apple',
+  'guava',
+  'banana',
+  'nectarine',
+  'peach',
+  'blueberry',
+  'strawberry',
+  'grape',
+  'pineapple',
+  'pear',
+  'cherry',
+  'watermelon',
+  'kiwi',
+  'coconut',
+  'blackberry'
+]);
 
 
 function slidesFor(cohortKey, bucketId) {
@@ -37,6 +60,7 @@ function slidesFor(cohortKey, bucketId) {
 
 export default {
   BUCKETS,
+  TEAM_CODES,
   questionsFor(cohortKey, bucketId) {
     return slidesFor(cohortKey, bucketId);
   }

--- a/ui/src/message_popup/playtest/hmtca_scenario.jsx
+++ b/ui/src/message_popup/playtest/hmtca_scenario.jsx
@@ -45,13 +45,13 @@ function slidesFor(cohortKey, bucketId) {
   const slides:[QuestionT] = [];
 
   if (bucketId === 201) {
-    slides.push({ type: 'Hello!', text: 'Does this work?' });
-    slides.push({ type: 'Hello!', text: 'Jose is watching YouTube.', applesSceneNumber: 1 });
-    slides.push({ type: 'Hello!', text: 'Samir puts his head down.', applesSceneNumber: 2 });
+    slides.push({ text: 'Does this work?' });
+    slides.push({ text: 'Jose is watching YouTube.', applesSceneNumber: 1 });
+    slides.push({ text: 'Samir puts his head down.', applesSceneNumber: 2 });
   } else {
-    slides.push({ type: 'Hello!', text: 'These scenarios are...' });
-    slides.push({ type: 'Hello!', text: 'Jose is watching YouTube.', applesSceneNumber: 1 });
-    slides.push({ type: 'Hello!', text: 'Samir puts his head down.', applesSceneNumber: 2 });
+    slides.push({ text: 'These scenarios are...' });
+    slides.push({ text: 'Jose is watching YouTube.', applesSceneNumber: 1 });
+    slides.push({ text: 'Samir puts his head down.', applesSceneNumber: 2 });
   }
 
   return slides;

--- a/ui/src/message_popup/playtest/hmtca_scenario.jsx
+++ b/ui/src/message_popup/playtest/hmtca_scenario.jsx
@@ -1,0 +1,27 @@
+/* @flow weak */
+
+// This file defines the content for the HMTCA scenarios.
+// Note: This only supports text scenes right now.
+export type QuestionT = {
+  type:string, // Used as a label
+  text:string, // Plain question text
+  applesSceneNumber?:number, // Ask for text response and log it specially
+};
+
+
+function slidesFor(cohortKey) {
+  const slides:[QuestionT] = [];
+
+  slides.push({ type: 'Hello!', text: 'Does this work?' });
+  slides.push({ type: 'Hello!', text: 'Jose is watching YouTube.', applesSceneNumber: 0 });
+  slides.push({ type: 'Hello!', text: 'Samir puts his head down.', applesSceneNumber: 1 });
+
+  return slides;
+}
+
+
+export default {
+  questionsFor(cohortKey) {
+    return slidesFor(cohortKey);
+  }
+};

--- a/ui/src/message_popup/playtest/hmtca_scenario.jsx
+++ b/ui/src/message_popup/playtest/hmtca_scenario.jsx
@@ -9,19 +9,35 @@ export type QuestionT = {
 };
 
 
-function slidesFor(cohortKey) {
+// Different categories for classroom management
+const BUCKETS = [
+  { id: 201, text: 'Students refusing to work' },
+  { id: 202, text: 'Disrespect towards teachers' },
+  { id: 203, text: 'Disrespect towards females' },
+  { id: 204, text: 'Combination of the above' }
+];
+
+
+function slidesFor(cohortKey, bucketId) {
   const slides:[QuestionT] = [];
 
-  slides.push({ type: 'Hello!', text: 'Does this work?' });
-  slides.push({ type: 'Hello!', text: 'Jose is watching YouTube.', applesSceneNumber: 0 });
-  slides.push({ type: 'Hello!', text: 'Samir puts his head down.', applesSceneNumber: 1 });
+  if (bucketId === 201) {
+    slides.push({ type: 'Hello!', text: 'Does this work?' });
+    slides.push({ type: 'Hello!', text: 'Jose is watching YouTube.', applesSceneNumber: 1 });
+    slides.push({ type: 'Hello!', text: 'Samir puts his head down.', applesSceneNumber: 2 });
+  } else {
+    slides.push({ type: 'Hello!', text: 'These scenarios are...' });
+    slides.push({ type: 'Hello!', text: 'Jose is watching YouTube.', applesSceneNumber: 1 });
+    slides.push({ type: 'Hello!', text: 'Samir puts his head down.', applesSceneNumber: 2 });
+  }
 
   return slides;
 }
 
 
 export default {
-  questionsFor(cohortKey) {
-    return slidesFor(cohortKey);
+  BUCKETS,
+  questionsFor(cohortKey, bucketId) {
+    return slidesFor(cohortKey, bucketId);
   }
 };

--- a/ui/src/message_popup/renderers/apples_text_response.jsx
+++ b/ui/src/message_popup/renderers/apples_text_response.jsx
@@ -29,6 +29,11 @@ export default React.createClass({
         sceneNumber: this.props.applesSceneNumber,
         anonymizedText: response.responseText
       });
+    } else if (type === 'message_popup_text_ignore') {
+      this.props.onLogMessage('anonymized_apples_to_apples_partial', {
+        sceneNumber: this.props.applesSceneNumber,
+        anonymizedText: "(Move on)"
+      });
     }
   },
 

--- a/ui/src/message_popup/renderers/apples_text_response.jsx
+++ b/ui/src/message_popup/renderers/apples_text_response.jsx
@@ -1,0 +1,43 @@
+/* @flow weak */
+import React from 'react';
+
+import MinimalTextResponse from './minimal_text_response.jsx';
+
+
+// This double-logs text responses for Apples-to-Apples style group reviewing.
+// It's intended to be have the same API as MinimalTextResponse.
+export default React.createClass({
+  displayName: 'ApplesTextResponse',
+
+  propTypes: {
+    applesSceneNumber: React.PropTypes.number.isRequired,
+    onLogMessage: React.PropTypes.func.isRequired,
+    onResponseSubmitted: React.PropTypes.func.isRequired,
+    forceResponse: React.PropTypes.bool,
+    responsePrompt: React.PropTypes.string,
+    recordText: React.PropTypes.string,
+    ignoreText: React.PropTypes.string,
+    autoFocus: React.PropTypes.bool,
+    textHeight: React.PropTypes.number
+  },
+
+
+  // Watch for text responses, and double-log them.
+  onApplesLogMessage(type, response) {
+    if (type === 'message_popup_text_response' && response.responseText) {
+      this.props.onLogMessage('anonymized_apples_to_apples_partial', {
+        sceneNumber: this.props.applesSceneNumber,
+        anonymizedText: response.responseText
+      });
+    }
+  },
+
+  render() {
+    const props = {
+      ...this.props,
+      onLogMessage: this.onApplesLogMessage
+    };
+
+    return <MinimalTextResponse {...props} />;
+  }
+});

--- a/ui/src/message_popup/renderers/mixed_question.jsx
+++ b/ui/src/message_popup/renderers/mixed_question.jsx
@@ -16,12 +16,12 @@ export default React.createClass({
     const {question} = this.props;
     return (
       <div className="MixedQuestion">
-        <b style={{
+        {(question.type !== undefined) && <b style={{
           display: 'block',
           padding: '15px 20px 15px',
           background: '#09407d',
           color: 'white'
-        }}>{question.type}</b>
+        }}>{question.type}</b>}
         {question.el && <ReactQuestion el={question.el} />}
         {question.text && <PlainTextQuestion question={{text: question.text}} />}
       </div>

--- a/ui/src/message_popup/renderers/question_interpreter.jsx
+++ b/ui/src/message_popup/renderers/question_interpreter.jsx
@@ -7,6 +7,7 @@ import MinimalOpenResponse from '../renderers/minimal_open_response.jsx';
 import MinimalTextResponse from '../renderers/minimal_text_response.jsx';
 import AudioCapture from '../../components/audio_capture.jsx';
 import MinimalTimedView from '../renderers/minimal_timed_view.jsx';
+import ApplesTextResponse from '../renderers/apples_text_response.jsx';
 
 
 // This renders a question and an interaction, and strives towards being a
@@ -71,6 +72,20 @@ export default React.createClass({
       }
     }
 
+    // Double-log for reading back safely during group reviews
+    if (question.applesSceneNumber !== undefined) {
+      return <ApplesTextResponse
+        key={key}
+        applesSceneNumber={question.applesSceneNumber}
+        forceResponse={question.force || false}
+        responsePrompt=""
+        recordText="Respond"
+        ignoreText="Move on"
+        onLogMessage={onLogMessage}
+        onResponseSubmitted={onResponseSubmitted}
+        />;
+    }
+
     if (question.write) {
       return <MinimalTextResponse
         key={key}
@@ -81,7 +96,6 @@ export default React.createClass({
         onResponseSubmitted={onResponseSubmitted}
       />;
     }
-
 
     if (question.notes) {
       return <MinimalTextResponse


### PR DESCRIPTION
This adds a new `/teachermoments/hmtca` route as a first prototype for the HMTCA session.  It also adds two new server endpoints - each for writing and reading `anonymized_apples_to_apples` data storing `(apples_key, scene_number, scene_text, anonymized_text)` so that we can store this data separately from data with other identifying data (eg., sessionId, timestamp).  These are used in a review UI at the end.  There's no way to synchronize between different users at the moment - that would be a great use for adding in a timer loop :)

In the process, I ran into some linting errors and also added linting for the server code.

<img width="375" alt="screen shot 2017-08-04 at 1 53 02 pm" src="https://user-images.githubusercontent.com/1056957/28982307-5cc27c02-7923-11e7-9133-5b2a82361909.png">
<img width="376" alt="screen shot 2017-08-04 at 2 43 11 pm" src="https://user-images.githubusercontent.com/1056957/28982314-5fdbccfe-7923-11e7-9b3b-a6a3e6b465ff.png">

<img width="359" alt="screen shot 2017-08-04 at 1 10 43 am" src="https://user-images.githubusercontent.com/1056957/28955194-a41f474a-78b2-11e7-9e9a-8c2720e57bda.png">
