### PR TITLE
adds larger text box to responses and switches Move on to Ignore

### DIFF
--- a/ui/src/message_popup/renderers/apples_text_response.jsx
+++ b/ui/src/message_popup/renderers/apples_text_response.jsx
@@ -32,7 +32,7 @@ export default React.createClass({
     } else if (type === 'message_popup_text_ignore') {
       this.props.onLogMessage('anonymized_apples_to_apples_partial', {
         sceneNumber: this.props.applesSceneNumber,
-        anonymizedText: "(Move on)"
+        anonymizedText: "(Ignore)"
       });
     }
   },

--- a/ui/src/message_popup/renderers/question_interpreter.jsx
+++ b/ui/src/message_popup/renderers/question_interpreter.jsx
@@ -43,6 +43,7 @@ export default React.createClass({
     const key = JSON.stringify(question);
     const {forceText} = this.props;
 
+
     // Open response with audio by default, falling back to text if unavailable, and
     // allowing text responses to be forced.
     if (question.open) {
@@ -80,7 +81,8 @@ export default React.createClass({
         forceResponse={question.force || false}
         responsePrompt=""
         recordText="Respond"
-        ignoreText="Move on"
+        textHeight={96}
+        ignoreText="Ignore"
         onLogMessage={onLogMessage}
         onResponseSubmitted={onResponseSubmitted}
         />;


### PR DESCRIPTION
This adds a larger text box (4 lines to the previous 2) to the 4 scenes of HMTCA. It also switches "move on" to "ignore" to make it more clear than by passing you will not get a chance to respond later. 

![image](https://user-images.githubusercontent.com/25137921/29528276-76af7982-8669-11e7-8c95-37ff0aa10e22.png)
