### PR TITLE
Update user flow through different phases

### DIFF
--- a/ui/src/message_popup/playtest/hmtca_experience_page.jsx
+++ b/ui/src/message_popup/playtest/hmtca_experience_page.jsx
@@ -310,8 +310,11 @@ export default React.createClass({
   renderFinalInstructions() {
     return (
       <div style={styles.instructions}>
-        <p><b>PART 3: Group Discussion</b></p>
-        <p>...edit me...</p>
+        <p><b>PART 3: Group discussion on bias</b> (15 Minutes)</p>
+        <ul>
+            <li>Close your computers and discuss as a team: <i>What classroom management situations would be most impacted by a teacher's assumptions about race, ethnicity, or gender?</i></li>
+            <li>Each team will be asked to share their responses with the whole group after.</li>
+          </ul>
       </div>
     );
   }

--- a/ui/src/message_popup/playtest/hmtca_experience_page.jsx
+++ b/ui/src/message_popup/playtest/hmtca_experience_page.jsx
@@ -47,7 +47,9 @@ export default React.createClass({
       cohortKey: this.props.query.cohort || '',
       identifier: '',
       bucketId: HMTCAScenarios.BUCKETS[0].id.toString(),
-      didSkipAhead: false,
+      isDonePractice: false,
+      isDoneGroupInstructions: false,
+      isDoneReview: false,
       questions: null,
       sessionId: uuid.v4()
     };
@@ -101,8 +103,12 @@ export default React.createClass({
     this.setState(this.getInitialState());
   },
 
-  onReviewTapped() {
-    this.setState({didSkipAhead: true});
+  onStartGroupReview() {
+    this.setState({ isDoneGroupInstructions: true});
+  },
+
+  onReviewDone() {
+    this.setState({ isDoneReview: true });
   },
 
   onLogMessage(type, response) {
@@ -143,9 +149,11 @@ export default React.createClass({
   },
 
   renderContent() {
-    const {questions, didSkipAhead} = this.state;
+    const {questions, isDonePractice, isDoneGroupInstructions, isDoneReview} = this.state;
     if (!questions) return this.renderIntro();
-    if (didSkipAhead) return this.renderGroupReview();
+    if (isDonePractice) return this.renderGroupInstructions();
+    if (isDoneGroupInstructions) return this.renderGroupReview();
+    if (isDoneGroupInstructions && isDoneReview) return this.renderFinalInstructions();
 
     return <LinearSession
       questions={questions}
@@ -154,7 +162,6 @@ export default React.createClass({
       onLogMessage={this.onLogMessage}
     />;
   },
-
 
   renderIntro() {
     const {bucketId} = this.state;
@@ -249,11 +256,40 @@ export default React.createClass({
   },
 
   renderClosingEl(questions:[QuestionT], responses:[ResponseT]) {
-    return this.renderGroupReview();
+    return this.renderGroupInstructions();
+  },
+
+  renderGroupInstructions() {
+    return (
+      <div style={{...styles.instructions, margin: 20}}>
+        <div>
+          <div><b>PART 2: Round-robin Discussion</b> (20 Minutes)</div>
+          <br />
+          <ul>
+            <li>Pick a facilitator to start the discussion. Rotate facilitators for each scene.</li>
+            <li>The facilitator reads through the submitted responses to a scene and asks the group: <i>Which responses would help de-escalate the situation?</i></li>
+            <li>The group chimes in, sharing stories from their own teaching experience.</li>
+            <li>The facilitator wraps up the discussion for their scene by summarizing key takeaways.</li>
+            <li>Move on to Part 3 after 20 minutes.</li>
+          </ul>
+        </div>
+        <div>
+          <RaisedButton
+            label="ok!"
+            onTouchTap={this.onStartGroupReview} />
+        </div>
+      </div>
+    );
   },
 
   renderGroupReview() {
-    return <HMTCAGroupReview applesKey={this.applesKey()} />;
+    return <HMTCAGroupReview
+      applesKey={this.applesKey()}
+      onDone={this.onReviewDone} />;
+  },
+
+  renderFinalInstructions() {
+    return <div>final instructions!  edit me :)</div>;
   }
 });
 

--- a/ui/src/message_popup/playtest/hmtca_experience_page_test.jsx
+++ b/ui/src/message_popup/playtest/hmtca_experience_page_test.jsx
@@ -1,0 +1,28 @@
+/* @flow weak */
+import React from 'react';
+
+import {render} from 'enzyme';
+import {expect} from 'chai';
+import TestAuthContainer from '../../test_auth_container.jsx';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import HMTCAExperiencePage from './hmtca_experience_page.jsx';
+
+
+// Wrap with application context for a full render
+// (eg., theming, authorization).
+function withContext(child) {
+  return (
+    <MuiThemeProvider>
+      <TestAuthContainer>
+        {child}
+      </TestAuthContainer>
+    </MuiThemeProvider>
+  );
+}
+
+describe('<HMTCAExperiencePage />', () => {
+  it('renders instructions', () => {    
+    const wrapper = render(withContext(<HMTCAExperiencePage query={{}} />));
+    expect(wrapper.text()).to.contain("What's your anonymous identifier?");
+  });
+});

--- a/ui/src/message_popup/playtest/hmtca_group_review.jsx
+++ b/ui/src/message_popup/playtest/hmtca_group_review.jsx
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import * as Api from '../../helpers/api.js';
 import Paper from 'material-ui/Paper';
 import {Card, CardTitle, CardText} from 'material-ui/Card';
+import RaisedButton from 'material-ui/RaisedButton';
 
 
 // For reviewing responses as a group.
@@ -12,7 +13,8 @@ export default React.createClass({
   displayName: 'HMTCAGroupReview',
 
   propTypes: {
-    applesKey: React.PropTypes.string
+    applesKey: React.PropTypes.string.isRequired,
+    onDone: React.PropTypes.func.isRequired
   },
 
   getInitialState() {
@@ -38,6 +40,10 @@ export default React.createClass({
   refreshResponses() {
     const {applesKey} = this.props;
     Api.getApples(applesKey).end(this.onResponsesReceived);
+  },
+
+  onButtonTapped() {
+    this.props.onDone();
   },
 
   onResponsesReceived(err, response){
@@ -81,6 +87,11 @@ export default React.createClass({
             </div>
           );
         })}</div>
+        <div>
+          <RaisedButton
+            label="ok!"
+            onTouchTap={this.onButtonTapped} />
+        </div>
       </div>
     );
   }

--- a/ui/src/message_popup/playtest/hmtca_group_review.jsx
+++ b/ui/src/message_popup/playtest/hmtca_group_review.jsx
@@ -87,9 +87,10 @@ export default React.createClass({
             </div>
           );
         })}</div>
-        <div>
+        <div style={{margin: 20}}>
           <RaisedButton
-            label="ok!"
+            label="Start Part #3"
+            secondary={true}
             onTouchTap={this.onButtonTapped} />
         </div>
       </div>

--- a/ui/src/message_popup/playtest/hmtca_scenario.jsx
+++ b/ui/src/message_popup/playtest/hmtca_scenario.jsx
@@ -59,34 +59,6 @@ function slidesFor(cohortKey, bucketId) {
     </div>
   });
 
-  slides.push({ el: 
-    <div>
-    <div><b>PART 2: Round-robin Discussion</b> (20 Minutes)</div>
-    <br />
-    <ul>
-      <li>Pick a facilitator to start the discussion. Rotate facilitators for each scene.</li>
-      <li>The facilitator reads through the submitted responses to a scene and asks the group: <i>Which responses would help de-escalate the situation?</i></li>
-      <li>The group chimes in, sharing stories from their own teaching experience.</li>
-      <li>The facilitator wraps up the discussion for their scene by summarizing key takeaways.</li>
-      <li>Move on to Part 3 after 20 minutes.</li>
-    </ul>
-    </div>
-
-  });
-
-
-  slides.push({ el:
-    <div>
-    <div><b>PART 3: Group Discussion on Bias</b> (15 Minutes)</div>
-    <br />
-    <ul>
-      <li>Close your computers and discuss as a team: <i>What classroom management situations would be most impacted by a teacher's assumptions about race, ethnicity, or gender?</i></li>
-      <li>Each team will be asked to share their responses with the whole group after.</li>
-    </ul>
-    </div>
-  });
-
-
   slides.push({ text:`Ready to begin?
 
 The next slide will show you the first of six scenes in the category you chose. For each scene, simulate how you’d respond to the student(s) in the moment. Type your response in the textbox located below each scene.`});
@@ -187,8 +159,11 @@ Lisa looks away, visibly angry.
 
 If you’ve finished early, wait for your whole group to finish before proceeding to group discussion.`});
 
+
   return slides;
 }
+
+
 
 
 export default {

--- a/ui/src/message_popup/playtest/hmtca_scenario.jsx
+++ b/ui/src/message_popup/playtest/hmtca_scenario.jsx
@@ -154,12 +154,6 @@ Lisa looks away, visibly angry.
     slides = slides.concat(scenes.map(addInAppleSceneNumber));
   }
 
-
-  slides.push({ text: `Pause:
-
-If you’ve finished early, wait for your whole group to finish before proceeding to group discussion.`});
-
-
   return slides;
 }
 

--- a/ui/src/message_popup/playtest/hmtca_scenario.jsx
+++ b/ui/src/message_popup/playtest/hmtca_scenario.jsx
@@ -67,7 +67,7 @@ The next slide will show you the first of six scenes in the category you chose. 
   const refusingWorkSlides = [
     { text: 'Students are using Chromebooks to work on individual projects in class. As you walk around the classroom, you notice Jose watching a music video on YouTube instead of doing work.' },
     
-    { text: 'An ELA teacher is leading a discussion on Othello. Julia, a student that usually sits in the second or third row of desks, has chosen to sit in the back today. About 15 minutes into your discussion, you notice Julia has spent most of the class with her head down and writing feverishly on a piece of paper. As you continue the discussion, you gradually start moving toward Julia and see what looks like Algebra homework.' },
+    { text: 'You are an ELA teacher and leading a discussion on Othello. Julia, a student that usually sits in the second or third row of desks, has chosen to sit in the back today. About 15 minutes into your discussion, you notice Julia has spent most of the class with her head down and writing feverishly on a piece of paper. As you continue the discussion, you gradually start moving toward Julia and see what looks like Algebra homework.' },
 
     { text: 'You have a flexible cell phone policy in your class. Rosario and Fabiola typically sit next to each other during class but they’ve decided to sit on separate sides of the classroom today. As you’re going through your lecture, you notice Rosario and Fabiola have their heads down for most of the class and it appears they’re doing something on their phones. As class continues, you notice that only one of them has their head down at a time and when one looks up, the other’s head comes down. You suspect they may be arguing over text.'},
 


### PR DESCRIPTION
This updates the flow through the different phases.

There are a few different states:
- practicing
- group instructions
- group review
- final instructions

Users move roughly sequentially through these, but if they click the button to start the group review, they'll move directly to the group instructions screen.

## Screenshots
<img width="371" alt="screen shot 2017-08-09 at 11 35 08 pm" src="https://user-images.githubusercontent.com/1056957/29153440-8091117a-7d5b-11e7-8947-88ae9a558a72.png">
<img width="372" alt="screen shot 2017-08-09 at 11 35 11 pm" src="https://user-images.githubusercontent.com/1056957/29153439-8090c4f4-7d5b-11e7-8caf-9eea792ef1eb.png">

<img width="370" alt="screen shot 2017-08-09 at 11 35 17 pm" src="https://user-images.githubusercontent.com/1056957/29153443-852abd08-7d5b-11e7-84ac-49918714bae5.png">
<img width="372" alt="screen shot 2017-08-09 at 11 35 25 pm" src="https://user-images.githubusercontent.com/1056957/29153447-85309250-7d5b-11e7-9ac3-0861eedf2328.png">
<img width="375" alt="screen shot 2017-08-09 at 11 35 32 pm" src="https://user-images.githubusercontent.com/1056957/29153444-852df496-7d5b-11e7-8f38-12dfc30e4b7c.png">
<img width="373" alt="screen shot 2017-08-09 at 11 35 37 pm" src="https://user-images.githubusercontent.com/1056957/29153445-852f22d0-7d5b-11e7-8955-8ed516a5c0dc.png">
<img width="373" alt="screen shot 2017-08-09 at 11 35 44 pm" src="https://user-images.githubusercontent.com/1056957/29153446-852fa980-7d5b-11e7-8c10-975d8c5cbad6.png">
