### PR TITLE
PLC restructuring

### DIFF
--- a/ui/src/message_popup/playtest/hmtca_experience_page.jsx
+++ b/ui/src/message_popup/playtest/hmtca_experience_page.jsx
@@ -10,7 +10,6 @@ import SessionFrame from '../linear_session/session_frame.jsx';
 import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
 import 'velocity-animate/velocity.ui';
 import RaisedButton from 'material-ui/RaisedButton';
-import {RadioButton, RadioButtonGroup} from 'material-ui/RadioButton';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import Divider from 'material-ui/Divider';
@@ -176,7 +175,6 @@ export default React.createClass({
   },
 
   renderIntro() {
-    const {bucketId} = this.state;
     return (
       <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
         <form onSubmit={this.onStart}>
@@ -194,25 +192,8 @@ export default React.createClass({
               onChange={this.onIdentifierChanged}
               rows={1} />
           </div>
-          <div style={{...styles.instructions, paddingBottom: 0}}>
-            <div>What would you like to practice?</div>
-            <RadioButtonGroup
-              style={{margin: 10}}
-              name="bucket"
-              valueSelected={bucketId}
-              onChange={this.onBucketChanged}
-            >
-              {HMTCAScenarios.BUCKETS.map(bucket =>
-                <RadioButton
-                  key={bucket.id.toString()}
-                  value={bucket.id.toString()}
-                  style={{fontSize: 14}}
-                  label={bucket.text}
-                />
-              )}
-            </RadioButtonGroup>
-          </div>
           <div style={styles.instructions}>
+            <div>What is your team code?</div>
             <SelectField
               maxHeight={250}
               style={{width: '100%'}}

--- a/ui/src/message_popup/playtest/hmtca_experience_page.jsx
+++ b/ui/src/message_popup/playtest/hmtca_experience_page.jsx
@@ -206,7 +206,7 @@ export default React.createClass({
             </SelectField>
           </div>
           <div style={styles.instructions}>
-            <p>In this practice space, you'll have to improvise and adapt to make the best of the situation.  Some scenarios might not exactly match your grade level and subject.</p>
+            <p>In this practice space, you'll have to improvise and adapt to make the best of the situation. Some scenarios might not exactly match your grade level and subject.</p>
             <RaisedButton
               disabled={this.state.cohortKey === '' || this.state.identifier === ''}
               onTouchTap={this.onStart}
@@ -251,9 +251,9 @@ export default React.createClass({
   renderPauseEl(questions:[QuestionT], responses:[ResponseT]) {
     return (
       <div style={{margin: 20}}>
-        <div style={{paddingBottom: 20}}>If you’ve finished early, wait for your whole group to finish before proceeding to group discussion.</div>
+        <div style={{paddingBottom: 20}}>If you’ve made it to this screen, you’ve finished responding to all the scenes. If you’ve finished early, wait for your whole group to finish before proceeding to Part 2. Once your whole group has finished, click on “Start Part 2.”</div>
         <RaisedButton
-          label="Start phase #2"
+          label="Start Part #2"
           onTouchTap={this.onShowGroupInstructions} />
       </div>
     );
@@ -263,15 +263,13 @@ export default React.createClass({
     return (
       <div style={{margin: 20}}>
         <div>
-          <div><b>PART 2: Round-robin Discussion</b> (20 Minutes)</div>
+          <div><b>PART 2: Round-robin discussion</b> (20 minutes)</div>
           <br />
-          <ul>
-            <li>Pick a facilitator to start the discussion. Rotate facilitators for each scene.</li>
-            <li>The facilitator reads through the submitted responses to a scene and asks the group: <i>Which responses would help de-escalate the situation?</i></li>
-            <li>The group chimes in, sharing stories from their own teaching experience.</li>
-            <li>The facilitator wraps up the discussion for their scene by summarizing key takeaways.</li>
-            <li>Move on to Part 3 after 20 minutes.</li>
-          </ul>
+          <div>For Part 2, you will initially be taken to a screen where you can see the anonymized responses of everyone in your team to all 4 scenes. Once you’re on this screen, your team will choose one person to facilitate discussion around the responses to the first scene. The facilitator’s role is to summarize briefly the similarities/differences in how people responded. They will then lead the team in deciding which response or combination of responses would best de-escalate the situation as described in the scene. A great question to start discussion is: <i>Which responses would help de-escalate this situation?</i></div>
+          <br />
+          <div>Once you’ve finished discussing the first scene, select a new facilitator to lead the discussion for the second scene. Repeat this process until you’ve finished discussing all 4 scenes or 20 minutes have elapsed (whichever comes first). At this point, move on to Part 3.</div>
+          <br />
+          <div>Ready to start?</div>
         </div>
         <div>
           <RaisedButton
@@ -291,11 +289,11 @@ export default React.createClass({
   renderFinalInstructions() {
     return (
       <div style={styles.instructions}>
-        <p><b>PART 3: Group discussion on bias</b> (15 Minutes)</p>
-        <ul>
-            <li>Close your computers and discuss as a team: <i>What classroom management situations would be most impacted by a teacher's assumptions about race, ethnicity, or gender?</i></li>
-            <li>Each team will be asked to share their responses with the whole group after.</li>
-          </ul>
+        <p><b>PART 3: Group discussion on bias</b> (15 minutes)</p>
+        <br />
+        <div>Part 3 is a team discussion, so close your computers. As a team, discuss your responses to the following question: <i>What classroom management situations would be most impacted by a teacher's assumptions about race, ethnicity, or gender?</i></div>
+        <br />
+        <div>Once you’ve discussed for 15 minutes, you will return to full group discussion. Each team will be asked to share what they discussed during Parts 2 and 3 with the large group.</div>
       </div>
     );
   }

--- a/ui/src/message_popup/playtest/hmtca_experience_page.jsx
+++ b/ui/src/message_popup/playtest/hmtca_experience_page.jsx
@@ -53,7 +53,6 @@ export default React.createClass({
     return {
       cohortKey: this.props.query.cohort || '',
       identifier: '',
-      bucketId: HMTCAScenarios.BUCKETS[0].id.toString(),
       questions: null,
       sessionId: uuid.v4(),
       currentPart: Parts.PRACTICE
@@ -61,14 +60,14 @@ export default React.createClass({
   },
 
   // This is the key for a "game session we want to later review."
-  // It's built from (cohort, bucket), so that each of those has its own
+  // It's built from (cohort), so that each of those has its own
   // scene number space (the number is used for ordering and is user-facing).
   //
   // This means that if the same team code plays again later, the number of
   // responses will keep growing over time (as opposed to "start a new game").
   applesKey() {
-    const {cohortKey, bucketId} = this.state;
-    return [cohortKey, bucketId].join(':');
+    const {cohortKey} = this.state;
+    return [cohortKey].join(':');
   },
 
   // Could make this smarter and have it coordinate across different users to
@@ -85,15 +84,11 @@ export default React.createClass({
     this.setState({ identifier: e.target.value });
   },
 
-  onBucketChanged(e) {
-    this.setState({ bucketId: e.target.value });
-  },
-
   // Making questions from the cohort
   onStart(e) {
     e.preventDefault();
-    const {cohortKey, bucketId} = this.state;
-    const allQuestions = HMTCAScenarios.questionsFor(cohortKey, parseInt(bucketId, 10));
+    const {cohortKey} = this.state;
+    const allQuestions = HMTCAScenarios.questionsFor(cohortKey);
 
     const startQuestionIndex = this.props.query.p || 0; // for testing or demoing
     const questions = allQuestions.slice(startQuestionIndex);

--- a/ui/src/message_popup/playtest/hmtca_scenario.jsx
+++ b/ui/src/message_popup/playtest/hmtca_scenario.jsx
@@ -12,10 +12,6 @@ export type QuestionT = {
 };
 
 
-// Different categories for classroom management
-const BUCKETS = [
-  { id: 201, text: 'Students refusing to work' },
-];
 
 const TEAM_CODES = _.sortBy([
   'blackberry',
@@ -54,7 +50,7 @@ function addInAppleSceneNumber(slide, index) {
   return {...slide, applesSceneNumber: index + 1};
 }
 
-function slidesFor(cohortKey, bucketId) {
+function slidesFor(cohortKey) {
   var slides:[QuestionT] = [];
   slides.push({ el: 
     <div>
@@ -87,9 +83,6 @@ Johnny: “You’re just being a bitch because you’re on your period.” `},
 
 
 
-
-
-
   slides = slides.concat(selectedSlides.map(addInAppleSceneNumber));
     
 
@@ -100,9 +93,8 @@ Johnny: “You’re just being a bitch because you’re on your period.” `},
 
 
 export default {
-  BUCKETS,
   TEAM_CODES,
-  questionsFor(cohortKey, bucketId) {
-    return slidesFor(cohortKey, bucketId);
+  questionsFor(cohortKey) {
+    return slidesFor(cohortKey);
   }
 };

--- a/ui/src/message_popup/playtest/hmtca_scenario.jsx
+++ b/ui/src/message_popup/playtest/hmtca_scenario.jsx
@@ -58,29 +58,32 @@ function slidesFor(cohortKey, bucketId) {
   var slides:[QuestionT] = [];
   slides.push({ el: 
     <div>
-    <div><b>PART 1: Practice Individually</b> (20 Minutes)</div>
+    <div><b>PART 1: Practice Individually</b> (10 minutes)</div>
     <br />
-    <ul>
-      <li>Read through 6 separate scenes and type your response to each scene.</li>
-      <li>Wait for your group to finish. Move on to Part 2 after 20 minutes.</li>
-    </ul>
+    <div>In Part 1, you’ll read through 4 separate classroom management scenes and type how you’d respond to each scene.</div>
+    <br />
+    <div>For each scene, simulate how you’d respond to the student(s) in the moment and type your response in the textbox located below the scene. </div>
+    <br />
+    <div>Once you’re finished with your responses, wait for your group to finish. You will move on to Part 2 after 10 minutes. Clicking on “Ok” will take you to your first scene. Ready?</div>
     </div>
   });
 
-  slides.push({ text:`Ready to begin?
+  const selectedSlides = [
 
-The next slide will show you the first of six scenes in the category you chose. For each scene, simulate how you’d respond to the student(s) in the moment. Type your response in the textbox located below each scene.`});
+    { text: 'You’re walking around the classroom going desk-to-desk taking your students’ assignments. You arrive at William’s desk and he doesn’t acknowledge your presence, keeping his head down and staring at his phone. You tell William, “It’s time to hand in your paper.” William doesn’t respond. You ask William if he completed his paper, to which he mutters under his breath without looking up, “Fuck off.”'},
 
-    const selectedSlides = [
-    { text: 'You have a flexible cell phone policy in your class. Rosario and Fabiola typically sit next to each other during class but they’ve decided to sit on separate sides of the classroom today. As you’re going through your lecture, you notice Rosario and Fabiola have their heads down for most of the class and it appears they’re doing something on their phones. As class continues, you notice that only one of them has their head down at a time and when one looks up, the other’s head comes down. You suspect they may be arguing over text.'},
+    { text: `Students are working on their group projects in class today. You overhear one group discussing their project and this exchange unfolds between Krystal and Johnny:
 
-    { text: 'Two weeks ago, you assigned a group project in class. Currently, there’s about a week left before students have to submit their assignments. After class ends this day, one of your students, Mark, comes up to you and says, “Hey my group is doing fine on the group project but I’m having to do extra work because Tyshawn doesn’t do anything and doesn’t offer to do anything. It’s super frustrating. Are you going to give us all the same grade or are you going to give Tyshawn the grade he deserves?”'},
+Johnny: “Why was 6 afraid of 7? Because 7 ate 9!”
+
+Krystal: “That’s a stupid joke.”
+
+Johnny: “You’re just being a bitch because you’re on your period.” `},
     
-    { text: `In the morning, you check your email for the first time in the day since before you went to sleep last night. You see an email from Drew and it arrived at 11:00pm last night after you had gone to bed. In the email he said he’s confused about the assignment and is stuck.
+    { text: 'You are a history teacher and you’re teaching a lesson on the Women’s Suffrage Movement. Jamika has her head down and is scrolling through her phone. A classmate sitting next to Jamika taps her on the shoulder and says, “Pay attention.” Jamika responds by saying, “I’m not paying attention to this whitewashed crap. Where are the black people?”'},
 
-Now class has started and you’ve asked students to turn in their assignments. Drew raises his hand and in front of everybody says, “I didn’t do the assignment because you never responded to my email.”`},
-    
-    { text: 'You are a history teacher and you’re teaching a lesson on the Women’s Suffrage Movement. Jamika has her head down and is scrolling through her phone. A classmate sitting next to Jamika taps her on the shoulder and says, “Pay attention.” Jamika responds by saying, “I’m not paying attention to this whitewashed crap. Where are the black people?”'}];
+    { text: 'It’s March and students are starting to receive their college acceptance letters. You are teaching Physics and you hear Amy talk about getting accepted to MIT. Another student, Mike, responds to her by saying, “You only got accepted to MIT because you’re a girl.”'}];
+
 
 //   const refusingWorkSlides = [
 //     { text: 'Students are using Chromebooks to work on individual projects in class. As you walk around the classroom, you notice Jose watching a music video on YouTube instead of doing work.' },

--- a/ui/src/message_popup/playtest/hmtca_scenario.jsx
+++ b/ui/src/message_popup/playtest/hmtca_scenario.jsx
@@ -85,61 +85,6 @@ Johnny: “You’re just being a bitch because you’re on your period.” `},
     { text: 'It’s March and students are starting to receive their college acceptance letters. You are teaching Physics and you hear Amy talk about getting accepted to MIT. Another student, Mike, responds to her by saying, “You only got accepted to MIT because you’re a girl.”'}];
 
 
-//   const refusingWorkSlides = [
-//     { text: 'Students are using Chromebooks to work on individual projects in class. As you walk around the classroom, you notice Jose watching a music video on YouTube instead of doing work.' },
-    
-//     { text: 'You are an ELA teacher and leading a discussion on Othello. Julia, a student that usually sits in the second or third row of desks, has chosen to sit in the back today. About 15 minutes into your discussion, you notice Julia has spent most of the class with her head down and writing feverishly on a piece of paper. As you continue the discussion, you gradually start moving toward Julia and see what looks like Algebra homework.' },
-
-//     { text: 'You have a flexible cell phone policy in your class. Rosario and Fabiola typically sit next to each other during class but they’ve decided to sit on separate sides of the classroom today. As you’re going through your lecture, you notice Rosario and Fabiola have their heads down for most of the class and it appears they’re doing something on their phones. As class continues, you notice that only one of them has their head down at a time and when one looks up, the other’s head comes down. You suspect they may be arguing over text.'},
-
-//     { text: 'Two weeks ago, you assigned a group project in class. Currently, there’s about a week left before students have to submit their assignments. After class ends this day, one of your students, Mark, comes up to you and says, “Hey my group is doing fine on the group project but I’m having to do extra work because Tyshawn doesn’t do anything and doesn’t offer to do anything. It’s super frustrating. Are you going to give us all the same grade or are you going to give Tyshawn the grade he deserves?”'},
-    
-//     { text: `In the morning, you check your email for the first time in the day since before you went to sleep last night. You see an email from Drew and it arrived at 11:00pm last night after you had gone to bed. In the email he said he’s confused about the assignment and is stuck.
-
-// Now class has started and you’ve asked students to turn in their assignments. Drew raises his hand and in front of everybody says, “I didn’t do the assignment because you never responded to my email.”`},
-    
-//     { text: 'You are a history teacher and you’re teaching a lesson on the Women’s Suffrage Movement. Jamika has her head down and is scrolling through her phone. A classmate sitting next to Jamika taps her on the shoulder and says, “Pay attention.” Jamika responds by saying, “I’m not paying attention to this whitewashed crap. Where are the black people?”'}];
-
-
-
-//   const teacherDisrespect = [
-
-//     { text: 'You’re teaching ELA. You’re in the middle of discussing Romeo and Juliet when Carlos interrupts you without raising his hand and says, “Why does any of this matter? How is Shakespeare going to help me get a job? Stop wasting our time!”'},
-    
-//     { text: 'You’re walking around the classroom going desk-to-desk taking your students’ assignments. You arrive at William’s desk and he doesn’t acknowledge your presence, keeping his head down and staring at his phone. You tell William, “It’s time to hand in your paper.” William doesn’t respond. You ask William if he completed his paper, to which he mutters under his breath without looking up, “Fuck off.”'},
-    
-//     { text: 'You’ve started class and notice that Karina hasn’t shown up yet. After 15 minutes have passed, Karina shows up. When you confront her, she says, “I told you I was going to be late today. Did you forget?” You’re confident she did not tell you because you typically take meticulous notes about when students will be late to class.'},
-    
-//     { text: 'You’re having lunch with Janice to talk about writing a recommendation for her. You decide to ask her how she’s doing in her classes overall. She responds by saying, “I’m doing pretty well overall, but I’m doing poorly in Mr. Smith’s class because he doesn’t like girls.”'},
-    
-//     { text: 'You have assigned a “free-write” activity to your class to brainstorm ideas for a short story. The rule is that everyone brainstorms freely for three minutes without stopping. Everyone’s pencil is moving constantly except for Jamal’s, who is staring out the window. You say, “Jamal, please start writing.” Jamal holds his pencil up, breaks it in half, and glares at you.'},
-    
-//     { text: 'You have a “no cell phones” policy in class. One day at the start of class, Trent has his cell phone out on his desk. When you remind him about your cell phone policy, he says, “I can’t put my phone away because I’m expecting a call from your mom.”'}];
-
-
-//   const maleFemaleDisrespect = [
-
-//     { text: 'It’s March and students are starting to receive their college acceptance letters. You are teaching Physics and you hear Amy talk about getting accepted to MIT. Another student, Mike, responds to her by saying, “You only got accepted to MIT because you’re a girl.”'},
-    
-//     { text: 'It’s Career Day, when students talk about the careers they are interested in and where they see themselves in 20 years. Ashley says she would like to be the head of a Fortune 500 tech company. Kevin snorts loudly. “Good luck,” he says. “You know there are like no women CEOs, right?”'},
-    
-//     { text: `You’ve finished grading Algebra assignments. As you’re handing them back, you hear the following conversation unfold between Mike and Lisa:
-
-// Mike: “Lisa, how did you do?”
-
-// Lisa: “I got 95% on the assignment.”
-
-// Mike: “Woah. I didn’t know pretty chicks could be good at math. You sleeping with the teacher?” 
-
-// Lisa looks away, visibly angry.
-//       `},
-    
-//     { text: 'An assignment is due at the beginning of class today. When Johnny hands in his assignment, he says, “I’m getting an A because you like me so much, right?” Krystal hears this and says, “Teacher doesn’t like you that much, so you must be getting an F.” Johnny replies, “Krystal - are you being bitchy because you’re on your period?” Krystal angrily responds, “Go to hell!”'},
-    
-//     { text: 'The prototype of the bridge the students have built has sagged during testing. You ask if anyone has any ideas about how this problem could be solved. Julie raises her hand and says, "We need to provide some support for the load of the bridge, probably with tower suspension lines." Carter then adds, "I think what she means is that the bridge needs to be supported with guide wires from the towers." Julie mutters under her breath, “I just said that.”'},
-    
-//     { text: 'You’re a Geometry teacher in the middle of a lecture about the Pythagorean theorem. Amanda raises her hand and asks, “Can you use the theorem for all triangles?” Connor turns to one of his classmates and says, “That’s a stupid question.”'}];
-
 
 
 

--- a/ui/src/message_popup/playtest/hmtca_scenario.jsx
+++ b/ui/src/message_popup/playtest/hmtca_scenario.jsx
@@ -15,17 +15,18 @@ export type QuestionT = {
 // Different categories for classroom management
 const BUCKETS = [
   { id: 201, text: 'Students refusing to work' },
-  { id: 202, text: 'Disrespect towards teachers' },
-  { id: 203, text: 'Disrespect towards females' },
-  { id: 204, text: 'Combination of the above' }
 ];
 
 const TEAM_CODES = _.sortBy([
+  'blackberry',
   'mango',
   'lemon',
   'papaya',
   'apple',
   'guava',
+  'apricot',
+  'lime',
+  'pomegranate',
   'banana',
   'nectarine',
   'peach',
@@ -33,12 +34,19 @@ const TEAM_CODES = _.sortBy([
   'strawberry',
   'grape',
   'pineapple',
+  'raspberry',
+  'avocado',
+  'orange',
+  'cantaloupe',
+  'tangerine',
+  'passion fruit',
+  'dragon fruit',
+  'lychee',
   'pear',
   'cherry',
   'watermelon',
   'kiwi',
   'coconut',
-  'blackberry'
 ]);
 
 
@@ -63,12 +71,7 @@ function slidesFor(cohortKey, bucketId) {
 
 The next slide will show you the first of six scenes in the category you chose. For each scene, simulate how you’d respond to the student(s) in the moment. Type your response in the textbox located below each scene.`});
 
-
-  const refusingWorkSlides = [
-    { text: 'Students are using Chromebooks to work on individual projects in class. As you walk around the classroom, you notice Jose watching a music video on YouTube instead of doing work.' },
-    
-    { text: 'You are an ELA teacher and leading a discussion on Othello. Julia, a student that usually sits in the second or third row of desks, has chosen to sit in the back today. About 15 minutes into your discussion, you notice Julia has spent most of the class with her head down and writing feverishly on a piece of paper. As you continue the discussion, you gradually start moving toward Julia and see what looks like Algebra homework.' },
-
+    const selectedSlides = [
     { text: 'You have a flexible cell phone policy in your class. Rosario and Fabiola typically sit next to each other during class but they’ve decided to sit on separate sides of the classroom today. As you’re going through your lecture, you notice Rosario and Fabiola have their heads down for most of the class and it appears they’re doing something on their phones. As class continues, you notice that only one of them has their head down at a time and when one looks up, the other’s head comes down. You suspect they may be arguing over text.'},
 
     { text: 'Two weeks ago, you assigned a group project in class. Currently, there’s about a week left before students have to submit their assignments. After class ends this day, one of your students, Mark, comes up to you and says, “Hey my group is doing fine on the group project but I’m having to do extra work because Tyshawn doesn’t do anything and doesn’t offer to do anything. It’s super frustrating. Are you going to give us all the same grade or are you going to give Tyshawn the grade he deserves?”'},
@@ -79,80 +82,68 @@ Now class has started and you’ve asked students to turn in their assignments. 
     
     { text: 'You are a history teacher and you’re teaching a lesson on the Women’s Suffrage Movement. Jamika has her head down and is scrolling through her phone. A classmate sitting next to Jamika taps her on the shoulder and says, “Pay attention.” Jamika responds by saying, “I’m not paying attention to this whitewashed crap. Where are the black people?”'}];
 
-
-
-  const teacherDisrespect = [
-
-    { text: 'You’re teaching ELA. You’re in the middle of discussing Romeo and Juliet when Carlos interrupts you without raising his hand and says, “Why does any of this matter? How is Shakespeare going to help me get a job? Stop wasting our time!”'},
+//   const refusingWorkSlides = [
+//     { text: 'Students are using Chromebooks to work on individual projects in class. As you walk around the classroom, you notice Jose watching a music video on YouTube instead of doing work.' },
     
-    { text: 'You’re walking around the classroom going desk-to-desk taking your students’ assignments. You arrive at William’s desk and he doesn’t acknowledge your presence, keeping his head down and staring at his phone. You tell William, “It’s time to hand in your paper.” William doesn’t respond. You ask William if he completed his paper, to which he mutters under his breath without looking up, “Fuck off.”'},
+//     { text: 'You are an ELA teacher and leading a discussion on Othello. Julia, a student that usually sits in the second or third row of desks, has chosen to sit in the back today. About 15 minutes into your discussion, you notice Julia has spent most of the class with her head down and writing feverishly on a piece of paper. As you continue the discussion, you gradually start moving toward Julia and see what looks like Algebra homework.' },
+
+//     { text: 'You have a flexible cell phone policy in your class. Rosario and Fabiola typically sit next to each other during class but they’ve decided to sit on separate sides of the classroom today. As you’re going through your lecture, you notice Rosario and Fabiola have their heads down for most of the class and it appears they’re doing something on their phones. As class continues, you notice that only one of them has their head down at a time and when one looks up, the other’s head comes down. You suspect they may be arguing over text.'},
+
+//     { text: 'Two weeks ago, you assigned a group project in class. Currently, there’s about a week left before students have to submit their assignments. After class ends this day, one of your students, Mark, comes up to you and says, “Hey my group is doing fine on the group project but I’m having to do extra work because Tyshawn doesn’t do anything and doesn’t offer to do anything. It’s super frustrating. Are you going to give us all the same grade or are you going to give Tyshawn the grade he deserves?”'},
     
-    { text: 'You’ve started class and notice that Karina hasn’t shown up yet. After 15 minutes have passed, Karina shows up. When you confront her, she says, “I told you I was going to be late today. Did you forget?” You’re confident she did not tell you because you typically take meticulous notes about when students will be late to class.'},
+//     { text: `In the morning, you check your email for the first time in the day since before you went to sleep last night. You see an email from Drew and it arrived at 11:00pm last night after you had gone to bed. In the email he said he’s confused about the assignment and is stuck.
+
+// Now class has started and you’ve asked students to turn in their assignments. Drew raises his hand and in front of everybody says, “I didn’t do the assignment because you never responded to my email.”`},
     
-    { text: 'You’re having lunch with Janice to talk about writing a recommendation for her. You decide to ask her how she’s doing in her classes overall. She responds by saying, “I’m doing pretty well overall, but I’m doing poorly in Mr. Smith’s class because he doesn’t like girls.”'},
+//     { text: 'You are a history teacher and you’re teaching a lesson on the Women’s Suffrage Movement. Jamika has her head down and is scrolling through her phone. A classmate sitting next to Jamika taps her on the shoulder and says, “Pay attention.” Jamika responds by saying, “I’m not paying attention to this whitewashed crap. Where are the black people?”'}];
+
+
+
+//   const teacherDisrespect = [
+
+//     { text: 'You’re teaching ELA. You’re in the middle of discussing Romeo and Juliet when Carlos interrupts you without raising his hand and says, “Why does any of this matter? How is Shakespeare going to help me get a job? Stop wasting our time!”'},
     
-    { text: 'You have assigned a “free-write” activity to your class to brainstorm ideas for a short story. The rule is that everyone brainstorms freely for three minutes without stopping. Everyone’s pencil is moving constantly except for Jamal’s, who is staring out the window. You say, “Jamal, please start writing.” Jamal holds his pencil up, breaks it in half, and glares at you.'},
+//     { text: 'You’re walking around the classroom going desk-to-desk taking your students’ assignments. You arrive at William’s desk and he doesn’t acknowledge your presence, keeping his head down and staring at his phone. You tell William, “It’s time to hand in your paper.” William doesn’t respond. You ask William if he completed his paper, to which he mutters under his breath without looking up, “Fuck off.”'},
     
-    { text: 'You have a “no cell phones” policy in class. One day at the start of class, Trent has his cell phone out on his desk. When you remind him about your cell phone policy, he says, “I can’t put my phone away because I’m expecting a call from your mom.”'}];
-
-
-  const maleFemaleDisrespect = [
-
-    { text: 'It’s March and students are starting to receive their college acceptance letters. You are teaching Physics and you hear Amy talk about getting accepted to MIT. Another student, Mike, responds to her by saying, “You only got accepted to MIT because you’re a girl.”'},
+//     { text: 'You’ve started class and notice that Karina hasn’t shown up yet. After 15 minutes have passed, Karina shows up. When you confront her, she says, “I told you I was going to be late today. Did you forget?” You’re confident she did not tell you because you typically take meticulous notes about when students will be late to class.'},
     
-    { text: 'It’s Career Day, when students talk about the careers they are interested in and where they see themselves in 20 years. Ashley says she would like to be the head of a Fortune 500 tech company. Kevin snorts loudly. “Good luck,” he says. “You know there are like no women CEOs, right?”'},
+//     { text: 'You’re having lunch with Janice to talk about writing a recommendation for her. You decide to ask her how she’s doing in her classes overall. She responds by saying, “I’m doing pretty well overall, but I’m doing poorly in Mr. Smith’s class because he doesn’t like girls.”'},
     
-    { text: `You’ve finished grading Algebra assignments. As you’re handing them back, you hear the following conversation unfold between Mike and Lisa:
-
-Mike: “Lisa, how did you do?”
-
-Lisa: “I got 95% on the assignment.”
-
-Mike: “Woah. I didn’t know pretty chicks could be good at math. You sleeping with the teacher?” 
-
-Lisa looks away, visibly angry.
-      `},
+//     { text: 'You have assigned a “free-write” activity to your class to brainstorm ideas for a short story. The rule is that everyone brainstorms freely for three minutes without stopping. Everyone’s pencil is moving constantly except for Jamal’s, who is staring out the window. You say, “Jamal, please start writing.” Jamal holds his pencil up, breaks it in half, and glares at you.'},
     
-    { text: 'An assignment is due at the beginning of class today. When Johnny hands in his assignment, he says, “I’m getting an A because you like me so much, right?” Krystal hears this and says, “Teacher doesn’t like you that much, so you must be getting an F.” Johnny replies, “Krystal - are you being bitchy because you’re on your period?” Krystal angrily responds, “Go to hell!”'},
+//     { text: 'You have a “no cell phones” policy in class. One day at the start of class, Trent has his cell phone out on his desk. When you remind him about your cell phone policy, he says, “I can’t put my phone away because I’m expecting a call from your mom.”'}];
+
+
+//   const maleFemaleDisrespect = [
+
+//     { text: 'It’s March and students are starting to receive their college acceptance letters. You are teaching Physics and you hear Amy talk about getting accepted to MIT. Another student, Mike, responds to her by saying, “You only got accepted to MIT because you’re a girl.”'},
     
-    { text: 'The prototype of the bridge the students have built has sagged during testing. You ask if anyone has any ideas about how this problem could be solved. Julie raises her hand and says, "We need to provide some support for the load of the bridge, probably with tower suspension lines." Carter then adds, "I think what she means is that the bridge needs to be supported with guide wires from the towers." Julie mutters under her breath, “I just said that.”'},
+//     { text: 'It’s Career Day, when students talk about the careers they are interested in and where they see themselves in 20 years. Ashley says she would like to be the head of a Fortune 500 tech company. Kevin snorts loudly. “Good luck,” he says. “You know there are like no women CEOs, right?”'},
     
-    { text: 'You’re a Geometry teacher in the middle of a lecture about the Pythagorean theorem. Amanda raises her hand and asks, “Can you use the theorem for all triangles?” Connor turns to one of his classmates and says, “That’s a stupid question.”'}];
+//     { text: `You’ve finished grading Algebra assignments. As you’re handing them back, you hear the following conversation unfold between Mike and Lisa:
 
+// Mike: “Lisa, how did you do?”
 
+// Lisa: “I got 95% on the assignment.”
 
+// Mike: “Woah. I didn’t know pretty chicks could be good at math. You sleeping with the teacher?” 
 
-  if (bucketId === 201) {
-
-    slides = slides.concat(refusingWorkSlides.map(addInAppleSceneNumber));
+// Lisa looks away, visibly angry.
+//       `},
     
-  } 
-
-
-  else if (bucketId === 202) {
+//     { text: 'An assignment is due at the beginning of class today. When Johnny hands in his assignment, he says, “I’m getting an A because you like me so much, right?” Krystal hears this and says, “Teacher doesn’t like you that much, so you must be getting an F.” Johnny replies, “Krystal - are you being bitchy because you’re on your period?” Krystal angrily responds, “Go to hell!”'},
     
-    slides = slides.concat(teacherDisrespect.map(addInAppleSceneNumber));
-
-  }
-
-
-  else if (bucketId === 203) {
-
+//     { text: 'The prototype of the bridge the students have built has sagged during testing. You ask if anyone has any ideas about how this problem could be solved. Julie raises her hand and says, "We need to provide some support for the load of the bridge, probably with tower suspension lines." Carter then adds, "I think what she means is that the bridge needs to be supported with guide wires from the towers." Julie mutters under her breath, “I just said that.”'},
     
-    slides = slides.concat(maleFemaleDisrespect.map(addInAppleSceneNumber));
-
-  }
+//     { text: 'You’re a Geometry teacher in the middle of a lecture about the Pythagorean theorem. Amanda raises her hand and asks, “Can you use the theorem for all triangles?” Connor turns to one of his classmates and says, “That’s a stupid question.”'}];
 
 
-  else {
 
-    const scenes = []
-      .concat(refusingWorkSlides.slice(0,2))
-      .concat(teacherDisrespect.slice(0,2))
-      .concat(maleFemaleDisrespect.slice(0,2));
 
-    slides = slides.concat(scenes.map(addInAppleSceneNumber));
-  }
+
+
+  slides = slides.concat(selectedSlides.map(addInAppleSceneNumber));
+    
 
   return slides;
 }


### PR DESCRIPTION
This update removes the option to choose your scene topic, and leaves only 4 of the original 18 scenes. It also includes rewrites of all the instruction pages, and changes the slide arrangements so that the instructions for each part comes directly before their respective parts. 

hmtca_experience_page:
- Starts by removing now unused variables (connected to topic selection which was removed).
- Removal of lines 197-214 is the removal of the scene selection process.
- Minor wording changes...
- Removes all requirements for BucketID variable

hmtca_scenario:
- Removes extra bucket IDs
- Adds more team codes (now at 26)
- Changes to instruction set
- Removes excess scenes and leaves only the 4 scenes users will run in new iteration(Lines 62-155) 

![image](https://user-images.githubusercontent.com/25137921/29291024-348ba19c-8110-11e7-9e45-565e6c7c9e43.png)

![image](https://user-images.githubusercontent.com/25137921/29291035-4014561c-8110-11e7-9e24-3b5c4feb26de.png)
