### PR TITLE
fix email mustache to include login link

### DIFF
--- a/server/research/loginlink.html.mustache
+++ b/server/research/loginlink.html.mustache
@@ -88,7 +88,7 @@
 
 <!-- HIDDEN PREHEADER TEXT -->
 <div style="display: none; font-size: 1px; color: #fefefe; line-height: 1px; font-family: Helvetica, Arial, sans-serif; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden;">
-    Here's the link you requested: {{linkText}}!
+    Here's the link you requested: {{link}}!
 </div>
 
 <!-- HEADER -->
@@ -114,7 +114,7 @@
                                         </tr>
                                         <tr>
                                             <td align="center" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;" class="padding">
-                                            <a href="{{linkText}}">{{linkText}}</a>
+                                            <a href="{{link}}">{{link}}</a>
                                         </tr>
                                     </table>
                                 </td>
@@ -127,7 +127,7 @@
                                             <td align="center" style="padding-top: 25px;" class="padding">
                                                 <table border="0" cellspacing="0" cellpadding="0" class="mobile-button-container">
                                                     <tr>
-                                                        <td align="center" style="border-radius: 3px;" bgcolor="#256F9C"><a href="{{linkText}}" target="_blank" style="font-size: 16px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; border-radius: 3px; padding: 15px 25px; border: 1px solid #256F9C; display: inline-block;" class="mobile-button">Confirm to login</a></td>
+                                                        <td align="center" style="border-radius: 3px;" bgcolor="#256F9C"><a href="{{link}}" target="_blank" style="font-size: 16px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; border-radius: 3px; padding: 15px 25px; border: 1px solid #256F9C; display: inline-block;" class="mobile-button">Confirm to login</a></td>
                                                     </tr>
                                                 </table>
                                             </td>


### PR DESCRIPTION
Addresses Issue https://github.com/mit-teaching-systems-lab/threeflows/issues/357.
When I migrated this code from the swipe right project, I changed how some things were named and broke this bit on the emailing functionality. This fixes that.

<img width="480" alt="screen shot 2018-04-19 at 3 30 17 pm" src="https://user-images.githubusercontent.com/11862658/39014097-58f3cbd2-43e7-11e8-8090-bb430708d24d.png">
