### PR TITLE
Add in minimal paper prototyping format and player, from equity workshop

### DIFF
--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -14,8 +14,10 @@ import CsBiasPage from './home/cs_bias_page.jsx';
 import ConsentPage from './home/consent_page.jsx';
 import * as MessagePopup from './message_popup/index.js';
 
+// equity
 import FairPage from './message_popup/equity/fair_page.jsx';
 import ClimatePage from './message_popup/equity/climate_page.jsx';
+import PaperPrototypePage from './message_popup/equity/paper_prototype_page.jsx';
 
 
 export default React.createClass({
@@ -47,6 +49,7 @@ export default React.createClass({
     '/equity': 'fairPage',
     '/equity/fair': 'fairPage',
     '/equity/climate': 'climatePage',
+    '/equity/paper/:key': 'paperPrototypePage',
     
     // Included in /demos, shared externally, or used in playtests
     '/teachermoments/original': 'messagePopup',
@@ -236,6 +239,10 @@ export default React.createClass({
 
   climatePage(query = {}) {
     return <ClimatePage query={query} />;
+  },
+
+  paperPrototypePage(prototypeKey, query = {}) {
+    return <PaperPrototypePage prototypeKey={prototypeKey} query={query} />;
   },
 
   messagePopupPlaytest(cohortKey, query = {}) {

--- a/ui/src/message_popup/equity/equity_paper_prototypes.jsx
+++ b/ui/src/message_popup/equity/equity_paper_prototypes.jsx
@@ -75,7 +75,7 @@ export function toSlides(prototype) {
       <div><b>2: Read scenario</b></div>
       <div style={style}>{scenario}</div>
     </div>
-  , force: true, open: true});
+  , force: true, open: true, applesSceneNumber: 1});
 
   slides.push({ el: 
     <div>

--- a/ui/src/message_popup/equity/equity_paper_prototypes.jsx
+++ b/ui/src/message_popup/equity/equity_paper_prototypes.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+
+export const SeedPaperPrototypes = [
+  {
+    key: 'group-unfair',
+    context: `Two weeks ago, you assigned a collaborative group project to your chemistry class.  Currently, there's about a week left until it's due and a student Mark comes to talk to you after class.`,
+    scenario: `Mark: My group is doing fine on the group project, but I'm having to do extra work because Tyshawn doesn't offer to do anything.  It's super frustrating.  Are you going to give us all the same grade or are you going to give Tyshawn what he deserves?`,
+    coaching: `How did you try to model "inclusive excellence?"`
+  }, {
+    key: 'mixing-languages',
+    context: `You're teaching ELA to 10th grade students.  Students are working in small groups to analyze the language in a scene, and are going to share out to the whole class.  Rosario's group starts off the discussion.`,
+    scenario: `Rosario: So we analyzed the language in our group, and all the old archaic weird phrases.  And it's kind of cool he's mixing in references to Greek and like it's his own slang.  But how come we can't mix languages like he does in our own school work?`,
+    coaching: `For students who speak several languages, how can we "see the whole student" and their strengths within the classroom?`
+  }, {
+    key: 'cell-posters',
+    context: `It's a middle school life science class.  Students are working in small groups to make posters showing the roles of different parts of the cell.`,
+    scenario: `Angel: Alright, I've done enough here, I outlined the mitochondria and Golgi apparatus.\nLexi: What about the rest?\nAngel: I don't know, you should take it from here, you'll make it look way neater and pretty.`,
+    coaching: `What assumptions did you make about what was happening?`
+  }, {
+    key: 'coordinates-privilege',
+    context: `It's a 10th grade math class.  Students are working in pairs on converting polar coordinates to x/y coordinates.`,
+    scenario: `Huey: Do you remember what we do here?\nNoah: Yeah, we use the sine and cosine.  This is basic trigonometry, I did something like this at videogame coding camp this summer, even the middle school kids did it.`,
+    coaching: `Huey and Noah have different levels of "preparatory privilege" outside of school.  How did that influence their experience of this lesson?`
+  }, {
+    key: 'asian-population-growth',
+    context: `It's a ninth grade social studies class.  Students are presenting short speeches about global isssues, and at one table the topic is population growth.`,
+    scenario: `Christine: Population growth exploded in Asia in particular.  In the next few years, India will be the most populous country.\nMarcus: Oh Raj, this is all because of your people.  There's just too many of you.\nRaj: Yeah, we are taking over.`,
+    coaching: `How did you interpret what happened?`
+  }, {
+    key: 'maria-absent',
+    context: `Maria is a junior, and she just moved to town this year.  She's frequently late or absent to first period.  Today, she just walked in 15 minutes late.`,
+    scenario: `Maria: Sorry, I just can't seem to wake up on time, I'm always tired...`,
+    coaching: `What assumptions did you make about Maria in this situation?`
+  }
+];
+
+
+export const CSSPaperPrototypes = [
+  {
+    key: 'tom-absent',
+    context: `Tom is missing a lot of school.  The techer has participation and attendance policies that includes points.  Tom's grade is affected due to missed points for attendance.  Tom has not communicated with his teazcher and there's been no communication from home.`,
+    scenario: `Tom comes to school after missing two weeks and asks the teacher, "How can I get my grade up?"`,
+    coaching: `What assumptions about Tom did you make?`,
+    debrief: `Improvements: grade level might be good, a statement about teacher's history with the student.  First, inquire about why he's been gone to check your assumptions.  Second, give students choice and agency over the solution.`
+  }, {
+    key: 'inclusion-special-ed',
+    context: `Ms. Carlson is a special education teacher.  She's sharing accommodations about a special education student who is new to the school with the mainstream classroom teacher, Mr. Johnson.`,
+    scenario: `Mrs. Carlson, the special education teacher walks into Mr. Johnson's classroom to discuss a new student's IEP accomodations for the upcoming meeting.\nMr. Johnson: Why are you bringing me these accommodations for this student?  The student has a severe disability and cannot be successful in my class.`,
+    coaching: `As the special education teacher, how would you respond to this situation?  How might your response model inclusive excellence?`
+  }/*, {
+    key: '',
+    context: `Twenty-five students are in a middle school math class.  There are about 10 boys and 12 girls, and the students are considered high achieving.  The teacher is well-loved.`,
+    scenario: `You are teaching about variables and show an example of how "x" can be used in an equation.  A girl in the back raises her hand to ask a question.\bShawna: "Could you please give another example?"\nTwo boys in the front of the room roll their eyes around and one says.  Mrs. Carlson, the special education teacher walks into Mr. Johnson's classroom to discuss a new student's IEP accomodations for the upcoming meeting.\nMr. Johnson: Why are you bringing me these accommodations for this student?  The student has a severe disability and cannot be successful in my class.`,
+    coaching: `As the special education teacher, how would you respond to this situation?  How might your response model inclusive excellence?`
+  },*/
+];
+
+export function toSlides(prototype) {
+  const {context, scenario, coaching} = prototype;
+  const style = {
+    whiteSpace: 'pre-wrap'
+  };
+
+
+  var slides = [];
+  slides.push({ el: 
+    <div>
+      <div><b>1: Read context</b></div>
+      <div style={style}>{context}</div>
+    </div>
+  , force: true, open: true});
+
+  slides.push({ el: 
+    <div>
+      <div><b>2: Read scenario</b></div>
+      <div style={style}>{scenario}</div>
+    </div>
+  , force: true, open: true});
+
+  slides.push({ el: 
+    <div>
+      <div><b>3: Ask this question to kick off coaching or discussion</b></div>
+      <div style={style}>{coaching}</div>
+    </div>
+  , force: true, open: true});
+
+  slides.push({ el: 
+    <div>
+      <div><b>4: Debrief together</b></div>
+      <div style={style}>How could we improve this prototype?</div>
+    </div>
+  , force: true, open: true});
+
+  return slides;
+}

--- a/ui/src/message_popup/equity/equity_paper_prototypes.jsx
+++ b/ui/src/message_popup/equity/equity_paper_prototypes.jsx
@@ -70,12 +70,12 @@ export function toSlides(prototype) {
     </div>
   , force: true, open: true});
 
-  slides.push({ el: 
+  slides.push({ text: scenario, el: 
     <div>
       <div><b>2: Read scenario</b></div>
       <div style={style}>{scenario}</div>
     </div>
-  , force: true, open: true, applesSceneNumber: 1});
+  , applesSceneNumber: 1});
 
   slides.push({ el: 
     <div>

--- a/ui/src/message_popup/equity/equity_paper_prototypes.jsx
+++ b/ui/src/message_popup/equity/equity_paper_prototypes.jsx
@@ -67,15 +67,11 @@ export function toSlides(prototype) {
     <div>
       <div><b>1: Read context</b></div>
       <div style={style}>{context}</div>
+      <div style={{marginTop: 30}}>What are you anticipating?</div>
     </div>
   , force: true, open: true});
 
-  slides.push({ text: scenario, el: 
-    <div>
-      <div><b>2: Read scenario</b></div>
-      <div style={style}>{scenario}</div>
-    </div>
-  , applesSceneNumber: 1});
+  slides.push({ text: scenario, applesSceneNumber: 1});
 
   slides.push({ el: 
     <div>

--- a/ui/src/message_popup/equity/fair_page.jsx
+++ b/ui/src/message_popup/equity/fair_page.jsx
@@ -53,6 +53,7 @@ export default React.createClass({
             <li style={styles.themes}>Seeing the whole student</li>
           </ul>
         </div>
+        <div style={{marginTop: 40}}>Question or new idea?  Reach out at <b>krob@mit.edu</b> or <a href="https://twitter.com/mit_tsl">@mit_tsl</a>.</div>
         <Divider style={{marginTop: 40, marginBottom: 30}} />
         <List style={styles.list}>
           {this.renderScenarioItem("/equity/climate?fromequity", '1: Gendered or racialized student comments', '"Climate"', muiColors.red400)}
@@ -67,18 +68,28 @@ export default React.createClass({
           {this.renderScenarioItem("/teachermoments/jayden?fromequity", '6: Encouraging student growth', '"Jayden"', muiColors.orange700)}
         </List>
         <Divider style={{marginTop: 30, marginBottom: 30}} />
-        <div style={styles.header}>Learn more!</div>
+        <List style={styles.list}>
+          {this.renderScenarioItem("/equity/paper/tom-absent?text", 'Prototype: Assumptions about students', '"Tom absent"', '#0B3662')}
+          <div style={{flex: 1}} />
+        </List>
+        <Divider style={{marginTop: 30, marginBottom: 30}} />
+        <div style={styles.header}>Play some more!</div>
         <div style={styles.links}>
-          <div style={styles.link}>Using Online Practice Spaces to Investigate Challenges in Enacting Principles of Equitable Computer Science Teaching (<a href="https://osf.io/preprints/socarxiv/ygazx/">Robinson and Reich, forthcoming</a>)</div>
-          <div style={styles.link}>Using "Teacher Moments" as an Online Practice Space for Parent-Teacher Conference Simulation in Preservice Teacher Education (<a href="https://osf.io/preprints/socarxiv/9y5cd/">Owho-Ovuakporie 2017</a>)</div>
-          <div style={styles.link}><a href="http://blogs.edweek.org/edweek/edtechresearcher/2017/03/helping_teachers_surface_and_address_bias_with_online_practice_spaces.html">Helping Teachers Surface and Address Bias with Online Practice Spaces</a></div>
-          <div style={styles.link}><a href="https://mit-teaching-systems-lab.github.io/unconscious-bias/">Bias in teaching</a></div>
-          <a style={{...styles.link, marginTop: 30, fontWeight: 'bold'}} href="/demos">Try other practice spaces!</a>
+          <a style={styles.link} href="/demos">Try other practice spaces!</a>
           <div style={styles.link}><a href="http://tsl.mit.edu/practice-spaces-for-teacher-preparation/">Game-based practice spaces</a></div>
           <div style={styles.link}><a href="https://threeflows-blockly.herokuapp.com/">Prototype your own scenarios</a></div>
           <div style={styles.link}><a href="https://github.com/mit-teaching-systems-lab/threeflows">github.com/mit-teaching-systems-lab</a></div>
         </div>
-        <div>New idea?  Reach out at <a href="https://twitter.com/mit_tsl">@mit_tsl</a>.</div>
+        <Divider style={{marginTop: 30, marginBottom: 30}} />
+        <div style={styles.header}>Read more!</div>
+        <div style={styles.links}>
+          <div style={styles.link}>Using Online Practice Spaces to Investigate Challenges in Enacting Principles of Equitable Computer Science Teaching (<a href="https://osf.io/preprints/socarxiv/ygazx/">Robinson and Reich, forthcoming</a>)</div>
+          <div style={styles.link}>Using "Teacher Moments" as an Online Practice Space for Parent-Teacher Conference Simulation in Preservice Teacher Education (<a href="https://osf.io/preprints/socarxiv/9y5cd/">Owho-Ovuakporie 2017</a>)</div>
+          <div style={styles.link}>Exposing Conditional Inclusive Ideologies Through Simulated Interactions (<a href="https://www.academia.edu/725220/Exposing_conditional_inclusive_ideologies_through_simulated_interactions?auto=download">Dotger and Ashby 2010</a>)</div>
+          <div style={styles.link}>Designing and Using Clinical Simulations to Prepare Teachers for Culturally Responsive Teaching (<a href="http://etd.library.vanderbilt.edu/available/etd-03022016-165211/unrestricted/Self.pdf">Self 2016</a>)</div>
+          <div style={styles.link}><a href="http://blogs.edweek.org/edweek/edtechresearcher/2017/03/helping_teachers_surface_and_address_bias_with_online_practice_spaces.html">Helping Teachers Surface and Address Bias with Online Practice Spaces</a></div>
+          <div style={styles.link}><a href="https://mit-teaching-systems-lab.github.io/unconscious-bias/">Bias in teaching</a></div>
+        </div>
         <Divider style={{marginTop: 30, marginBottom: 30}} />
         <div style={{marginTop: 20}}>
           <a href="http://tsl.mit.edu">

--- a/ui/src/message_popup/equity/fair_page_test.jsx
+++ b/ui/src/message_popup/equity/fair_page_test.jsx
@@ -24,6 +24,6 @@ describe('<FairPage />', () => {
 
   it('renders Paper for each practice space', () => {
     const wrapper = shallow(<FairPage />);
-    expect(wrapper.find(Paper).length).to.equal(6);
+    expect(wrapper.find(Paper).length).to.equal(7);
   });
 });

--- a/ui/src/message_popup/equity/paper_prototype_page.jsx
+++ b/ui/src/message_popup/equity/paper_prototype_page.jsx
@@ -1,0 +1,289 @@
+/* @flow weak */
+import React from 'react';
+import uuid from 'uuid';
+import _ from 'lodash';
+
+import * as Api from '../../helpers/api.js';
+import hash from '../../helpers/hash.js';
+import LinearSession from '../linear_session/linear_session.jsx';
+import SessionFrame from '../linear_session/session_frame.jsx';
+import VelocityTransitionGroup from "velocity-react/velocity-transition-group";
+import 'velocity-animate/velocity.ui';
+import RaisedButton from 'material-ui/RaisedButton';
+
+import QuestionInterpreter from '../renderers/question_interpreter.jsx';
+import type {QuestionT} from '../playtest/pairs_scenario.jsx';
+import {toSlides, CSSPaperPrototypes, SeedPaperPrototypes} from './equity_paper_prototypes.jsx';
+import HMTCAGroupReview from '../playtest/hmtca_group_review.jsx';
+// TODO(kr) refactor
+
+
+type ResponseT = {
+  choice:string,
+  question:QuestionT,
+  sceneNumber?:number,
+  anonymizedText?:string
+};
+
+
+// These parts are the different phases of the online experience.
+const Parts = {
+  PRACTICE: 'PRACTICE',
+  GROUP_INSTRUCTIONS: 'GROUP_INSTRUCTIONS',
+  GROUP_REVIEW: 'GROUP_REVIEW',
+  FINAL_INSTRUCTIONS: 'FINAL_INSTRUCTIONS'
+};
+
+
+// For showing minimal paper prototypes
+export default React.createClass({
+  displayName: 'PaperPrototypePage',
+
+  propTypes: {
+    prototypeKey: React.PropTypes.string.isRequired,
+    query: React.PropTypes.shape({
+      cohort: React.PropTypes.string,
+      p: React.PropTypes.string,
+      workshop: React.PropTypes.string
+    }).isRequired
+  },
+
+  // User types cohort for team
+  getInitialState() {
+    return {
+      cohortKey: 'EQUITY_DEMO',
+      identifier: 'EQUITY_DEMO:' + uuid.v4(),
+      workshop: this.props.query.workshop || 'defaultWorkshop',
+      questions: null,
+      sessionId: uuid.v4(),
+      currentPart: Parts.PRACTICE
+    };
+  },
+
+  // This is the key for a "game session we want to later review."
+  // It's built from (cohort, workshop), so that each cohort of those has its own
+  // scene number space (the number is used for ordering and is user-facing).
+  //
+  // This means that if the same team code plays again later, the number of
+  // responses will keep growing over time (as opposed to "start a new game").
+  //
+  // Different workshop sessions on different days can use URLs to different workshop
+  // values for isolation.
+  applesKey() {
+    const {cohortKey, workshop} = this.state;
+    return [cohortKey, workshop].join(':');
+  },
+
+  firstSlide() {
+    return { el: 
+      <div>
+      <div><b>PART 1: Practice Individually</b></div>
+      <br />
+      <div>In Part 1, you’ll read through 4 separate classroom management scenes and type how you’d respond to each scene.</div>
+      <br />
+      <div>For each scene, simulate how you’d respond to the student(s) in the moment and type your response in the textbox located below the scene. </div>
+      <br />
+      <div>Once you’re finished with your responses, You'll review how people have responded and discuss.  Clicking on “Ok” will take you to your first scene. Ready?</div>
+      </div>
+    };
+  },
+
+  onCohortKeyChanged(e, menuItemKey, cohortKey) {
+    this.setState({cohortKey});
+  },
+
+  onIdentifierChanged(e) {
+    this.setState({ identifier: e.target.value });
+  },
+
+  // Making questions from the cohort
+  onStart(e) {
+    e.preventDefault();
+    const {prototypeKey} = this.props;
+    // const {cohortKey} = this.state;
+    const prototype = _.find([].concat(CSSPaperPrototypes).concat(SeedPaperPrototypes), { key: prototypeKey });
+    const allQuestions = toSlides(prototype);
+
+    const startQuestionIndex = this.props.query.p || 0; // for testing or demoing
+    const questions = allQuestions.slice(startQuestionIndex);
+    const questionsHash = hash(JSON.stringify(questions));
+    this.setState({
+      questions,
+      questionsHash
+    });
+  },
+
+  onShowGroupInstructions() {
+    this.setState({ currentPart: Parts.GROUP_INSTRUCTIONS });
+  },
+
+  onStartGroupReview() {
+    this.setState({ currentPart: Parts.GROUP_REVIEW });
+  },
+
+  onGroupReviewDone() {
+    this.setState({ currentPart: Parts.FINAL_INSTRUCTIONS });
+  },
+
+  onLogMessage(type, response) {
+    const {
+      identifier,
+      cohortKey,
+      sessionId,
+      questionsHash
+    } = this.state;
+    
+    // Watch for a particular message, then add in the applesKey and double-log
+    // it, stripping out all the identifiers from the log message so we can read it
+    // back later safely anonymized.
+    if (type === 'anonymized_apples_to_apples_partial') {
+      Api.logApplesText({
+        applesKey: this.applesKey(),
+        sceneNumber: response.sceneNumber,
+        sceneText: response.question.text,
+        anonymizedText: response.anonymizedText
+      });
+    }
+
+    Api.logEvidence(type, {
+      ...response,
+      sessionId,
+      cohortKey,
+      questionsHash,
+      identifier
+    });
+  },
+
+  render() {
+    return (
+      <SessionFrame>
+        {this.renderContent()}
+      </SessionFrame>
+    );
+  },
+
+  renderContent() {
+    const {questions, currentPart} = this.state;
+    if (currentPart === Parts.PRACTICE) {
+      if (!questions) return this.renderIntro();
+      return <LinearSession
+        questions={questions}
+        questionEl={this.renderQuestionEl}
+        summaryEl={this.renderPauseEl}
+        onLogMessage={this.onLogMessage}
+      />;
+    }
+
+    if (currentPart === Parts.GROUP_INSTRUCTIONS) return this.renderGroupInstructions();
+    if (currentPart === Parts.GROUP_REVIEW) return this.renderGroupReview();
+    if (currentPart === Parts.FINAL_INSTRUCTIONS) return this.renderFinalInstructions();
+  },
+
+  renderIntro() {
+    return (
+      <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
+        <form onSubmit={this.onStart}>
+          <div style={styles.instructions}>
+            <p>Welcome!  This is an online practice space adapted from a paper prototype.</p>
+          </div>
+          <div style={styles.instructions}>
+            <p>You can use this in partners, with one person playing the teacher candidate and the other the coach.  Or you can use it individually and then discuss in small groups afterward.</p>
+          </div>
+          <div style={styles.instructions}>
+            <p>In this practice space, you'll have to improvise and adapt to make the best of the situation. Some scenarios might not exactly match your grade level and subject.</p>
+          </div>
+          <div style={styles.instructions}>
+            <RaisedButton
+              onTouchTap={this.onStart}
+              type="submit"
+              style={styles.button}
+              secondary={true}
+              label="Start" />
+          </div>
+        </form>
+      </VelocityTransitionGroup>
+    );
+  },
+
+  renderQuestionEl(question:QuestionT, onLog, onResponseSubmitted) {
+    const forceText = _.has(this.props.query, 'text');
+    return (
+      <div>
+        <QuestionInterpreter
+          question={question}
+          onLog={onLog}
+          forceText={forceText}
+          onResponseSubmitted={onResponseSubmitted} />
+      </div>
+    );
+  },
+
+  renderPauseEl(questions:[QuestionT], responses:[ResponseT]) {
+    return (
+      <div style={{margin: 20}}>
+        <div style={{paddingBottom: 20}}>That's the end of Part 1.  Click to proceeed.</div>
+        <RaisedButton
+          label="Start Part #2"
+          secondary={true}
+          onTouchTap={this.onShowGroupInstructions} />
+      </div>
+    );
+  },
+
+  renderGroupInstructions() {
+    return (
+      <div style={{margin: 20}}>
+        <div>
+          <div><b>PART 2: Review, discuss, and capture</b></div>
+          <br />
+          <div>For Part 2, go through each scene as a group.  For each scene, review the responses and discuss them as a group.</div>
+          <br />
+          <i style={{margin: 10, display: 'block'}}>What does inclusive excellence look like in a K12 classroom?  How can we see the whole student in these situations?</i>
+          <br />
+          <div>Ready to start?</div>
+          <br />
+        </div>
+        <div>
+          <RaisedButton
+            label="ok!"
+            onTouchTap={this.onStartGroupReview} />
+        </div>
+      </div>
+    );
+  },
+
+  renderGroupReview() {
+    return <HMTCAGroupReview
+      prompt="Scroll through and discuss."
+      applesKey={this.applesKey()}
+      onDone={this.onGroupReviewDone} />;
+  },
+
+  renderFinalInstructions() {
+    return (
+      <div style={styles.instructions}>
+        <p><b>PART 3: Discuss assumptions</b></p>
+        <br />
+        <div>Part 3 is a group discussion, you won't work on your computers.</div>
+        <br />
+        <i style={{margin: 10, display: 'block'}}>What assumptions might we make about students based on their gender, race or ethnicity and how might these influence how we interpret and respond to situations?</i>
+        <br />
+        <div>If you have time, capture the main points of your discussion on the poster board, to share it out with the whole group after.</div>
+      </div>
+    );
+  }
+});
+
+const styles = {
+  instructions: {
+    fontSize: 18,
+    padding: 0,
+    margin:0,
+    paddingLeft: 20,
+    paddingRight: 20,
+    paddingBottom: 0
+  },
+  button: {
+    marginTop: 20
+  }
+};

--- a/ui/src/message_popup/equity/paper_prototype_page.jsx
+++ b/ui/src/message_popup/equity/paper_prototype_page.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import uuid from 'uuid';
 import _ from 'lodash';
 
+import TextField from 'material-ui/TextField';
 import * as Api from '../../helpers/api.js';
 import hash from '../../helpers/hash.js';
 import LinearSession from '../linear_session/linear_session.jsx';
@@ -51,9 +52,9 @@ export default React.createClass({
   // User types cohort for team
   getInitialState() {
     return {
-      cohortKey: 'EQUITY_DEMO',
-      identifier: 'EQUITY_DEMO:' + uuid.v4(),
-      workshop: this.props.query.workshop || 'defaultWorkshop',
+      cohortKey: '',
+      identifier: 'PAPER_PROTOTYPE_IDENTIFIER:' + uuid.v4(),
+      workshop: 'PAPER_PROTOTYPE_PAGE' + (this.props.query.workshop || 'defaultWorkshop'),
       questions: null,
       sessionId: uuid.v4(),
       currentPart: Parts.PRACTICE
@@ -88,8 +89,8 @@ export default React.createClass({
     };
   },
 
-  onCohortKeyChanged(e, menuItemKey, cohortKey) {
-    this.setState({cohortKey});
+  onCohortKeyChanged(e) {
+    this.setState({cohortKey: e.target.value});
   },
 
   onIdentifierChanged(e) {
@@ -192,9 +193,21 @@ export default React.createClass({
           <div style={styles.instructions}>
             <p>In this practice space, you'll have to improvise and adapt to make the best of the situation. Some scenarios might not exactly match your grade level and subject.</p>
           </div>
+          <div style={{...styles.instructions, marginTop: 40}}>
+            <div>What is your group code?</div>
+            <TextField
+              name="cohortKey"
+              style={{width: '100%', marginBottom: 20}}
+              underlineShow={true}
+              hintText="edu231@css"
+              value={this.state.cohortKey}
+              onChange={this.onCohortKeyChanged}
+              rows={1} />
+          </div>
           <div style={styles.instructions}>
             <RaisedButton
               onTouchTap={this.onStart}
+              disabled={this.state.cohortKey === ''}
               type="submit"
               style={styles.button}
               secondary={true}

--- a/ui/src/message_popup/equity/paper_prototype_page.jsx
+++ b/ui/src/message_popup/equity/paper_prototype_page.jsx
@@ -187,11 +187,12 @@ export default React.createClass({
           <div style={styles.instructions}>
             <p>Welcome!  This is an online practice space adapted from a paper prototype.</p>
           </div>
+          <div style={{marginLeft: 30}}><img src="https://s3-us-west-2.amazonaws.com/tsl-public/threeflows/paper-prototypes-crumpled.png" width={202} height={140} /></div>
           <div style={styles.instructions}>
-            <p>You can use this in partners, with one person playing the teacher candidate and the other the coach.  Or you can use it individually and then discuss in small groups afterward.</p>
+            <p>You can use this in partners, with one person playing the teacher candidate and the other the coach.  Or you could try it individually and then discuss afterward.</p>
           </div>
           <div style={styles.instructions}>
-            <p>In this practice space, you'll have to improvise and adapt to make the best of the situation. Some scenarios might not exactly match your grade level and subject.</p>
+            <p>In this practice space, you'll have to improvise and adapt to make the best of the situation. It might not exactly match your grade level and subject.</p>
           </div>
           <div style={{...styles.instructions, marginTop: 40}}>
             <div>What is your group code?</div>

--- a/ui/src/message_popup/equity/paper_prototype_page.jsx
+++ b/ui/src/message_popup/equity/paper_prototype_page.jsx
@@ -138,7 +138,6 @@ export default React.createClass({
     // it, stripping out all the identifiers from the log message so we can read it
     // back later safely anonymized.
     if (type === 'anonymized_apples_to_apples_partial') {
-      console.log('anon', response);
       Api.logApplesText({
         applesKey: this.applesKey(),
         sceneNumber: response.sceneNumber,

--- a/ui/src/message_popup/equity/paper_prototype_page.jsx
+++ b/ui/src/message_popup/equity/paper_prototype_page.jsx
@@ -138,6 +138,7 @@ export default React.createClass({
     // it, stripping out all the identifiers from the log message so we can read it
     // back later safely anonymized.
     if (type === 'anonymized_apples_to_apples_partial') {
+      console.log('anon', response);
       Api.logApplesText({
         applesKey: this.applesKey(),
         sceneNumber: response.sceneNumber,
@@ -282,6 +283,8 @@ export default React.createClass({
         <i style={{margin: 10, display: 'block'}}>What assumptions might we make about students based on their gender, race or ethnicity and how might these influence how we interpret and respond to situations?</i>
         <br />
         <div>If you have time, capture the main points of your discussion on the poster board, to share it out with the whole group after.</div>
+        <br />
+        <div>If you're online, connect with others at <a target="_blank" href="https://twitter.com/search?q=%23TeacherPracticeSpaces">#TeacherPracticeSpaces</a>.</div>
       </div>
     );
   }


### PR DESCRIPTION
Adds a new link to the equity page, and a way to play paper prototypes.

<img width="3
![Uploading Screen Shot 2017-12-01 at 2.36.25 PM.png…]()
73" alt="screen shot 2017-12-01 at 2 26 52 pm" src="https://user-images.githubusercontent.com/1056957/33501914-dcbc50b2-d6a3-11e7-9d66-9e76a86a5707.png">
<img width="368" alt="screen shot 2017-12-01 at 2 26 08 pm" src="https://user-images.githubusercontent.com/1056957/33501915-dcd7f830-d6a3-11e7-83da-2e39f73dc04e.png">
<img width="369" alt="screen shot 2017-12-01 at 2 12 29 pm" src="https://user-images.githubusercontent.com/1056957/33501916-dcf52400-d6a3-11e7-85c6-2f93aeb40b74.png">
