### PR TITLE
adds facilitated and fully online options to the smithTimer scenario

### DIFF
--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -58,7 +58,8 @@ export default React.createClass({
     '/teachermoments/jayden': 'jaydenScenario',
     '/teachermoments/smithA': 'smithScenarioA',
     '/teachermoments/smithB': 'smithScenarioB',
-    '/teachermoments/smithFacilitated': 'smithScenario',
+    '/teachermoments/smithFacilitated': 'smithFacilitatedScenario',
+    '/teachermoments/smith': 'smithScenario',
     '/teachermoments/ecs': 'ecsScenario',
 
 
@@ -152,7 +153,11 @@ export default React.createClass({
   },
 
   smithScenario(query = {}) {
-    return <MessagePopup.SmithExperiencePage query={{}}/>;
+    return <MessagePopup.SmithExperiencePage query={query} facilitated={false} />;
+  },
+
+  smithFacilitatedScenario(query = {}) {
+    return <MessagePopup.SmithExperiencePage query={query} facilitated={true} />;
   },
 
   messagePopupBubbleSort(query = {}) {

--- a/ui/src/message_popup/playtest/smith_experience_page.jsx
+++ b/ui/src/message_popup/playtest/smith_experience_page.jsx
@@ -28,12 +28,23 @@ export default React.createClass({
     query: React.PropTypes.shape({
       cohort: React.PropTypes.string,
       p: React.PropTypes.string
-    }).isRequired
+    }).isRequired,
+    facilitated: React.PropTypes.bool.isRequired
   },
 
   contextTypes: {
     auth: React.PropTypes.object.isRequired
   },
+
+
+
+
+  getDefaultProps() {
+    return {
+      facilitated: false
+    };
+  },
+
 
   // Cohort comes from URL
   getInitialState() {
@@ -52,8 +63,8 @@ export default React.createClass({
   // Making questions from the cohort
   onStart(email) {
     const {cohortKey} = this.state;
-    const allQuestions = smithScenario.questionsFor(cohortKey);
-
+    const {facilitated} = this.props;
+    const allQuestions = smithScenario.questionsFor(cohortKey, (facilitated));
     const startQuestionIndex = this.props.query.p || 0; // for testing or demoing
     const questions = allQuestions.slice(startQuestionIndex);
     const questionsHash = hash(JSON.stringify(questions));

--- a/ui/src/message_popup/playtest/smith_experience_page.jsx
+++ b/ui/src/message_popup/playtest/smith_experience_page.jsx
@@ -64,7 +64,7 @@ export default React.createClass({
   onStart(email) {
     const {cohortKey} = this.state;
     const {facilitated} = this.props;
-    const allQuestions = smithScenario.questionsFor(cohortKey, (facilitated));
+    const allQuestions = smithScenario.questionsFor(cohortKey, {isFacilitated: facilitated});
     const startQuestionIndex = this.props.query.p || 0; // for testing or demoing
     const questions = allQuestions.slice(startQuestionIndex);
     const questionsHash = hash(JSON.stringify(questions));

--- a/ui/src/message_popup/playtest/smith_scenario.jsx
+++ b/ui/src/message_popup/playtest/smith_scenario.jsx
@@ -13,25 +13,33 @@ export type QuestionT = {
 };
 
 
-function slidesFor(cohortKey) {
+
+function slidesFor(cohortKey, isFacilitated) {
   const slides:[QuestionT] = [];
+
 
   slides.push({ type: 'Overview', el:
     <div>
     <div>1. Set Context</div>
-    <div>Imagine yourself as a teacher situated in the context of the particular school, classroom and subject.</div>
+    <div>Imagine yourself as an observer in a highschool computer science classroom taught by a fellow teacher. Your role is to observe your fellow teacher and give feedback to the best of your ability.</div>
     <br />
     <div>2. Background</div>
-    <div>A little bit of background information on the lesson being taught.</div>
+    <div>You'll receive a bit of background information on the lesson being taught.</div>
     <br />
     <div>3. Try it!</div>
     <div>When you're ready, you'll go through a set of short scenes that simulate moments in the classroom. Note what you observe.</div>
     <br />
-    <div>4. PAUSE!</div>
-    <div>Pause for a brief group discussion before resuming.</div>
+    {(isFacilitated)
+      ? <div>
+        <div>4. PAUSE!</div>
+       <div>After the first set of scenes, pause for a brief group discussion before resuming.</div></div>
+      : <div>
+        <div>4. Reflect</div>
+       <div>After the first set of scenes you'll get a chance to reflect on what you observed before moving on.</div>
+       </div>}
     <br />
     <div>5. Lenses</div>
-    <div>You will go through another set of scenes, this time with a new focus.</div>
+    <div>Finally, you'll be given a second set of scenes to observe. This time you'll be asked to view the classroom interactions with a more specific focus.</div>
   </div>
   });
 
@@ -107,10 +115,7 @@ Okay! Ready to start?`
 
 
   slides.push({type: 'Try it!', text:
-`
-What did you notice? Take notes below!
-` , notes: true
-
+`What did you notice? Take notes below!` , notes: true
 });
 
 
@@ -165,8 +170,7 @@ What did you notice? Take notes below!
 
 
   slides.push({type: 'Try it!', text:
-`
-` , notes: true
+`` , notes: true
 
 });
 
@@ -198,8 +202,7 @@ What did you notice? Take notes below!
 
 
   slides.push({type: 'Try it!', text:
-`
-` , notes: true
+`` , notes: true
 
 });
 
@@ -229,8 +232,7 @@ What did you notice? Take notes below!
 
 
   slides.push({type: 'Try it!', text:
-`
-` , notes: true
+`` , notes: true
 
 });
 
@@ -260,8 +262,7 @@ What did you notice? Take notes below!
 
 
   slides.push({type: 'Try it!', text:
-`
-` , notes: true
+`` , notes: true
 
 });
 
@@ -290,36 +291,67 @@ What did you notice? Take notes below!
 
 
   slides.push({type: 'Try it!', text:
-`
-` , notes: true
+`` , notes: true
 
 });
 
 
-  slides.push({type: 'Try it!', text:
+
+  if (isFacilitated) {
+    slides.push({type: 'Try it!', text:
+    `That's the end of the class! Take a moment to reflect on how you felt the class went overall.` 
+
+    });
+        
+
+    slides.push({type: 'Try it!', text:
+    `Once the students have left, your friend Mr. Smith comes up to you and asks for your thoughts. What feedback would you give him about what you observed?`, notes: true
+    });
+
+    slides.push({type: 'PAUSE!', text:
+    `PAUSE HERE
+
+
+    Pause here and return to the group. We will continue with this part of the simulation after a brief group discussion. 
+    `});
+  }
+
+  else {
+    slides.push({type: 'Reflect', text:
+    ` That's the end of the class! You will now get a chance to reflect on what you observed.
+    ` 
+    });
+
+    slides.push({type: 'Reflect', text:
+    `How do you feel the class went overall?`, notes: true 
+    });
+
+    slides.push({type: 'Reflect', text:
+    `How did different students experience the class?`, notes: true 
+    });
+
+    slides.push({type: 'Reflect', text:
+    `How did Mr. Smith's actions impact the students' experience?`, notes: true 
+    });
+
+    slides.push({type: 'Reflect', text:
+    `Once the students have left, your friend Mr. Smith comes up to you and asks for your thoughts. What feedback would you give him about what you observed?`, notes: true
+    });
+  }
+
+
+
+
+  slides.push({type: 'Class #2', text:
 `
-That's the end of the class! Take a moment to reflect on how you felt the class went overall.
+
+Take a moment and collect yourself. It's time for class #2! 
+
 ` 
 
 });
-    
-
-  slides.push({type: 'Try it!', text:
-`Once the students have left, your friend Mr. Smith comes up to you and asks for your thoughts. What feedback would you give him about what you observed?
- `,
-  notes: true
-
-});
-    // ---------------------------------
-    // PAUSE 
-    // ---------------------------------
-
-  slides.push({type: 'PAUSE!', text:
-  `PAUSE HERE
 
 
-Pause here and return to the group. We will continue with this part of the simulation after a brief group discussion. 
-`});
 
     // ---------------------------------
     // Round TWO
@@ -348,7 +380,6 @@ Pause here and return to the group. We will continue with this part of the simul
   Jose: Hispanic Male
   Li: Asian American Male
   Mark: White Male
-
 ` 
 });
 
@@ -380,10 +411,8 @@ Ready? Okay! Go!
   });
 
 
-  slides.push({type: 'Try it!', text:
-`
-What did you notice? Take notes below!
-` , notes: true
+  slides.push({type: 'Try it! - Lenses', text:
+`What did you notice? Take notes below!` , notes: true
 
 });
 
@@ -407,9 +436,8 @@ What did you notice? Take notes below!
   });
 
 
-  slides.push({type: 'Try it!', text:
-`
-` , notes: true
+  slides.push({type: 'Try it! - Lenses', text:
+`` , notes: true
 
 });
 
@@ -430,9 +458,8 @@ What did you notice? Take notes below!
   });
 
 
-  slides.push({type: 'Try it!', text:
-`
-` , notes: true
+  slides.push({type: 'Try it! - Lenses', text:
+`` , notes: true
 
 });
 
@@ -453,9 +480,8 @@ What did you notice? Take notes below!
   });
 
 
-  slides.push({type: 'Try it!', text:
-`
-` , notes: true
+  slides.push({type: 'Try it! - Lenses', text:
+`` , notes: true
 
 });
 
@@ -478,9 +504,8 @@ What did you notice? Take notes below!
   });
 
 
-  slides.push({type: 'Try it!', text:
-`
-` , notes: true
+  slides.push({type: 'Try it! - Lenses', text:
+`` , notes: true
 
 });
 
@@ -503,28 +528,53 @@ What did you notice? Take notes below!
   });
 
 
-  slides.push({type: 'Try it!', text:
-`
-` , notes: true
-
-});
-
-
-
   slides.push({type: 'Try it! - Lenses', text:
-`
-That's the end of the class! Take a moment to reflect on how you felt the class went overall.
-` 
+`` , notes: true
 
 });
-    
 
-  slides.push({type: 'Try it! - Lenses', text:
-`At the end of the second class, Mr. Smith again comes up to you and asks for your thoughts. What feedback would you give him about what you observed?
- `,
-  notes: true
 
-});
+
+  if (isFacilitated) {
+    slides.push({type: 'Try it! - Lenses', text:
+    `
+    That's the end of the class! Take a moment to reflect on how you felt the class went overall.
+    ` 
+    });
+        
+
+    slides.push({type: 'Try it! - Lenses', text:
+    `At the end of the second class, Mr. Smith again comes up to you and asks for your thoughts. What feedback would you give him about what you observed?`,
+      notes: true
+    });
+  }
+
+
+  else {
+    slides.push({type: 'Reflect - Lenses', text:
+    ` That's the end of the class! You will now get a chance to reflect on what you observed.` 
+    });
+
+
+    slides.push({type: 'Reflect - Lenses', text:
+    `How do you feel the class went overall?`, notes: true 
+    });
+
+    slides.push({type: 'Reflect - Lenses', text:
+    `Did you notice any social dynamics between students related to race/ethnicity/gender/class?`, notes: true 
+    });
+
+    slides.push({type: 'Reflect - Lenses', text:
+    `How are the interactions impacting the confidence of the students involved and their motivation to learn?`, notes: true 
+    });
+
+    slides.push({type: 'Reflect - Lenses', text:
+    `At the end of the second class, Mr. Smith again comes up to you and asks for your thoughts. What would you say to Mr. Smith?`, notes: true
+    });
+  }
+
+
+
 
 
   return slides;
@@ -532,7 +582,7 @@ That's the end of the class! Take a moment to reflect on how you felt the class 
 
 
 export const smithScenario = {
-  questionsFor(cohortKey) {
-    return slidesFor(cohortKey);
+  questionsFor(cohortKey, isFacilitated) {
+    return slidesFor(cohortKey, isFacilitated);
   }
 };

--- a/ui/src/message_popup/playtest/smith_scenario.jsx
+++ b/ui/src/message_popup/playtest/smith_scenario.jsx
@@ -14,7 +14,7 @@ export type QuestionT = {
 
 
 
-function slidesFor(cohortKey, isFacilitated) {
+function slidesFor(cohortKey, options) {
   const slides:[QuestionT] = [];
 
 
@@ -29,7 +29,7 @@ function slidesFor(cohortKey, isFacilitated) {
     <div>3. Try it!</div>
     <div>When you're ready, you'll go through a set of short scenes that simulate moments in the classroom. Note what you observe.</div>
     <br />
-    {(isFacilitated)
+    {(options.isFacilitated)
       ? <div>
         <div>4. PAUSE!</div>
        <div>After the first set of scenes, pause for a brief group discussion before resuming.</div></div>
@@ -297,7 +297,7 @@ Okay! Ready to start?`
 
 
 
-  if (isFacilitated) {
+  if (options.isFacilitated) {
     slides.push({type: 'Try it!', text:
     `That's the end of the class! Take a moment to reflect on how you felt the class went overall.` 
 
@@ -535,7 +535,7 @@ Ready? Okay! Go!
 
 
 
-  if (isFacilitated) {
+  if (options.isFacilitated) {
     slides.push({type: 'Try it! - Lenses', text:
     `
     That's the end of the class! Take a moment to reflect on how you felt the class went overall.
@@ -582,7 +582,7 @@ Ready? Okay! Go!
 
 
 export const smithScenario = {
-  questionsFor(cohortKey, isFacilitated) {
-    return slidesFor(cohortKey, isFacilitated);
+  questionsFor(cohortKey, options) {
+    return slidesFor(cohortKey, options);
   }
 };


### PR DESCRIPTION
This branch takes smithTimer and splits it into two web-addresses (each with subtle scenario differences) based on whether the scenario is being facilitated or taken fully online. 

The two new web-addresses are as follows:
     /teachermoments/smithFacilitated:  For facilitated uses of the Smith scenario
     /teachermoments/smith :  For fully online (individual) use of the Smith scenario

Code Modifications:

App.jsx    -  Adds the two URLs for the smith scenario. Depending on which is accessed, a boolean (for use within the singular smith_scenario.jsx) is set to represent whether it is a facilitated or individual use.

smith_experience_page.jsx    -   Adds a required facilitated/unfacilitated boolean. Sets default boolean value to false. Changes, allQuestions to pass said boolean to smith_scenario. 

smith_scenario.jsx    -  Adds boolean variable to slidesFor function. Lines 32-39 change Step 4 depending on whether the scenario is being facilitated or not.  Made cosmetic changes to the notes pages. 290-345 changes/adds the post scene set #1 questions depending on facilitated (this is a major change). Similarly, lines 538-575 do the same for scene set #2 (the other major change). 

![screen shot 2017-08-07 at 9 57 43 am](https://user-images.githubusercontent.com/25137921/29030962-bab32b8e-7b5a-11e7-8f9d-e40c0de800b1.png)

