### PR TITLE
Add in lettering to responses when reviewing

### DIFF
--- a/ui/src/message_popup/playtest/hmtca_group_review.jsx
+++ b/ui/src/message_popup/playtest/hmtca_group_review.jsx
@@ -56,6 +56,7 @@ export default React.createClass({
   },
 
   render() {
+    var responseNum = 1;
     const {hasLoaded, applesResponses} = this.state;
     if (!hasLoaded) return <div>Loading...</div>;
 
@@ -73,13 +74,18 @@ export default React.createClass({
                   title={`Scene #${index + 1}`}
                   subtitle={sceneToResponses[sceneNumber][0]['scene_text']}
                 />
+                {responseNum = 1};
                 <CardText>
               <div style={styles.cardContainer}>
                 {_.uniq(_.map(sceneToResponses[sceneNumber], 'anonymized_text')).map(anonymizedText => 
                   <Paper
                     key={anonymizedText}
                     style={styles.responseCard}
-                    zDepth={3}>{anonymizedText}</Paper>
+                    zDepth={3}>
+                    {`Response #${responseNum ++}: 
+
+
+                    ${anonymizedText}`}</Paper>
                 )}
               </div>
               </CardText>

--- a/ui/src/message_popup/playtest/hmtca_group_review.jsx
+++ b/ui/src/message_popup/playtest/hmtca_group_review.jsx
@@ -56,7 +56,6 @@ export default React.createClass({
   },
 
   render() {
-    var responseNum = 1;
     const {hasLoaded, applesResponses} = this.state;
     if (!hasLoaded) return <div>Loading...</div>;
 
@@ -74,19 +73,21 @@ export default React.createClass({
                   title={`Scene #${index + 1}`}
                   subtitle={sceneToResponses[sceneNumber][0]['scene_text']}
                 />
-                {responseNum = 1};
                 <CardText>
               <div style={styles.cardContainer}>
-                {_.uniq(_.map(sceneToResponses[sceneNumber], 'anonymized_text')).map(anonymizedText => 
-                  <Paper
-                    key={anonymizedText}
-                    style={styles.responseCard}
-                    zDepth={3}>
-                    {`Response #${responseNum ++}: 
+                {_.uniq(_.map(sceneToResponses[sceneNumber], 'anonymized_text')).map((anonymizedText, index) => {
+                  const responseLetter = String.fromCharCode('A'.charCodeAt() + index);
 
-
-                    ${anonymizedText}`}</Paper>
-                )}
+                  return (
+                    <Paper
+                      key={anonymizedText}
+                      style={styles.responseCard}
+                      zDepth={3}>
+                      <div>{`Response ${responseLetter}:`}</div>
+                      <div style={{padding: 10}}>{anonymizedText}</div>
+                    </Paper>
+                  );
+                })}
               </div>
               </CardText>
               </Card>


### PR DESCRIPTION
So that folks can talk about responses using letter names instead of "the third one from the bottom".

Screenshot:
<img width="373" alt="screen shot 2017-08-21 at 11 29 47 am" src="https://user-images.githubusercontent.com/1056957/29526552-128cabe6-8664-11e7-89af-9e09cd384c88.png">
