### PR TITLE
Add Danson and Darius to /equity page, improve context around paper prototype

### DIFF
--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -47,7 +47,7 @@ export default React.createClass({
     '/bias': 'biasHome',
     '/equity': 'equityFairPage',
 
-    // Stable and publicly shared practice spaces 
+    // Stable, field tested, publicly shared practice spaces
     '/teachermoments/danson': 'dansonPlaytest',
     '/teachermoments/turner': 'TurnerPlaytest',
     '/teachermoments/sub': 'messagePopupPairs',

--- a/ui/src/app.jsx
+++ b/ui/src/app.jsx
@@ -14,7 +14,7 @@ import ConsentPage from './home/consent_page.jsx';
 import * as MessagePopup from './message_popup/index.js';
 
 // equity
-import FairPage from './message_popup/equity/fair_page.jsx';
+import EquityFairPage from './message_popup/equity/equity_fair_page.jsx';
 import ClimatePage from './message_popup/equity/climate_page.jsx';
 import PaperPrototypePage from './message_popup/equity/paper_prototype_page.jsx';
 
@@ -45,7 +45,7 @@ export default React.createClass({
     '/demos': 'demos',
     '/consent': 'consent',
     '/bias': 'biasHome',
-    '/equity': 'fairPage',
+    '/equity': 'equityFairPage',
 
     // Stable and publicly shared practice spaces 
     '/teachermoments/danson': 'dansonPlaytest',
@@ -255,8 +255,8 @@ export default React.createClass({
     return <MessagePopup.HMTCAExperiencePage query={query} />;
   },
 
-  fairPage(query = {}) {
-    return <FairPage query={query} />;
+  equityFairPage(query = {}) {
+    return <EquityFairPage query={query} />;
   },
 
   climatePage(query = {}) {

--- a/ui/src/message_popup/equity/climate_page.jsx
+++ b/ui/src/message_popup/equity/climate_page.jsx
@@ -14,7 +14,7 @@ import RaisedButton from 'material-ui/RaisedButton';
 import QuestionInterpreter from '../renderers/question_interpreter.jsx';
 import type {QuestionT} from '../playtest/pairs_scenario.jsx';
 import HMTCAScenarios from '../playtest/hmtca_scenario.jsx';
-import HMTCAGroupReview from '../playtest/hmtca_group_review.jsx';
+import GroupReview from '../review/group_review.jsx';
 
 type ResponseT = {
   choice:string,
@@ -33,7 +33,7 @@ const Parts = {
 };
 
 
-// Adapte from HMTCA
+// Adapted from HMTCA session, for use in other workshops or as a public demo.
 export default React.createClass({
   displayName: 'ClimagePage',
 
@@ -248,7 +248,7 @@ export default React.createClass({
   },
 
   renderGroupReview() {
-    return <HMTCAGroupReview
+    return <GroupReview
       prompt="Scroll through and discuss."
       applesKey={this.applesKey()}
       onDone={this.onGroupReviewDone} />;

--- a/ui/src/message_popup/equity/equity_fair_page.jsx
+++ b/ui/src/message_popup/equity/equity_fair_page.jsx
@@ -8,9 +8,10 @@ import * as muiColors from 'material-ui/styles/colors.js';
 import * as Routes from '../../routes.js';
 
 
-// Equity Workshop home page
+// Equity Workshop home page.  Intended for use in an in-person workshop,
+// or as a landing page that can be shared publicly.
 export default React.createClass({
-  displayName: 'EquityPage',
+  displayName: 'EquityFairPage',
 
   onClicked(href) {
     if (href.indexOf('http') === 0) {
@@ -28,23 +29,15 @@ export default React.createClass({
   render() {
     return (
       <div style={styles.page}>
-        {this.renderScenarios()}
-      </div>
-    );
-  },
-
-  renderScenarios() {
-    return (
-      <div style={styles.content}>
-      <div style={{marginTop: 20}}>
-        <a href="http://tsl.mit.edu">
-          <img
-            style={styles.logo}
-            src="https://tsl-public.s3.amazonaws.com/threeflows/teacher-moments-tsl-logo.png" />
-        </a>
-      </div>
-      <Divider style={{marginTop: 20, marginBottom: 30}} />
-      <h2>Equity practice spaces</h2>
+        <div style={styles.content}>
+          <a href="http://tsl.mit.edu">
+            <img
+              style={styles.logo}
+              src="https://tsl-public.s3.amazonaws.com/threeflows/teacher-moments-tsl-logo.png" />
+          </a>
+        </div>
+        <Divider style={{marginTop: 30, marginBottom: 30}} />
+        <h2>Equity practice spaces</h2>
         <p style={{marginTop: 10, marginBottom: 20}}>These interactive case studies can be used to spark conversation during in-person workshops, as homework to seed work in class, or within online PLCs.  They can be used for initial exposure to challenges teachers face in classrooms, or as formative assessments.</p>
         <div>
          <div style={styles.themes}>Themes:</div>
@@ -53,26 +46,47 @@ export default React.createClass({
             <li style={styles.themes}>Seeing the whole student</li>
           </ul>
         </div>
-        <div style={{marginTop: 40}}>Question or new idea?  Reach out at <b>krob@mit.edu</b> or <a href="https://twitter.com/mit_tsl">@mit_tsl</a>.</div>
-        <Divider style={{marginTop: 40, marginBottom: 30}} />
-        <List style={styles.list}>
-          {this.renderScenarioItem("/equity/climate?fromequity", '1: Gendered or racialized student comments', '"Climate"', muiColors.red400)}
-          {this.renderScenarioItem("/teachermoments/smith?fromequity", '2: Noticing student belonging in the classroom', '"Mr. Smith"', muiColors.blueGrey500)}
-        </List>
-        <List style={styles.list}>
-          {this.renderScenarioItem("/teachermoments/sub?fromequity", '3: Positioning students in the classroom', '"Lego pairs"', muiColors.green500)}
-          {this.renderScenarioItem("/teachermoments/rosa?fromequity", '4: Talking about identity', '"Rosa"', muiColors.indigo400)}
-        </List>
-        <List style={styles.list}>
-          {this.renderScenarioItem("https://swipe-right-for-cs.herokuapp.com/play?fromequity", '5: Connecting student strengths to academics', '"Swipe Right for CS"', muiColors.brown400)}
-          {this.renderScenarioItem("/teachermoments/jayden?fromequity", '6: Encouraging student growth', '"Jayden"', muiColors.orange700)}
-        </List>
+        <div style={{marginTop: 40, marginBottom: 30}}>Question or new idea?  Reach out at <b>krob@mit.edu</b> or <a href="https://twitter.com/mit_tsl">@mit_tsl</a>.</div>
+        {this.renderPanels()}
+        {this.renderMoreInfo()}
+      </div>
+    );
+  },
+
+  renderPanels() {
+    const scholasticaBlue = '#0B3662'; // from their website
+    return (
+      <div>
         <Divider style={{marginTop: 30, marginBottom: 30}} />
         <List style={styles.list}>
-          {this.renderScenarioItem("/equity/paper/tom-absent?text", 'Prototype: Assumptions about students', '"Tom absent"', '#0B3662')}
+          {this.renderPanel("/equity/climate?fromequity", '1: Gendered or racialized student comments', '"Climate"', muiColors.red400)}
+          {this.renderPanel("/teachermoments/smith?fromequity", '2: Noticing student belonging in the classroom', '"Mr. Smith"', muiColors.blueGrey500)}
+        </List>
+        <List style={styles.list}>
+          {this.renderPanel("/teachermoments/sub?fromequity", '3: Positioning students in the classroom', '"Lego pairs"', muiColors.green500)}
+          {this.renderPanel("/teachermoments/rosa?fromequity", '4: Talking about identity', '"Rosa"', muiColors.indigo400)}
+        </List>
+        <List style={styles.list}>
+          {this.renderPanel("https://swipe-right-for-cs.herokuapp.com/play?fromequity", '5: Connecting student strengths to academics', '"Swipe Right for CS"', muiColors.brown400)}
+          {this.renderPanel("/teachermoments/jayden?fromequity", '6: Encouraging student growth', '"Jayden"', muiColors.orange700)}
+        </List>
+        <List style={styles.list}>
+          {this.renderPanel("/teachermoments/turner?fromequity", '7: High expecations with parents', '"Jennifer Turner"', muiColors.deepPurple500)}
           <div style={{flex: 1}} />
         </List>
         <Divider style={{marginTop: 30, marginBottom: 30}} />
+        <List style={styles.list}>
+          {this.renderPanel("/equity/paper/tom-absent?fromequity&text", 'Prototype: Talking ', '"Tom absent"', scholasticaBlue)}
+          {this.renderPanel("/teachermoments/darius?fromequity", 'Prototype: Student concerns about equity', '"Darius"', muiColors.grey700)}
+        </List>
+        <Divider style={{marginTop: 30, marginBottom: 30}} />
+      </div>
+    );
+  },
+
+  renderMoreInfo() {
+    return (
+      <div>
         <div style={styles.header}>Play some more!</div>
         <div style={styles.links}>
           <a style={styles.link} href="/demos">Try other practice spaces!</a>
@@ -102,7 +116,7 @@ export default React.createClass({
     );
   },
 
-  renderScenarioItem(href, linkText, text, backgroundColor) {
+  renderPanel(href, linkText, text, backgroundColor) {
     return (
       <Paper zDepth={3} style={{flex: 1, margin: 15, backgroundColor}}>
         <div style={{cursor: 'pointer', padding: 30, display: 'inline-block', textDecoration: 'none', color: '#333'}} onClick={this.onClicked.bind(this, href)}>
@@ -118,16 +132,15 @@ export default React.createClass({
 
 const styles = {
   page: {
-    width: 800,
+    width: 740,
     marginLeft: 'auto',
     marginRight: 'auto',
     marginTop: 20,
-    marginBottom: 20
+    marginBottom: 20,
+    padding: 30,
+    backgroundColor: 'white'
   },
   content: {
-    padding: 30,
-    paddingTop: 10,
-    backgroundColor: 'white'
   },
   quote: {
     fontStyle: 'italic'

--- a/ui/src/message_popup/equity/equity_fair_page_test.jsx
+++ b/ui/src/message_popup/equity/equity_fair_page_test.jsx
@@ -4,26 +4,26 @@ import ReactDOM from 'react-dom';
 import {shallow} from 'enzyme';
 import {expect} from 'chai';
 
-import FairPage from './fair_page.jsx';
+import EquityFairPage from './equity_fair_page.jsx';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import TestAuthContainer from '../../test_auth_container.jsx';
 import Paper from 'material-ui/Paper';
 
 
-describe('<FairPage />', () => {
+describe('<EquityFairPage />', () => {
   it('renders', () => {
     const div = document.createElement('div');
     ReactDOM.render(
       <MuiThemeProvider>
         <TestAuthContainer>
-          <FairPage />
+          <EquityFairPage />
         </TestAuthContainer>
       </MuiThemeProvider>
     , div);
   });
 
   it('renders Paper for each practice space', () => {
-    const wrapper = shallow(<FairPage />);
+    const wrapper = shallow(<EquityFairPage />);
     expect(wrapper.find(Paper).length).to.equal(7);
   });
 });

--- a/ui/src/message_popup/equity/equity_fair_page_test.jsx
+++ b/ui/src/message_popup/equity/equity_fair_page_test.jsx
@@ -24,6 +24,6 @@ describe('<EquityFairPage />', () => {
 
   it('renders Paper for each practice space', () => {
     const wrapper = shallow(<EquityFairPage />);
-    expect(wrapper.find(Paper).length).to.equal(7);
+    expect(wrapper.find(Paper).length).to.equal(9);
   });
 });

--- a/ui/src/message_popup/equity/paper_prototype_page.jsx
+++ b/ui/src/message_popup/equity/paper_prototype_page.jsx
@@ -14,9 +14,8 @@ import RaisedButton from 'material-ui/RaisedButton';
 
 import QuestionInterpreter from '../renderers/question_interpreter.jsx';
 import type {QuestionT} from '../playtest/pairs_scenario.jsx';
-import {toSlides, CSSPaperPrototypes, SeedPaperPrototypes} from './equity_paper_prototypes.jsx';
-import HMTCAGroupReview from '../playtest/hmtca_group_review.jsx';
-// TODO(kr) refactor
+import {toSlides, CSSPaperPrototypes, SeedPaperPrototypes} from './paper_prototype_scenarios.jsx';
+import GroupReview from '../review/group_review.jsx';
 
 
 type ResponseT = {
@@ -36,7 +35,8 @@ const Parts = {
 };
 
 
-// For showing minimal paper prototypes
+// For showing minimal paper prototypes.
+// This was adapted from HMTCAExperiencePage
 export default React.createClass({
   displayName: 'PaperPrototypePage',
 
@@ -89,19 +89,9 @@ export default React.createClass({
     };
   },
 
-  onCohortKeyChanged(e) {
-    this.setState({cohortKey: e.target.value});
-  },
-
-  onIdentifierChanged(e) {
-    this.setState({ identifier: e.target.value });
-  },
-
   // Making questions from the cohort
-  onStart(e) {
-    e.preventDefault();
+  doStart() {
     const {prototypeKey} = this.props;
-    // const {cohortKey} = this.state;
     const prototype = _.find([].concat(CSSPaperPrototypes).concat(SeedPaperPrototypes), { key: prototypeKey });
     const allQuestions = toSlides(prototype);
 
@@ -112,6 +102,26 @@ export default React.createClass({
       questions,
       questionsHash
     });
+  },
+
+  onCohortKeyChanged(e) {
+    this.setState({cohortKey: e.target.value});
+  },
+
+  onIdentifierChanged(e) {
+    this.setState({ identifier: e.target.value });
+  },
+
+  onNoGroupCode(e) {
+    e.preventDefault();
+    const cohortKey = 'DEMO_COHORT';
+    this.setState({cohortKey});
+    this.doStart();
+  },
+
+  onStart(e) {
+    e.preventDefault();
+    this.doStart();
   },
 
   onShowGroupInstructions() {
@@ -200,19 +210,24 @@ export default React.createClass({
               name="cohortKey"
               style={{width: '100%', marginBottom: 20}}
               underlineShow={true}
-              hintText="edu231@css"
+              hintText="example: edu5252"
               value={this.state.cohortKey}
               onChange={this.onCohortKeyChanged}
               rows={1} />
           </div>
-          <div style={styles.instructions}>
+          <div style={{...styles.instructions, marginBottom: 40}}>
             <RaisedButton
               onTouchTap={this.onStart}
-              disabled={this.state.cohortKey === ''}
               type="submit"
+              disabled={this.state.cohortKey === ''}
               style={styles.button}
               secondary={true}
               label="Start" />
+            <RaisedButton
+              onTouchTap={this.onNoGroupCode}
+              type="submit"
+              style={styles.button}
+              label="I don't have a group code" />
           </div>
         </form>
       </VelocityTransitionGroup>
@@ -252,7 +267,7 @@ export default React.createClass({
           <br />
           <div>For Part 2, go through each scene as a group.  For each scene, review the responses and discuss them as a group.</div>
           <br />
-          <i style={{margin: 10, display: 'block'}}>What does inclusive excellence look like in a K12 classroom?  How can we see the whole student in these situations?</i>
+          <i style={{margin: 10, display: 'block'}}>What does equity look like in a K12 classroom for students?  How can we see the whole student in these situations?</i>
           <br />
           <div>Ready to start?</div>
           <br />
@@ -267,7 +282,7 @@ export default React.createClass({
   },
 
   renderGroupReview() {
-    return <HMTCAGroupReview
+    return <GroupReview
       prompt="Scroll through and discuss."
       applesKey={this.applesKey()}
       onDone={this.onGroupReviewDone} />;

--- a/ui/src/message_popup/equity/paper_prototype_scenarios.jsx
+++ b/ui/src/message_popup/equity/paper_prototype_scenarios.jsx
@@ -38,7 +38,7 @@ export const SeedPaperPrototypes = [
 export const CSSPaperPrototypes = [
   {
     key: 'tom-absent',
-    context: `Tom is missing a lot of school.  The techer has participation and attendance policies that includes points.  Tom's grade is affected due to missed points for attendance.  Tom has not communicated with his teazcher and there's been no communication from home.`,
+    context: `Tom is missing a lot of school.  The teacher has participation and attendance policies that includes points.  Tom's grade is affected due to missed points for attendance.  Tom has not communicated with his teacher and there's been no communication from home.`,
     scenario: `Tom comes to school after missing two weeks and asks the teacher, "How can I get my grade up?"`,
     coaching: `What assumptions about Tom did you make?`,
     debrief: `Improvements: grade level might be good, a statement about teacher's history with the student.  First, inquire about why he's been gone to check your assumptions.  Second, give students choice and agency over the solution.`
@@ -63,29 +63,46 @@ export function toSlides(prototype) {
 
 
   var slides = [];
-  slides.push({ el: 
+  slides.push({ type: 'Introduction', el: 
     <div>
-      <div><b>1: Read context</b></div>
-      <div style={style}>{context}</div>
-      <div style={{marginTop: 30}}>What are you anticipating?</div>
+      <div>1. Read context</div>
+      <div>Imagine yourself in the particular school and classroom.  You won't know all the answers, and will have to improvise and adapt to make the best of the situation.</div>
+      <br />
+      <div>2. Anticipate</div>
+      <div>Before starting the simulation, answer a few questions about what might happen.  You shouldn't have an in-depth understanding, but do your best to anticipate what might happen.</div>
+      <br />
+      <div>3. Try it!</div>
+      <div>When you're ready, you'll go through a set of short scenes that simulate interactions between you and a student.</div>
+      <br />
+      <div>4. Reflect</div>
+      <div>Finally, you'll reflect on your experience and then discuss in your group.</div>
     </div>
-  , force: true, open: true});
+  });
 
-  slides.push({ text: scenario, applesSceneNumber: 1});
+  slides.push({
+    type: '1. Read context',
+    el: <div style={style}>{context}</div>
+  });
 
-  slides.push({ el: 
-    <div>
-      <div><b>3: Ask this question to kick off coaching or discussion</b></div>
-      <div style={style}>{coaching}</div>
-    </div>
-  , force: true, open: true});
+  slides.push({
+    type: '2. Anticipate',
+    force: true,
+    open: true,
+    el: <div style={style}>What are you anticipating?</div>,
+  });
 
-  slides.push({ el: 
-    <div>
-      <div><b>4: Debrief together</b></div>
-      <div style={style}>How could we improve this prototype?</div>
-    </div>
-  , force: true, open: true});
+  slides.push({
+    type: '3. Try it!',
+    applesSceneNumber: 1,
+    text: scenario
+  });
+
+  slides.push({
+    type: '4. Reflect',
+    force: true,
+    open: true,
+    el: <div style={style}>{coaching}</div>
+  });
 
   return slides;
 }

--- a/ui/src/message_popup/playtest/group_review.jsx
+++ b/ui/src/message_popup/playtest/group_review.jsx
@@ -1,0 +1,135 @@
+// TODO(kr) flow typing disabled because of error in refreshTimer typing
+import React from 'react';
+import _ from 'lodash';
+
+import * as Api from '../../helpers/api.js';
+import Paper from 'material-ui/Paper';
+import {Card, CardTitle, CardText} from 'material-ui/Card';
+import RaisedButton from 'material-ui/RaisedButton';
+
+
+// For reviewing and discussing in small groups.  Shows questions along with
+// how other people have responsed (anonymized text responses).
+//
+// Responses are grouped by the `applesKey` (this was originally part of a feature
+// that worked like the game Apples-to-Apples), and requires that responses
+// were logged in a particular format and with the same `applesKey`.
+export default React.createClass({
+  displayName: 'GroupReview',
+
+  propTypes: {
+    prompt: React.PropTypes.string.isRequired,
+    applesKey: React.PropTypes.string.isRequired,
+    onDone: React.PropTypes.func.isRequired
+  },
+
+  getInitialState() {
+    return {
+      hasLoaded: false,
+      applesResponses: null
+    };
+  },
+
+  // This is where we could add a timer using setInterval to repeatedly call the
+  // method that refreshes the responses (and then add a componentWillUnmount to cleanup).
+  componentDidMount() {
+    this.refreshResponses();
+    this.refreshTimer = setInterval(this.refreshResponses,5000);
+  },
+
+  componentWillUnmount(){
+    clearInterval(this.refreshTimer);
+  },
+
+  refreshTimer: (null: ?number),
+
+  refreshResponses() {
+    const {applesKey} = this.props;
+    Api.getApples(applesKey).end(this.onResponsesReceived);
+  },
+
+  onButtonTapped() {
+    this.props.onDone();
+  },
+
+  onResponsesReceived(err, response){
+    if (err){
+      this.setState({ hasLoaded: true });
+      return;
+    }
+    const applesResponses = JSON.parse(response.text);
+    this.setState({ hasLoaded: true, applesResponses });
+  },
+
+  render() {
+    const {prompt} = this.props;
+    const {hasLoaded, applesResponses} = this.state;
+    if (!hasLoaded) return <div>Loading...</div>;
+
+    // Use scene number for ordering, but then just number then naturally
+    const sceneToResponses = _.groupBy(applesResponses, 'scene_number');
+    return (
+      <div>
+        <div style={styles.instructions}>{prompt}</div>
+        <div>{_.sortBy(Object.keys(sceneToResponses)).map((sceneNumber, index) => {
+          if (sceneNumber === 'null') return;
+          return (
+            <div key={sceneNumber}>
+              <Card>
+                <CardTitle
+                  title={`Scene #${index + 1}`}
+                  subtitle={sceneToResponses[sceneNumber][0]['scene_text']}
+                />
+                <CardText>
+              <div style={styles.cardContainer}>
+                {_.uniq(_.map(sceneToResponses[sceneNumber], 'anonymized_text')).map((anonymizedText, index) => {
+                  const responseLetter = String.fromCharCode('A'.charCodeAt() + index);
+
+                  return (
+                    <Paper
+                      key={anonymizedText}
+                      style={styles.responseCard}
+                      zDepth={3}>
+                      <div>{`Response ${responseLetter}:`}</div>
+                      <div style={{padding: 10}}>{anonymizedText}</div>
+                    </Paper>
+                  );
+                })}
+              </div>
+              </CardText>
+              </Card>
+            </div>
+          );
+        })}</div>
+        <div style={{margin: 20}}>
+          <RaisedButton
+            label="Start Part #3"
+            secondary={true}
+            onTouchTap={this.onButtonTapped} />
+        </div>
+      </div>
+    );
+  }
+});
+
+const styles = {
+  instructions: {
+    fontSize: 18,
+    marginLeft: 15,
+    marginTop: 30,
+    marginBottom: 30
+  },
+  cardContainer: {
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  responseCard: {
+    minHeight: 200,
+    flex: 1,
+    textAlign: 'left',
+    marginBottom: 15,
+    marginTop: 15,
+    padding: 15,
+    display: 'inline-block'
+  }
+};

--- a/ui/src/message_popup/playtest/hmtca_experience_page.jsx
+++ b/ui/src/message_popup/playtest/hmtca_experience_page.jsx
@@ -18,7 +18,7 @@ import TextField from 'material-ui/TextField';
 import QuestionInterpreter from '../renderers/question_interpreter.jsx';
 import type {QuestionT} from './pairs_scenario.jsx';
 import HMTCAScenarios from './hmtca_scenario.jsx';
-import HMTCAGroupReview from './hmtca_group_review.jsx';
+import GroupReview from '../review/group_review.jsx';
 
 type ResponseT = {
   choice:string,
@@ -282,7 +282,7 @@ export default React.createClass({
   },
 
   renderGroupReview() {
-    return <HMTCAGroupReview
+    return <GroupReview
       prompt="Scroll through, discuss and capture."
       applesKey={this.applesKey()}
       onDone={this.onGroupReviewDone} />;

--- a/ui/src/message_popup/review/group_review.jsx
+++ b/ui/src/message_popup/review/group_review.jsx
@@ -10,7 +10,7 @@ import RaisedButton from 'material-ui/RaisedButton';
 
 // For reviewing responses as a group.
 export default React.createClass({
-  displayName: 'HMTCAGroupReview',
+  displayName: 'GroupReview',
 
   propTypes: {
     prompt: React.PropTypes.string.isRequired,


### PR DESCRIPTION
## New panels on /equity
<img width="847" alt="screen shot 2017-12-02 at 2 21 11 pm" src="https://user-images.githubusercontent.com/1056957/33519201-16368ebc-d770-11e7-9f38-71b7ac03d593.png">

## Examples of paper prototype improvements
<img width="377" alt="screen shot 2017-12-02 at 2 49 17 pm" src="https://user-images.githubusercontent.com/1056957/33519199-161a5710-d770-11e7-8cb3-0d98f9edc1a2.png">
<img width="369" alt="screen shot 2017-12-02 at 2 49 13 pm" src="https://user-images.githubusercontent.com/1056957/33519200-162adfc2-d770-11e7-85dc-7f0840f4706a.png">

