### PR TITLE
Add responses to questionEl in LinearSession to fix bug with Turner scenario

### DIFF
--- a/ui/src/message_popup/linear_session/linear_session.jsx
+++ b/ui/src/message_popup/linear_session/linear_session.jsx
@@ -78,7 +78,7 @@ export default React.createClass({
 
     return (
       <div key={question.id}>
-        {this.props.questionEl(question, this.onLogMessageWithQuestion.bind(this, question), this.onResponseSubmitted.bind(this, question))}
+        {this.props.questionEl(question, this.onLogMessageWithQuestion.bind(this, question), this.onResponseSubmitted.bind(this, question), {responses})}
       </div>
     );
   }

--- a/ui/src/message_popup/linear_session/linear_session_test.jsx
+++ b/ui/src/message_popup/linear_session/linear_session_test.jsx
@@ -36,8 +36,9 @@ describe('<LinearSession />', ()=>{
 
     expect(props.questionEl.getCalls().length).to.equal(1);
     const renderCall = props.questionEl.getCall(0);
-    expect(renderCall.args.length).to.equal(3);
-    expect(renderCall.args[0]).to.equal('foo');
+    expect(renderCall.args.length).to.equal(4);
+    expect(renderCall.args[0]).to.equal('foo'); // passes question
+    expect(renderCall.args[3]).to.deep.equal({ responses: [] }); // passes options:{responses}
   });
 
   it('provides default getNextQuestion', ()=>{
@@ -52,8 +53,9 @@ describe('<LinearSession />', ()=>{
 
     expect(props.questionEl.getCalls().length).to.equal(1);
     const renderCall = props.questionEl.getCall(0);
-    expect(renderCall.args.length).to.equal(3);
-    expect(renderCall.args[0]).to.equal('bar');
+    expect(renderCall.args.length).to.equal(4);
+    expect(renderCall.args[0]).to.equal('bar'); // passes question
+    expect(renderCall.args[3]).to.deep.equal({ responses: [] }); // passes options:{responses}
   });
 
   it('takes responses, logs them with question merged, and updates state', ()=>{

--- a/ui/src/message_popup/playtest/turner_experience_page.jsx
+++ b/ui/src/message_popup/playtest/turner_experience_page.jsx
@@ -16,11 +16,6 @@ import MixedQuestion from '../renderers/mixed_question.jsx';
 import OkResponse from '../responses/ok_response.jsx';
 import * as Routes from '../../routes.js';
 
-type NextQuestionT = {
-  id:number,
-  question:QuestionT,
-  responses:[ResponseT]
-};
 
 // The top-level page, manages logistics around email, questions,
 // and the display of instructions, questions, and summary.
@@ -76,14 +71,6 @@ export default React.createClass({
     onResponseSubmitted(response);
   },
 
-  onGetNextQuestion(questions:[QuestionT], responses:[ResponseT]) {
-    if (responses.length >= questions.length) {
-      return null;
-    }
-    const question = questions[responses.length];
-    return {id: question.id, question:question, responses:responses};
-  },
-
   render() {
     return (
       <SessionFrame>
@@ -99,7 +86,6 @@ export default React.createClass({
     return <LinearSession
       questions={questions}
       questionEl={this.renderQuestionEl}
-      getNextQuestion={this.onGetNextQuestion}
       summaryEl={this.renderSummaryEl}
       onLogMessage={this.onLogMessage}
     />;
@@ -119,8 +105,8 @@ export default React.createClass({
     );
   },
 
-  renderQuestionEl(nextQuestion:NextQuestionT, onLog, onResponseSubmitted) {
-    const {question, responses} = nextQuestion;
+  renderQuestionEl(question:QuestionT, onLog, onResponseSubmitted, options = {}) {
+    const {responses} = options;
 
     if (question.stage === 'scenario') {
       return (


### PR DESCRIPTION
This fixes a bug with the Turner scenario that was likely introduced in https://github.com/mit-teaching-systems-lab/threeflows/pull/270.  This bug also affects the Danson scenario, which isn't fixed here and needs to be addressed separately.

The problem comes from two pieces of code.  The first piece of code is in `LinearSession` in https://github.com/mit-teaching-systems-lab/threeflows/pull/270 that merges in the `question` to every response that is logged.  This is useful for some data analysis, since the question that the user was shown is guaranteed to be in the same log data as the response itself (otherwise analysis would have to look back over multiple log items and join that, which is less simple).  The second piece of code is the implementation of `getNextQuestion` in the Turner (and Danson) scenario.  The Turner scenario has some postreflection questions that show the user all of the past questions and their responses.  To accomplish this, we'd previously implement `getNextQuestion` and merged in all past responses to each question.  This was a workaround of not having access to past `responses` in `questionEl`.

These two things interacted so that for the Turner scenario, `getNextQuestion` would put all past responses into the `question`, and then when any logging happened, `LinearSession` would put the `question` into each `response`.  This led to essentially doubling the size of the response that was logged each time, and led to payload too large errors on the server when parsing JSON, and memory errors on the client that could crash the browser.