### PR TITLE
Update server code to read static files from create-react-app build

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -184,19 +184,12 @@ app.get('/teachermoments/wav/(:id).wav', ReviewEndpoint.sensitiveGetAudioFile({q
 app.get('/server/apples/:key', ApplesEndpoint.sensitiveGetApples({queryDatabase}));
 
 
-// serve static HTML
-function readFile(filename) {
-  return function(request, response) {
-    const absolutePath = path.join(__dirname, '..', 'ui', 'build', filename);
-    console.log(absolutePath);
-    const readStream = fs.createReadStream(absolutePath);
-    readStream.pipe(response);
-  };
-}
-app.get('/bundle.js', readFile('bundle.js'));
-app.get('/playtest.html', readFile('playtest.html'));
-app.get('/favicon.ico', (request, response) => { response.status(404).end(); });
-app.get('*', readFile('index.html'));
+// Serve any static files.
+// Route other requests return the React app, so it can handle routing.
+app.use(express.static(path.resolve(__dirname, '../client/build')));
+app.get('*', (request, response) => {
+  response.sendFile(path.resolve(__dirname, '../client/build', 'index.html'));
+});
 
 
 // start server


### PR DESCRIPTION
This is a follow-on to https://github.com/mit-teaching-systems-lab/threeflows/pull/339.  This PR is intended to be merged into https://github.com/mit-teaching-systems-lab/threeflows/pull/344 (which reverts the revert, to deploy the new build process).

This changes the way the server code reads static assets like `index.html` and `.js` files in production, since we moved the UI code from `ui/` to `client/` and because the files that create-react-app builds are slightly different than the previous build process.