### PR TITLE
Add feature for reviewing notes when giving feedback in Smith scenario

### DIFF
--- a/ui/src/message_popup/playtest/smith_experience_page_test.jsx
+++ b/ui/src/message_popup/playtest/smith_experience_page_test.jsx
@@ -1,0 +1,63 @@
+/* @flow weak */
+import React from 'react';
+
+import {shallow} from 'enzyme';
+import {expect} from 'chai';
+import sinon from 'sinon';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+
+import SmithExperiencePage from './smith_experience_page.jsx';
+
+
+const context = {
+  muiTheme: getMuiTheme(),
+  auth: {
+    userProfile: {
+      email: 'user@foo.com'
+    },
+    doLogout: sinon.spy()
+  }
+};
+
+const questions = [
+  { text: 'hello' },
+  { el: 'first thing happens' },
+  { text: 'What did you notice? Take notes below!', notes: true },
+  { el: 'something else happens' },
+  { text: 'What did you notice? Take notes below!', notes: true },
+  { text: 'Give feedback!', feedback: true },
+  { text: 'PAUSE' },
+  { el: 'second section scene' },
+  { text: 'What did you notice? Take notes below!', notes: true },
+  { text: 'Give feedback!', feedback: true },
+];
+
+describe('<SmithExperiencePage />', () => {
+  it('#getNotesBeforeFeedbackIndex for first section', () => {
+    const wrapper =  shallow(<SmithExperiencePage query={{}} />, { context});
+    const responses = [
+      { question: questions[0] },
+      { question: questions[1] },
+      { question: questions[2], responseText: 'foo' },
+      { question: questions[3] },
+      { question: questions[4], responseText: 'bar' },
+    ];
+    expect(wrapper.instance().getNotesBeforeFeedbackIndex(questions, responses, 5)).to.deep.equal(['foo', 'bar']);
+  });
+
+  it('#getNotesBeforeFeedbackIndex for second section', () => {
+    const wrapper =  shallow(<SmithExperiencePage query={{}} />, { context});
+    const responses = [
+      { question: questions[0] },
+      { question: questions[1] },
+      { question: questions[2], responseText: 'foo' },
+      { question: questions[3] },
+      { question: questions[4], responseText: 'bar' },
+      { question: questions[5], responseText: 'this is my feedback' },
+      { question: questions[6] },
+      { question: questions[7] },
+      { question: questions[8], responseText: 'yaaaaay' },
+    ];
+    expect(wrapper.instance().getNotesBeforeFeedbackIndex(questions, responses, 9)).to.deep.equal(['yaaaaay']);
+  });
+});

--- a/ui/src/message_popup/playtest/smith_scenario.jsx
+++ b/ui/src/message_popup/playtest/smith_scenario.jsx
@@ -305,7 +305,7 @@ Okay! Ready to start?`
         
 
     slides.push({type: 'Try it!', text:
-    `Once the students have left, your friend Mr. Smith comes up to you and asks for your thoughts. What feedback would you give him about what you observed?`, notes: true
+    `Once the students have left, your friend Mr. Smith comes up to you and asks for your thoughts. What feedback would you give him about what you observed?`, feedback: true
     });
 
     slides.push({type: 'PAUSE!', text:
@@ -545,7 +545,7 @@ Ready? Okay! Go!
 
     slides.push({type: 'Try it! - Lenses', text:
     `At the end of the second class, Mr. Smith again comes up to you and asks for your thoughts. What feedback would you give him about what you observed?`,
-      notes: true
+      feedback: true
     });
   }
 

--- a/ui/src/message_popup/renderers/question_interpreter.jsx
+++ b/ui/src/message_popup/renderers/question_interpreter.jsx
@@ -8,7 +8,7 @@ import MinimalTextResponse from '../renderers/minimal_text_response.jsx';
 import AudioCapture from '../../components/audio_capture.jsx';
 import MinimalTimedView from '../renderers/minimal_timed_view.jsx';
 import ApplesTextResponse from '../renderers/apples_text_response.jsx';
-
+import ResponseWithPastNotes from '../renderers/response_with_past_notes.jsx';
 
 // This renders a question and an interaction, and strives towards being a
 // general-purpose interpreter that over time ends up converging towards shared
@@ -107,6 +107,21 @@ export default React.createClass({
         onLogMessage={onLogMessage}
         onResponseSubmitted={onResponseSubmitted}
       />;
+    }
+
+    if (question.feedback && question.pastNotes) {
+      return (
+        <ResponseWithPastNotes key={key} pastNotes={question.pastNotes}>
+          <MinimalTextResponse
+            textHeight={192}
+            forceResponse={true}
+            responsePrompt="Feedback to Mr. Smith:"
+            recordText="Next"
+            onLogMessage={onLogMessage}
+            onResponseSubmitted={onResponseSubmitted}
+          />
+        </ResponseWithPastNotes>
+      );
     }
 
 

--- a/ui/src/message_popup/renderers/response_with_past_notes.jsx
+++ b/ui/src/message_popup/renderers/response_with_past_notes.jsx
@@ -19,7 +19,7 @@ export default React.createClass({
       <div>
         <div style={styles.container}>
           <div>Your notes:</div>
-          <ul>{pastNotes.map(note => <li style={{}}>{note}</li>)}</ul>
+          <ul>{pastNotes.map(note => <li key={note} style={{}}>{note}</li>)}</ul>
         </div>
         {children}
       </div>

--- a/ui/src/message_popup/renderers/response_with_past_notes.jsx
+++ b/ui/src/message_popup/renderers/response_with_past_notes.jsx
@@ -1,0 +1,35 @@
+/* @flow weak */
+import React from 'react';
+
+
+// This shows a past set of notes from previous scenes, for writing feedback based on those notes.
+// `children` is intended to be an response like MinimalTextResponse.
+export default React.createClass({
+  displayName: 'ResponseWithNotes',
+
+  propTypes: {
+    pastNotes: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
+    children: React.PropTypes.element
+  },
+
+
+  render() {
+    const {pastNotes, children} = this.props;
+    return (
+      <div>
+        <div style={styles.container}>
+          <div>Your notes:</div>
+          <ul>{pastNotes.map(note => <li style={{}}>{note}</li>)}</ul>
+        </div>
+        {children}
+      </div>
+    );
+  }
+});
+
+const styles = {
+  container: {
+    paddingBottom: 5,
+    margin: 20
+  }
+};


### PR DESCRIPTION
This allows folks to review their past notes when giving feedback in the Mr. Smith scenario.

It works by modifying the scenario to have `feedback` questions, and `getNextQuestion` then checks for this and grabs the past notes to include them in the question when rendering.  Rendering is done by `ResponseWithPastNotes`.

Screenshot:
<img width="374" alt="screen shot 2017-08-22 at 10 13 45 am" src="https://user-images.githubusercontent.com/1056957/29571380-0aa51b84-8727-11e7-95b4-d25b280444f0.png">
