### PR TITLE
Add minimal tests to insubordination scenarios

### DIFF
--- a/ui/src/message_popup/playtest/insubordination_scenarios_test.jsx
+++ b/ui/src/message_popup/playtest/insubordination_scenarios_test.jsx
@@ -1,0 +1,18 @@
+/* @flow weak */
+import {expect} from 'chai';
+
+import {InsubordinationScenarios} from './insubordination_scenarios.js';
+
+
+describe('InsubordinationScenarios', () => {
+  it('#cohortKey', () => {    
+    expect(InsubordinationScenarios.cohortKey('krob@mit.edu')).to.equal(2);
+    expect(InsubordinationScenarios.cohortKey('sfd')).to.equal(1);
+  });
+
+  it('#data', () => {
+    const {conditions, questionTemplates} = InsubordinationScenarios.data();
+    expect(conditions.length).to.equal(4);
+    expect(questionTemplates.length).to.equal(5);
+  });
+});


### PR DESCRIPTION
Used in unsuccessfully debugging a Rollbar error, adding this in for a bit more coverage.