### PR TITLE
Fix Flow errors for paper_prototype_page.jsx

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "clipboard": "^1.6.1",
+    "flow-bin": "^0.66.0",
     "material-ui": "^0.20.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
@@ -33,7 +34,6 @@
     "chai": "^4.1.2",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
-    "flow-bin": "^0.65.0",
     "sinon": "^4.3.0"
   }
 }

--- a/client/src/auth_container.test.js
+++ b/client/src/auth_container.test.js
@@ -1,5 +1,5 @@
 /* @flow weak */
-import React from 'react';
+import * as React from 'react';
 
 import {shallow} from 'enzyme';
 import {expect} from 'chai';

--- a/client/src/message_popup/equity/paper_prototype_page.jsx
+++ b/client/src/message_popup/equity/paper_prototype_page.jsx
@@ -36,19 +36,29 @@ const Parts = {
   FINAL_INSTRUCTIONS: 'FINAL_INSTRUCTIONS'
 };
 
+type Props = {
+  prototypeKey: string,
+  query: {
+    cohort?: string,
+    p?: string,
+    workshop?: string,
+  }
+};
+
+type State = {
+  cohortKey: string,
+  identifier: string,
+  workshop: string,
+  questions: string,
+  questionsHash: string,
+  sessionId: string,
+  currentPart: string
+};
+
 
 // For showing minimal paper prototypes.
 // This was adapted from HMTCAExperiencePage
-export default class extends React.Component {
-  props: {
-    prototypeKey: string,
-    query: {
-      cohort?: string,
-      p?: string,
-      workshop?: string,
-    },
-  };
-
+export default class extends React.Component<Props, State> {
   static displayName = 'PaperPrototypePage';
 
   static propTypes = {
@@ -79,13 +89,13 @@ export default class extends React.Component {
   //
   // Different workshop sessions on different days can use URLs to different workshop
   // values for isolation.
-  applesKey = () => {
+  applesKey() {
     const {prototypeKey} = this.props;
     const {cohortKey, workshop} = this.state;
     return [prototypeKey, cohortKey, workshop].join(':');
-  };
+  }
 
-  firstSlide = () => {
+  firstSlide() {
     return { el: 
       <div>
         <div><b>PART 1: Practice Individually</b></div>
@@ -97,10 +107,10 @@ export default class extends React.Component {
         <div>Once you’re finished with your responses, You'll review how people have responded and discuss.  Clicking on “Ok” will take you to your first scene. Ready?</div>
       </div>
     };
-  };
+  }
 
   // Making questions from the cohort
-  doStart = () => {
+  doStart() {
     const {prototypeKey} = this.props;
     const prototype = _.find([].concat(CSSPaperPrototypes).concat(SeedPaperPrototypes), { key: prototypeKey });
     const allQuestions = toSlides(prototype);
@@ -112,41 +122,42 @@ export default class extends React.Component {
       questions,
       questionsHash
     });
-  };
+  }
 
-  onCohortKeyChanged = (e) => {
+  onCohortKeyChanged(e) {
     this.setState({cohortKey: e.target.value});
-  };
+  }
 
-  onIdentifierChanged = (e) => {
-    this.setState({ identifier: e.target.value });
-  };
+  onIdentifierChanged(e) {
+    const identifier:string = e.target.value;
+    this.setState({identifier});
+  }
 
-  onNoGroupCode = (e) => {
+  onNoGroupCode(e) {
     e.preventDefault();
     const cohortKey = 'DEMO_COHORT';
     this.setState({cohortKey});
     this.doStart();
-  };
+  }
 
-  onStart = (e) => {
+  onStart(e) {
     e.preventDefault();
     this.doStart();
-  };
+  }
 
-  onShowGroupInstructions = () => {
+  onShowGroupInstructions() {
     this.setState({ currentPart: Parts.GROUP_INSTRUCTIONS });
-  };
+  }
 
-  onStartGroupReview = () => {
+  onStartGroupReview() {
     this.setState({ currentPart: Parts.GROUP_REVIEW });
-  };
+  }
 
-  onGroupReviewDone = () => {
+  onGroupReviewDone() {
     this.setState({ currentPart: Parts.FINAL_INSTRUCTIONS });
-  };
+  }
 
-  onLogMessage = (type, response) => {
+  onLogMessage(type, response) {
     const {
       identifier,
       cohortKey,
@@ -173,7 +184,7 @@ export default class extends React.Component {
       questionsHash,
       identifier
     });
-  };
+  }
 
   render() {
     return (
@@ -183,7 +194,7 @@ export default class extends React.Component {
     );
   }
 
-  renderContent = () => {
+  renderContent() {
     const {questions, currentPart} = this.state;
     if (currentPart === Parts.PRACTICE) {
       if (!questions) return this.renderIntro();
@@ -198,9 +209,9 @@ export default class extends React.Component {
     if (currentPart === Parts.GROUP_INSTRUCTIONS) return this.renderGroupInstructions();
     if (currentPart === Parts.GROUP_REVIEW) return this.renderGroupReview();
     if (currentPart === Parts.FINAL_INSTRUCTIONS) return this.renderFinalInstructions();
-  };
+  }
 
-  renderIntro = () => {
+  renderIntro() {
     return (
       <VelocityTransitionGroup enter={{animation: "callout.pulse", duration: 500}} leave={{animation: "slideUp"}} runOnMount={true}>
         <form onSubmit={this.onStart}>
@@ -242,9 +253,9 @@ export default class extends React.Component {
         </form>
       </VelocityTransitionGroup>
     );
-  };
+  }
 
-  renderQuestionEl = (question:QuestionT, onLog, onResponseSubmitted) => {
+  renderQuestionEl(question:QuestionT, onLog, onResponseSubmitted) {
     const forceText = true; // because of the text reviews after
     return (
       <div>
@@ -255,9 +266,9 @@ export default class extends React.Component {
           onResponseSubmitted={onResponseSubmitted} />
       </div>
     );
-  };
+  }
 
-  renderPauseEl = (questions:[QuestionT], responses:[ResponseT]) => {
+  renderPauseEl(questions:[QuestionT], responses:[ResponseT]) {
     return (
       <div style={{margin: 20}}>
         <div style={{paddingBottom: 20}}>That's the end of Part 1.  Click to proceeed.</div>
@@ -267,9 +278,9 @@ export default class extends React.Component {
           onTouchTap={this.onShowGroupInstructions} />
       </div>
     );
-  };
+  }
 
-  renderGroupInstructions = () => {
+  renderGroupInstructions() {
     return (
       <div style={{margin: 20}}>
         <div>
@@ -289,16 +300,16 @@ export default class extends React.Component {
         </div>
       </div>
     );
-  };
+  }
 
-  renderGroupReview = () => {
+  renderGroupReview() {
     return <GroupReview
       prompt="Scroll through and discuss."
       applesKey={this.applesKey()}
       onDone={this.onGroupReviewDone} />;
-  };
+  }
 
-  renderFinalInstructions = () => {
+  renderFinalInstructions() {
     return (
       <div style={styles.instructions}>
         <p><b>PART 3: Discuss assumptions</b></p>
@@ -312,7 +323,7 @@ export default class extends React.Component {
         <div>If you're online, connect with others at <a target="_blank" rel="noopener noreferrer" href="https://twitter.com/search?q=%23TeacherPracticeSpaces">#TeacherPracticeSpaces</a>.</div>
       </div>
     );
-  };
+  }
 }
 
 const styles = {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2762,9 +2762,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.65.0:
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.65.0.tgz#64ffeca27211c786e2d68508c65686ba1b8a2169"
+flow-bin@^0.66.0:
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.66.0.tgz#a96dde7015dc3343fd552a7b4963c02be705ca26"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
@keving17 I looked at the Flow errors a bit more, sorry I didn't get to this yesterday.  The root problem is that the way Flow typing works for React components changed in 0.53 ([docs](https://github.com/facebook/flow/blob/master/Changelog.md#0530)), and we pulled in that upgrade as well in switching to `create-react-app`.  I ran the [flow-upgrade](https://github.com/facebook/flow/tree/5aaf9b9177514c7ed0c2b65af7efff4fea5c5775/packages/flow-upgrade) tool they recommended but it didn't fix anything up automatically.

Fortunately, even though there's 500 some errors, from scanning I think almost all of them are from one particular change, and that this is both a simple and beneficial change to make that only affects ~10-20 files.  Also, accidentally I upgraded from 0.65 to 0.66 in the process of looking at that and they have a more helpful format for error messages too :)

Here's what the last error I see on new-build running flow 0.66:
<img width="852" alt="screen shot 2018-03-01 at 7 21 05 am" src="https://user-images.githubusercontent.com/1056957/36844540-2003db4c-1d21-11e8-836f-9073c53c608a.png">

And here's one more up a bit further for the same file, `paper_prototype_page.jsx`, so we stay focused on the changes for one file at a time:
<img width="860" alt="screen shot 2018-03-01 at 7 22 59 am" src="https://user-images.githubusercontent.com/1056957/36844612-719b7230-1d21-11e8-860c-f5e22c5da369.png">

They're both complaining because we're calling `setState` in an unsafe way, where we're trying to set a value for state that may not be type safe.  This is happening because we haven't added type information for the component and Flow now expects this as of 0.53.  So before our component looked like this:
<img width="759" alt="screen shot 2018-03-01 at 7 22 38 am" src="https://user-images.githubusercontent.com/1056957/36844585-57772b38-1d21-11e8-924b-d478fed2f761.png">

So Flow can't infer all the types from just that and the new recommended way to do this is to add explicit type for props and state, which is great.  Here's what that looks like:

<img width="535" alt="screen shot 2018-03-01 at 7 16 15 am" src="https://user-images.githubusercontent.com/1056957/36844661-a45d8fe6-1d21-11e8-9f1c-b49707e75664.png">

In the process of doing this, the Flow error message also correctly pointed out that we were using `questionsHash` in some code but it wasn't in the type definition.  So I added that in.

So to back up, I think this is the root cause of all of these, and that there's probably only 10-15 files to do this for.  In the process we'll also get better type checking on these kinds of mistakes.  So I'd say let's try to fix forward from this and get things working, and I'm happy to spend time on this next Wednesday as well and try to burn through them.  If you want to take this and run with it and try to work through the other files that's awesome but I'm happy to take a crack at that Wednesday too if it's better for you to focus on other week.  If we're still stuck on this next week then maybe we shift strategies.

How does that sound?