### PR TITLE
Patch Jayden summary to work with text, rename component, fix copy bug

### DIFF
--- a/ui/src/message_popup/playtest/jayden_experience_page.jsx
+++ b/ui/src/message_popup/playtest/jayden_experience_page.jsx
@@ -12,7 +12,7 @@ import IntroWithEmail from '../linear_session/intro_with_email.jsx';
 import QuestionInterpreter from '../renderers/question_interpreter.jsx';
 import type {QuestionT} from './pairs_scenario.jsx';
 import JaydenScenario from './jayden_scenario.jsx';
-import AudioResponseSummary from '../renderers/audio_response_summary.jsx';
+import ResponseSummary from '../renderers/response_summary.jsx';
 
 type ResponseT = {
   choice:string,
@@ -51,10 +51,16 @@ export default React.createClass({
     };
   },
 
+  shouldForceText() {
+    return _.has(this.props.query, 'text');
+  },
+
   // Making questions from the cohort
   onStart(email) {
     const {cohortKey} = this.state;
-    const allQuestions = JaydenScenario.questionsFor(cohortKey);
+    const allQuestions = JaydenScenario.questionsFor(cohortKey, {
+      forceText: this.shouldForceText()
+    });
 
     const startQuestionIndex = this.props.query.p || 0; // for testing or demoing
     const questions = allQuestions.slice(startQuestionIndex);
@@ -118,19 +124,18 @@ export default React.createClass({
   },
 
   renderQuestionEl(question:QuestionT, onLog, onResponseSubmitted) {
-    const forceText = _.has(this.props.query, 'text');
     return <QuestionInterpreter
       question={question}
       onLog={onLog}
-      forceText={forceText}
+      forceText={this.shouldForceText()}
       onResponseSubmitted={onResponseSubmitted} />;
   },
 
   renderClosingEl(questions:[QuestionT], responses:[ResponseT]) {
     return (
-      <AudioResponseSummary responses={responses}>
+      <ResponseSummary responses={responses}>
         You've finished the simulation. Congrats! Below, you'll find your responses to the anticipate questions, the scenes with Jayden, and the reflection questions. Take time now to review your responses before returning to group discussion.
-      </AudioResponseSummary>
+      </ResponseSummary>
     );
   }
 });

--- a/ui/src/message_popup/playtest/jayden_scenario.jsx
+++ b/ui/src/message_popup/playtest/jayden_scenario.jsx
@@ -12,8 +12,11 @@ export type QuestionT = {
   choices:?bool // Forced-choice response
 };
 
+function lineAboutResponseMode(options) {
+  return (options && options.forceText) ? '' : "\nClick and speak aloud the words you'd say to the student.\n";
+}
 
-function slidesFor(cohortKey) {
+function questionsFor(cohortKey, options) {
   const slides:[QuestionT] = [];
 
   slides.push({ type: 'Overview', el:
@@ -75,10 +78,7 @@ You’ve noticed one of your students, Jayden, an African-American young man in 
 `When you're ready, you'll go through a set of scenes that simulate the conversation between you and Jayden.
 
 Improvise how you would act as a teacher, even if you don't have all the right answers or know the perfect thing to say.
-
-Click and speak aloud the words you'd say to the student.
-
-
+${lineAboutResponseMode(options)}
 Ready to start?
 `});
 
@@ -128,7 +128,6 @@ Before heading back to the group, let's shift to reflecting on what happened.
 
 
 export default {
-  questionsFor(cohortKey) {
-    return slidesFor(cohortKey);
-  }
+  questionsFor,
+  lineAboutResponseMode
 };

--- a/ui/src/message_popup/playtest/jayden_scenario_test.jsx
+++ b/ui/src/message_popup/playtest/jayden_scenario_test.jsx
@@ -1,0 +1,17 @@
+/* @flow weak */
+import {expect} from 'chai';
+
+import JaydenScenario from './jayden_scenario.jsx';
+
+
+describe('JaydenScenario', () => {
+  it('includes line about audio', () => {
+    const lineText = JaydenScenario.lineAboutResponseMode();
+    expect(lineText).to.equal("\nClick and speak aloud the words you'd say to the student.\n");
+  });
+
+  it('does not include line about audio', () => {
+    const lineText = JaydenScenario.lineAboutResponseMode({ forceText: true });
+    expect(lineText).to.equal('');
+  });
+});

--- a/ui/src/message_popup/playtest/rosa_experience_page.jsx
+++ b/ui/src/message_popup/playtest/rosa_experience_page.jsx
@@ -12,7 +12,7 @@ import IntroWithEmail from '../linear_session/intro_with_email.jsx';
 import QuestionInterpreter from '../renderers/question_interpreter.jsx';
 import type {QuestionT} from './pairs_scenario.jsx';
 import RosaScenario from './rosa_scenario.jsx';
-import AudioResponseSummary from '../renderers/audio_response_summary.jsx';
+import ResponseSummary from '../renderers/response_summary.jsx';
 
 type ResponseT = {
   choice:string,
@@ -128,9 +128,9 @@ export default React.createClass({
 
   renderClosingEl(questions:[QuestionT], responses:[ResponseT]) {
     return (
-      <AudioResponseSummary responses={responses}>
+      <ResponseSummary responses={responses}>
         You've finished the simulation. Congrats! Below, you'll find your responses to the anticipate questions, the scenes with Rosa, and the reflection questions.
-      </AudioResponseSummary>
+      </ResponseSummary>
     );
   }
 });

--- a/ui/src/message_popup/renderers/response_summary.jsx
+++ b/ui/src/message_popup/renderers/response_summary.jsx
@@ -7,17 +7,17 @@ import Divider from 'material-ui/Divider';
 import ReadMore from './read_more.jsx';
 
 /*
-Component that displays the summary of audio responses.
+Component that displays the summary of responses, either audio or text.
 */
 export default React.createClass({
-  displayName: 'AudioResponseSummary',
+  displayName: 'ResponseSummary',
 
   propTypes: {
     responses: React.PropTypes.array.isRequired,
     children: React.PropTypes.node
   },
 
-  // Supports text or audio
+  // Supports audio and two forms of text response.
   computeSummaryItems() {
     const {responses} = this.props;
 
@@ -32,6 +32,11 @@ export default React.createClass({
 
       if (response.textResponse) {
         const {responseText} = response.textResponse;
+        return {questionId, questionText, responseText};
+      }
+
+      if (response.responseText) {
+        const {responseText} = response;
         return {questionId, questionText, responseText};
       }
 

--- a/ui/src/message_popup/renderers/response_summary_test.jsx
+++ b/ui/src/message_popup/renderers/response_summary_test.jsx
@@ -1,0 +1,32 @@
+/* @flow weak */
+import React from 'react';
+
+import {shallow} from 'enzyme';
+import {expect} from 'chai';
+
+import ResponseSummary from './response_summary.jsx';
+
+
+describe('<ResponseSummary />', () => {
+  it('#computeSummaryItems for audio responses and two types of text responses', () => {
+    const responses = [{
+      question: { id: 'foo1', text: 'hello1' },
+      choice: 'OK'
+    }, {
+      question: { id: 'foo2', text: 'hello2' },
+      audioResponse: { downloadUrl: 'bar2'  }
+    }, {
+      question: { id: 'foo3', text: 'hello3' },
+      textResponse: { responseText: 'bar3' }
+    }, {
+      question: { id: 'foo4', text: 'hello4' },
+      responseText: 'bar4'
+    }];
+    const wrapper =  shallow(<ResponseSummary responses={responses} />);
+    expect(wrapper.instance().computeSummaryItems()).to.deep.equal([
+      { questionId: 'foo2', questionText: 'hello2', audioUrl: 'bar2' },
+      { questionId: 'foo3', questionText: 'hello3', responseText: 'bar3' },
+      { questionId: 'foo4', questionText: 'hello4', responseText: 'bar4' }
+    ]);
+  });
+});


### PR DESCRIPTION
The `AudioResponseSummary` component actually works for text too, so rename it.  There's two kinds of responses that are text, so this updates it to include both (depending on whether it's `MinimalTextComponent` directly or if that component is wrapped by `MinimalOpenResponse`.  Adds a test too.

Screenshot:
<img width="372" alt="screen shot 2017-08-24 at 3 00 25 pm" src="https://user-images.githubusercontent.com/1056957/29692832-132552c6-8900-11e7-93a8-79d93d282a57.png">
