### PR TITLE
Bump node version in Travis for yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6.2.1"
+  - "6.2.2"
 
 branches:
   only:


### PR DESCRIPTION
Follow on to https://github.com/mit-teaching-systems-lab/threeflows/pull/330 addressing yarn warning in https://travis-ci.org/mit-teaching-systems-lab/threeflows/builds/319411294?utm_source=email&utm_medium=notification