### PR TITLE
adds initial scene text to hmtca

### DIFF
--- a/ui/src/message_popup/playtest/hmtca_scenario.jsx
+++ b/ui/src/message_popup/playtest/hmtca_scenario.jsx
@@ -43,9 +43,35 @@ const TEAM_CODES = _.sortBy([
 
 function slidesFor(cohortKey, bucketId) {
   const slides:[QuestionT] = [];
+  slides.push({ text: `1. Practice
+
+You're about to be presented with several different situations with students based on the selection you made on the previous screen.
+
+After you click "Practice," you'll see your first scene involving student(s) and you’ll type how you'd respond to the student(s) in the moment. Once you finished your response to the first scene, another scene will appear and you’ll type your response to that scene. This process will continue until you’ve read and responded to six (6) different scenes.
+`});
+
+  slides.push({ text: `2. Reflect and Discuss
+
+Once you’ve responded to all the scenes, you’ll come back as a group and discuss your responses in the vein of apples-to-apples. Basically, one person will be the “owner” of the first scene and will review the responses to the scene with the group and then select their preferred response based on the group’s feedback and their own preferences. The next person will “own” the second scene and will repeat the process as described above. You will do this until everyone has had a turn “owning” a scene.
+`});
+
+
+  slides.push({ text: `3. Connect to Personal Experience
+
+Once all members of your team have had a chance to “own” a scene, you will debrief as a team by discussing your personal experiences with students engaging in the behavior you selected at the beginning.
+
+
+
+4. Return to Large Group Discussion
+
+Once 60 minutes elapses, you will return to the all-school discussion.
+
+
+`});
+
 
   if (bucketId === 201) {
-    slides.push({ text: 'Students Refusing to do Work'});
+    slides.push({ text: 'Students Refusing to do Work:'});
     
     slides.push({ text: 'Students are using Chromebooks to work on individual projects in class. As you walk around the classroom, you notice Jose watching a music video on YouTube instead of doing work.', applesSceneNumber: 1 });
     
@@ -64,7 +90,7 @@ Now class has started and you’ve asked students to turn in their assignments. 
 
 
   else if (bucketId === 202) {
-    slides.push({ text: 'Disrespect Towards Teachers'});
+    slides.push({ text: 'Disrespect Towards Teachers:'});
     
     slides.push({ text: 'You’re teaching ELA. You’re in the middle of discussing Romeo and Juliet when Carlos interrupts you without raising his hand and says, “Why does any of this matter? How is Shakespeare going to help me get a job? Stop wasting our time!”', applesSceneNumber: 1});
     
@@ -81,7 +107,7 @@ Now class has started and you’ve asked students to turn in their assignments. 
 
 
   else if (bucketId === 203) {
-    slides.push({ text: 'Disrespect Towards Female Students'});
+    slides.push({ text: 'Disrespect Towards Female Students:'});
     
     slides.push({ text: 'It’s March and students are starting to receive their college acceptance letters. You are teaching Physics and you hear Amy talk about getting accepted to MIT. Another student, Mike, responds to her by saying, “You only got accepted to MIT because you’re a girl.”', applesSceneNumber: 1});
     

--- a/ui/src/message_popup/playtest/hmtca_scenario.jsx
+++ b/ui/src/message_popup/playtest/hmtca_scenario.jsx
@@ -45,13 +45,71 @@ function slidesFor(cohortKey, bucketId) {
   const slides:[QuestionT] = [];
 
   if (bucketId === 201) {
-    slides.push({ text: 'Does this work?' });
-    slides.push({ text: 'Jose is watching YouTube.', applesSceneNumber: 1 });
-    slides.push({ text: 'Samir puts his head down.', applesSceneNumber: 2 });
-  } else {
-    slides.push({ text: 'These scenarios are...' });
-    slides.push({ text: 'Jose is watching YouTube.', applesSceneNumber: 1 });
-    slides.push({ text: 'Samir puts his head down.', applesSceneNumber: 2 });
+    slides.push({ text: 'Students Refusing to do Work'});
+    
+    slides.push({ text: 'Students are using Chromebooks to work on individual projects in class. As you walk around the classroom, you notice Jose watching a music video on YouTube instead of doing work.', applesSceneNumber: 1 });
+    
+    slides.push({ text: 'An ELA teacher is leading a discussion on Othello. Julia, a student that usually sits in the second or third row of desks, has chosen to sit in the back today. About 15 minutes into your discussion, you notice Julia has spent most of the class with her head down and writing feverishly on a piece of paper. As you continue the discussion, you gradually start moving toward Julia and see what looks like Algebra homework.', applesSceneNumber: 2 });
+
+    slides.push({ text: 'You have a flexible cell phone policy in your class. Rosario and Fabiola typically sit next to each other during class but they’ve decided to sit on separate sides of the classroom today. As you’re going through your lecture, you notice Rosario and Fabiola have their heads down for most of the class and it appears they’re doing something on their phones. As class continues, you notice that only one of them has their head down at a time and when one looks up, the other’s head comes down. You suspect they may be arguing over text.', applesSceneNumber: 3});
+
+    slides.push({ text: 'Two weeks ago, you assigned a group project in class. Currently, there’s about a week left before students have to submit their assignments. After class ends this day, one of your students, Mark, comes up to you and says, “Hey my group is doing fine on the group project but I’m having to do extra work because Tyshawn doesn’t do anything and doesn’t offer to do anything. It’s super frustrating. Are you going to give us all the same grade or are you going to give Tyshawn the grade he deserves?”', applesSceneNumber: 4});
+    
+    slides.push({ text: `In the morning, you check your email for the first time in the day since before you went to sleep last night. You see an email from Drew and it arrived at 11:00pm last night after you had gone to bed. In the email he said he’s confused about the assignment and is stuck.
+
+Now class has started and you’ve asked students to turn in their assignments. Drew raises his hand and in front of everybody says, “I didn’t do the assignment because you never responded to my email.”`, applesSceneNumber: 5});
+    
+    slides.push({ text: 'You are a history teacher and you’re teaching a lesson on the Women’s Suffrage Movement. Jamika has her head down and is scrolling through her phone. A classmate sitting next to Jamika taps her on the shoulder and says, “Pay attention.” Jamika responds by saying, “I’m not paying attention to this whitewashed crap. Where are the black people?”', applesSceneNumber: 6});
+  } 
+
+
+  else if (bucketId === 202) {
+    slides.push({ text: 'Disrespect Towards Teachers'});
+    
+    slides.push({ text: 'You’re teaching ELA. You’re in the middle of discussing Romeo and Juliet when Carlos interrupts you without raising his hand and says, “Why does any of this matter? How is Shakespeare going to help me get a job? Stop wasting our time!”', applesSceneNumber: 1});
+    
+    slides.push({ text: 'You’re walking around the classroom going desk-to-desk taking your students’ assignments. You arrive at William’s desk and he doesn’t acknowledge your presence, keeping his head down and staring at his phone. You tell William, “It’s time to hand in your paper.” William doesn’t respond. You ask William if he completed his paper, to which he mutters under his breath without looking up, “Fuck off.”', applesSceneNumber: 2});
+    
+    slides.push({ text: 'You’ve started class and notice that Karina hasn’t shown up yet. After 15 minutes have passed, Karina shows up. When you confront her, she says, “I told you I was going to be late today. Did you forget?” You’re confident she did not tell you because you typically take meticulous notes about when students will be late to class.', applesSceneNumber: 3});
+    
+    slides.push({ text: 'You’re having lunch with Janice to talk about writing a recommendation for her. You decide to ask her how she’s doing in her classes overall. She responds by saying, “I’m doing pretty well overall, but I’m doing poorly in Mr. Smith’s class because he doesn’t like girls.”', applesSceneNumber: 4});
+    
+    slides.push({ text: 'You have assigned a “free-write” activity to your class to brainstorm ideas for a short story. The rule is that everyone brainstorms freely for three minutes without stopping. Everyone’s pencil is moving constantly except for Jamal’s, who is staring out the window. You say, “Jamal, please start writing.” Jamal holds his pencil up, breaks it in half, and glares at you.', applesSceneNumber: 5});
+    
+    slides.push({ text: 'You have a “no cell phones” policy in class. One day at the start of class, Trent has his cell phone out on his desk. When you remind him about your cell phone policy, he says, “I can’t put my phone away because I’m expecting a call from your mom.”', applesSceneNumber: 6});
+  }
+
+
+  else if (bucketId === 203) {
+    slides.push({ text: 'Disrespect Towards Female Students'});
+    
+    slides.push({ text: 'It’s March and students are starting to receive their college acceptance letters. You are teaching Physics and you hear Amy talk about getting accepted to MIT. Another student, Mike, responds to her by saying, “You only got accepted to MIT because you’re a girl.”', applesSceneNumber: 1});
+    
+    slides.push({ text: 'It’s Career Day, when students talk about the careers they are interested in and where they see themselves in 20 years. Ashley says she would like to be the head of a Fortune 500 tech company. Kevin snorts loudly. “Good luck,” he says. “You know there are like no women CEOs, right?”', applesSceneNumber: 2});
+    
+    slides.push({ text: `You’ve finished grading Algebra assignments. As you’re handing them back, you hear the following conversation unfold between Mike and Lisa:
+
+Mike: “Lisa, how did you do?”
+
+Lisa: “I got 95% on the assignment.”
+
+Mike: “Woah. I didn’t know pretty chicks could be good at math. You sleeping with the teacher?” 
+
+Lisa looks away, visibly angry.
+      `, applesSceneNumber: 3});
+    
+    slides.push({ text: 'An assignment is due at the beginning of class today. When Johnny hands in his assignment, he says, “I’m getting an A because you like me so much, right?” Krystal hears this and says, “Teacher doesn’t like you that much, so you must be getting an F.” Johnny replies, “Krystal - are you being bitchy because you’re on your period?” Krystal angrily responds, “Go to hell!”', applesSceneNumber: 4});
+    
+    slides.push({ text: 'The prototype of the bridge the students have built has sagged during testing. You ask if anyone has any ideas about how this problem could be solved. Julie raises her hand and says, "We need to provide some support for the load of the bridge, probably with tower suspension lines." Carter then adds, "I think what she means is that the bridge needs to be supported with guide wires from the towers." Julie mutters under her breath, “I just said that.”', applesSceneNumber: 5});
+    
+    slides.push({ text: 'You’re a Geometry teacher in the middle of a lecture about the Pythagorean theorem. Amanda raises her hand and asks, “Can you use the theorem for all triangles?” Connor turns to one of his classmates and says, “That’s a stupid question.”', applesSceneNumber: 6});
+  }
+
+
+  else {
+    slides.push({ text: 'Mix'});
+    slides.push({ text: 'Empty', applesSceneNumber: 1 });
+    slides.push({ text: '', applesSceneNumber: 2 });
   }
 
   return slides;

--- a/ui/src/message_popup/playtest/hmtca_scenario.jsx
+++ b/ui/src/message_popup/playtest/hmtca_scenario.jsx
@@ -41,8 +41,12 @@ const TEAM_CODES = _.sortBy([
 ]);
 
 
+function addInAppleSceneNumber(slide, index) {
+  return {...slide, applesSceneNumber: index + 1};
+}
+
 function slidesFor(cohortKey, bucketId) {
-  const slides:[QuestionT] = [];
+  var slides:[QuestionT] = [];
   slides.push({ text: `1. Practice
 
 You're about to be presented with several different situations with students based on the selection you made on the previous screen.
@@ -69,51 +73,45 @@ Once 60 minutes elapses, you will return to the all-school discussion.
 
 `});
 
-
-  if (bucketId === 201) {
-    slides.push({ text: 'Students Refusing to do Work:'});
+  const refusingWorkSlides = [
+    { text: 'Students are using Chromebooks to work on individual projects in class. As you walk around the classroom, you notice Jose watching a music video on YouTube instead of doing work.' },
     
-    slides.push({ text: 'Students are using Chromebooks to work on individual projects in class. As you walk around the classroom, you notice Jose watching a music video on YouTube instead of doing work.', applesSceneNumber: 1 });
-    
-    slides.push({ text: 'An ELA teacher is leading a discussion on Othello. Julia, a student that usually sits in the second or third row of desks, has chosen to sit in the back today. About 15 minutes into your discussion, you notice Julia has spent most of the class with her head down and writing feverishly on a piece of paper. As you continue the discussion, you gradually start moving toward Julia and see what looks like Algebra homework.', applesSceneNumber: 2 });
+    { text: 'An ELA teacher is leading a discussion on Othello. Julia, a student that usually sits in the second or third row of desks, has chosen to sit in the back today. About 15 minutes into your discussion, you notice Julia has spent most of the class with her head down and writing feverishly on a piece of paper. As you continue the discussion, you gradually start moving toward Julia and see what looks like Algebra homework.' },
 
-    slides.push({ text: 'You have a flexible cell phone policy in your class. Rosario and Fabiola typically sit next to each other during class but they’ve decided to sit on separate sides of the classroom today. As you’re going through your lecture, you notice Rosario and Fabiola have their heads down for most of the class and it appears they’re doing something on their phones. As class continues, you notice that only one of them has their head down at a time and when one looks up, the other’s head comes down. You suspect they may be arguing over text.', applesSceneNumber: 3});
+    { text: 'You have a flexible cell phone policy in your class. Rosario and Fabiola typically sit next to each other during class but they’ve decided to sit on separate sides of the classroom today. As you’re going through your lecture, you notice Rosario and Fabiola have their heads down for most of the class and it appears they’re doing something on their phones. As class continues, you notice that only one of them has their head down at a time and when one looks up, the other’s head comes down. You suspect they may be arguing over text.'},
 
-    slides.push({ text: 'Two weeks ago, you assigned a group project in class. Currently, there’s about a week left before students have to submit their assignments. After class ends this day, one of your students, Mark, comes up to you and says, “Hey my group is doing fine on the group project but I’m having to do extra work because Tyshawn doesn’t do anything and doesn’t offer to do anything. It’s super frustrating. Are you going to give us all the same grade or are you going to give Tyshawn the grade he deserves?”', applesSceneNumber: 4});
+    { text: 'Two weeks ago, you assigned a group project in class. Currently, there’s about a week left before students have to submit their assignments. After class ends this day, one of your students, Mark, comes up to you and says, “Hey my group is doing fine on the group project but I’m having to do extra work because Tyshawn doesn’t do anything and doesn’t offer to do anything. It’s super frustrating. Are you going to give us all the same grade or are you going to give Tyshawn the grade he deserves?”'},
     
-    slides.push({ text: `In the morning, you check your email for the first time in the day since before you went to sleep last night. You see an email from Drew and it arrived at 11:00pm last night after you had gone to bed. In the email he said he’s confused about the assignment and is stuck.
+    { text: `In the morning, you check your email for the first time in the day since before you went to sleep last night. You see an email from Drew and it arrived at 11:00pm last night after you had gone to bed. In the email he said he’s confused about the assignment and is stuck.
 
-Now class has started and you’ve asked students to turn in their assignments. Drew raises his hand and in front of everybody says, “I didn’t do the assignment because you never responded to my email.”`, applesSceneNumber: 5});
+Now class has started and you’ve asked students to turn in their assignments. Drew raises his hand and in front of everybody says, “I didn’t do the assignment because you never responded to my email.”`},
     
-    slides.push({ text: 'You are a history teacher and you’re teaching a lesson on the Women’s Suffrage Movement. Jamika has her head down and is scrolling through her phone. A classmate sitting next to Jamika taps her on the shoulder and says, “Pay attention.” Jamika responds by saying, “I’m not paying attention to this whitewashed crap. Where are the black people?”', applesSceneNumber: 6});
-  } 
+    { text: 'You are a history teacher and you’re teaching a lesson on the Women’s Suffrage Movement. Jamika has her head down and is scrolling through her phone. A classmate sitting next to Jamika taps her on the shoulder and says, “Pay attention.” Jamika responds by saying, “I’m not paying attention to this whitewashed crap. Where are the black people?”'}];
 
 
-  else if (bucketId === 202) {
-    slides.push({ text: 'Disrespect Towards Teachers:'});
+
+  const teacherDisrespect = [
+
+    { text: 'You’re teaching ELA. You’re in the middle of discussing Romeo and Juliet when Carlos interrupts you without raising his hand and says, “Why does any of this matter? How is Shakespeare going to help me get a job? Stop wasting our time!”'},
     
-    slides.push({ text: 'You’re teaching ELA. You’re in the middle of discussing Romeo and Juliet when Carlos interrupts you without raising his hand and says, “Why does any of this matter? How is Shakespeare going to help me get a job? Stop wasting our time!”', applesSceneNumber: 1});
+    { text: 'You’re walking around the classroom going desk-to-desk taking your students’ assignments. You arrive at William’s desk and he doesn’t acknowledge your presence, keeping his head down and staring at his phone. You tell William, “It’s time to hand in your paper.” William doesn’t respond. You ask William if he completed his paper, to which he mutters under his breath without looking up, “Fuck off.”'},
     
-    slides.push({ text: 'You’re walking around the classroom going desk-to-desk taking your students’ assignments. You arrive at William’s desk and he doesn’t acknowledge your presence, keeping his head down and staring at his phone. You tell William, “It’s time to hand in your paper.” William doesn’t respond. You ask William if he completed his paper, to which he mutters under his breath without looking up, “Fuck off.”', applesSceneNumber: 2});
+    { text: 'You’ve started class and notice that Karina hasn’t shown up yet. After 15 minutes have passed, Karina shows up. When you confront her, she says, “I told you I was going to be late today. Did you forget?” You’re confident she did not tell you because you typically take meticulous notes about when students will be late to class.'},
     
-    slides.push({ text: 'You’ve started class and notice that Karina hasn’t shown up yet. After 15 minutes have passed, Karina shows up. When you confront her, she says, “I told you I was going to be late today. Did you forget?” You’re confident she did not tell you because you typically take meticulous notes about when students will be late to class.', applesSceneNumber: 3});
+    { text: 'You’re having lunch with Janice to talk about writing a recommendation for her. You decide to ask her how she’s doing in her classes overall. She responds by saying, “I’m doing pretty well overall, but I’m doing poorly in Mr. Smith’s class because he doesn’t like girls.”'},
     
-    slides.push({ text: 'You’re having lunch with Janice to talk about writing a recommendation for her. You decide to ask her how she’s doing in her classes overall. She responds by saying, “I’m doing pretty well overall, but I’m doing poorly in Mr. Smith’s class because he doesn’t like girls.”', applesSceneNumber: 4});
+    { text: 'You have assigned a “free-write” activity to your class to brainstorm ideas for a short story. The rule is that everyone brainstorms freely for three minutes without stopping. Everyone’s pencil is moving constantly except for Jamal’s, who is staring out the window. You say, “Jamal, please start writing.” Jamal holds his pencil up, breaks it in half, and glares at you.'},
     
-    slides.push({ text: 'You have assigned a “free-write” activity to your class to brainstorm ideas for a short story. The rule is that everyone brainstorms freely for three minutes without stopping. Everyone’s pencil is moving constantly except for Jamal’s, who is staring out the window. You say, “Jamal, please start writing.” Jamal holds his pencil up, breaks it in half, and glares at you.', applesSceneNumber: 5});
-    
-    slides.push({ text: 'You have a “no cell phones” policy in class. One day at the start of class, Trent has his cell phone out on his desk. When you remind him about your cell phone policy, he says, “I can’t put my phone away because I’m expecting a call from your mom.”', applesSceneNumber: 6});
-  }
+    { text: 'You have a “no cell phones” policy in class. One day at the start of class, Trent has his cell phone out on his desk. When you remind him about your cell phone policy, he says, “I can’t put my phone away because I’m expecting a call from your mom.”'}];
 
 
-  else if (bucketId === 203) {
-    slides.push({ text: 'Disrespect Towards Female Students:'});
+  const maleFemaleDisrespect = [
+
+    { text: 'It’s March and students are starting to receive their college acceptance letters. You are teaching Physics and you hear Amy talk about getting accepted to MIT. Another student, Mike, responds to her by saying, “You only got accepted to MIT because you’re a girl.”'},
     
-    slides.push({ text: 'It’s March and students are starting to receive their college acceptance letters. You are teaching Physics and you hear Amy talk about getting accepted to MIT. Another student, Mike, responds to her by saying, “You only got accepted to MIT because you’re a girl.”', applesSceneNumber: 1});
+    { text: 'It’s Career Day, when students talk about the careers they are interested in and where they see themselves in 20 years. Ashley says she would like to be the head of a Fortune 500 tech company. Kevin snorts loudly. “Good luck,” he says. “You know there are like no women CEOs, right?”'},
     
-    slides.push({ text: 'It’s Career Day, when students talk about the careers they are interested in and where they see themselves in 20 years. Ashley says she would like to be the head of a Fortune 500 tech company. Kevin snorts loudly. “Good luck,” he says. “You know there are like no women CEOs, right?”', applesSceneNumber: 2});
-    
-    slides.push({ text: `You’ve finished grading Algebra assignments. As you’re handing them back, you hear the following conversation unfold between Mike and Lisa:
+    { text: `You’ve finished grading Algebra assignments. As you’re handing them back, you hear the following conversation unfold between Mike and Lisa:
 
 Mike: “Lisa, how did you do?”
 
@@ -122,20 +120,50 @@ Lisa: “I got 95% on the assignment.”
 Mike: “Woah. I didn’t know pretty chicks could be good at math. You sleeping with the teacher?” 
 
 Lisa looks away, visibly angry.
-      `, applesSceneNumber: 3});
+      `},
     
-    slides.push({ text: 'An assignment is due at the beginning of class today. When Johnny hands in his assignment, he says, “I’m getting an A because you like me so much, right?” Krystal hears this and says, “Teacher doesn’t like you that much, so you must be getting an F.” Johnny replies, “Krystal - are you being bitchy because you’re on your period?” Krystal angrily responds, “Go to hell!”', applesSceneNumber: 4});
+    { text: 'An assignment is due at the beginning of class today. When Johnny hands in his assignment, he says, “I’m getting an A because you like me so much, right?” Krystal hears this and says, “Teacher doesn’t like you that much, so you must be getting an F.” Johnny replies, “Krystal - are you being bitchy because you’re on your period?” Krystal angrily responds, “Go to hell!”'},
     
-    slides.push({ text: 'The prototype of the bridge the students have built has sagged during testing. You ask if anyone has any ideas about how this problem could be solved. Julie raises her hand and says, "We need to provide some support for the load of the bridge, probably with tower suspension lines." Carter then adds, "I think what she means is that the bridge needs to be supported with guide wires from the towers." Julie mutters under her breath, “I just said that.”', applesSceneNumber: 5});
+    { text: 'The prototype of the bridge the students have built has sagged during testing. You ask if anyone has any ideas about how this problem could be solved. Julie raises her hand and says, "We need to provide some support for the load of the bridge, probably with tower suspension lines." Carter then adds, "I think what she means is that the bridge needs to be supported with guide wires from the towers." Julie mutters under her breath, “I just said that.”'},
     
-    slides.push({ text: 'You’re a Geometry teacher in the middle of a lecture about the Pythagorean theorem. Amanda raises her hand and asks, “Can you use the theorem for all triangles?” Connor turns to one of his classmates and says, “That’s a stupid question.”', applesSceneNumber: 6});
+    { text: 'You’re a Geometry teacher in the middle of a lecture about the Pythagorean theorem. Amanda raises her hand and asks, “Can you use the theorem for all triangles?” Connor turns to one of his classmates and says, “That’s a stupid question.”'}];
+
+
+
+
+  if (bucketId === 201) {
+
+    slides.push({ text: 'Students Refusing to do Work:'});
+
+    slides = slides.concat(refusingWorkSlides.map(addInAppleSceneNumber));
+    
+  } 
+
+
+  else if (bucketId === 202) {
+    slides.push({ text: 'Disrespect Towards Teachers:'});
+    
+    slides = slides.concat(teacherDisrespect.map(addInAppleSceneNumber));
+    
+  }
+
+
+  else if (bucketId === 203) {
+    slides.push({ text: 'Disrespect Towards Female Students:'});
+    
+    slides = slides.concat(maleFemaleDisrespect.map(addInAppleSceneNumber));
+
   }
 
 
   else {
     slides.push({ text: 'Mix'});
-    slides.push({ text: 'Empty', applesSceneNumber: 1 });
-    slides.push({ text: '', applesSceneNumber: 2 });
+    const scenes = []
+      .concat(refusingWorkSlides.slice(0,2))
+      .concat(teacherDisrespect.slice(0,2))
+      .concat(maleFemaleDisrespect.slice(0,2));
+
+    slides = slides.concat(scenes.map(addInAppleSceneNumber));
   }
 
   return slides;


### PR DESCRIPTION
This pull request fills in the slide text of the the HMTCA scenario page. It adds 18 scenes, 6 from each of the three categories. The text is copied from the google deck listed below:

https://docs.google.com/presentation/d/1JK7fdRjX82y0U3vxbLsmrc6jOi2KYLpJG5lRzexVpa8/edit#slide=id.g2353d84acc_0_267

![screen shot 2017-08-07 at 12 37 44 pm](https://user-images.githubusercontent.com/25137921/29036396-46775f5c-7b6d-11e7-8b41-e1c8f1bca799.png)
