### PR TITLE
Patch/readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ $ yarn db-create-dev
 ```
 - For storing audio files, you'll need keys authorized for a development S3 bucket.
 - For transcribing audio files, you'll need keys authorized for accessing the Watson Speech to Text API. Details on [how to use the API](https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/) can be found on their website.
+
 Ask someone for these keys.
 
 #### Viewing data

--- a/README.md
+++ b/README.md
@@ -149,11 +149,11 @@ To update Teacher Moments on who has consented to share their data, you need to:
 ```
 $ yarn run prep-consent
 ```
-This should generate 2 files: `consented-latest.json` and `consented-YYYY-MM-DD.json`.
+This should generate 1 file in the `threeflows/tmp` folder: `consented-latest.json`.
 
-3. Run the update-consent script in heroku to update the live `consented_email` database using
+3. Run the update-consent script in heroku to update the live `consented_email` database and clean sensitive information from your codebase using
 ```
-$ cat ./tmp/consented-latest.json | heroku run --no-tty yarn run update-consent
+$ cat ./tmp/consented-latest.json | heroku run --no-tty yarn run update-consent | rm ./tmp/consented-latest.json ./tmp/consented-latest-raw.csv
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -37,51 +37,20 @@ If you already have node installed, you can check the version with `node -v`.  I
 
 [Install Postgres](https://devcenter.heroku.com/articles/heroku-postgresql#set-up-postgres-on-mac).
 
-Seed the database:
+Seed the database to store text responses:
 ```
-CREATE DATABASE "teacher-moments-db";
-\c teacher-moments-db;
-CREATE TABLE evidence (
-  id serial primary key,
-  app text,
-  type text,
-  version integer,
-  timestamp timestamp,
-  json jsonb
-);
-CREATE TABLE evaluations (
-  id serial primary key,
-  app text,
-  type text,
-  version integer,
-  timestamp timestamp,
-  json jsonb
-);
-
-CREATE TABLE message_popup_questions (
-  id serial primary key,
-  timestamp timestamp,
-  questions jsonb
-);
-
-CREATE TABLE reviews (
-  id serial primary key,
-  timestamp timestamp,
-  review_key text,
-  access_code text
-);
-
-CREATE TABLE review_tokens (
-  id serial primary key,
-  timestamp timestamp,
-  review_id integer,
-  email_address text,
-  hid text,
-  token text
-);
+$ yarn db-create-dev
 
 ```
-For storing audio files, you'll need keys authorized for a development S3 bucket.  Ask someone for these.
+- For storing audio files, you'll need keys authorized for a development S3 bucket.
+- For transcribing audio files, you'll need keys authorized for accessing the Watson Speech to Text API. Details on [how to use the API](https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/) can be found on their website.
+Ask someone for these keys.
+
+#### Viewing data
+To view data, go to `localhost:3000/login` in your web browser. You can use the default `test@mit.edu` email to login. A link should appear in your terminal for verification. 
+
+Note: This only gives you access to the Researcher Portal. The `test@mit.edu` default user does not have access to any data. You can fix this by adding entries to the `whitelist` and `access` databases and using the corresponding urls when generating local development data.
+
 
 Now you can play around with the app locally!
 
@@ -97,25 +66,23 @@ You may also want to check out [react-devtools](https://github.com/facebook/reac
 ### Type check with Flow
 This starts a [Flow](https://flowtype.org/) server in the background, and then runs a typecheck once.  There's no watch command right now.
 ```
-ui $ yarn run flow-quiet
+client $ yarn run flow-quiet
 ```
 
 ### Lint and fixup with eslint
 ```
-ui $ yarn run lint-quiet
+client $ yarn run lint
 ```
 
-### Run Mocha tests
-This project uses Mocha, with Chai's expect-style assertions, and Enzyme for some React testing utilities.  Tests are co-located with source code in the same folder, distinguished by a `_test.jsx` extension.  To run a process that watches and continually re-runs the tests:
-
+### Run Jest tests
 ```
-ui $ yarn run mocha-watch
+client $ yarn run jest
 ```
 
 ### Run all tests
 This is used in CI, and runs any and all tests in the project including linting, typechecks and actual tests.
 ```
-ui $ yarn run test
+client $ yarn run test
 ```
 
 ### Sublime setup

--- a/README.md
+++ b/README.md
@@ -143,12 +143,14 @@ For example, if they are using the Jessica Turner scenario for their thesis proj
 All data collected by Teacher Moments is protected to ensure the privacy of participants. In order for a researcher or TE to view the data collected on a specific participant, the participant must fill out a [TSL consent form.](https://tsl.mit.edu/consent)
 
 To update Teacher Moments on who has consented to share their data, you need to:
-1. Download a CSV version of the consent spreadsheet. Search for `User Testing Consent Form (Responses)` in the TSL team Google Drive. Rename the file to `consented-latest-raw.csv` and save this file in the `threeflows/tmp` folder
+1. Download a CSV version of the consent spreadsheet. Search for `User Testing Consent Form (Responses)` in the TSL team Google Drive. Rename the file to `consented-latest-raw.csv` and save this file in the `threeflows/tmp` folder.
+
 2. Run the prep-consent script to process the CSV file using
 ```
 $ yarn run prep-consent
 ```
-This should generate 2 files: `consented-latest.json` and `consented-YYYY-MM-DD.json`
+This should generate 2 files: `consented-latest.json` and `consented-YYYY-MM-DD.json`.
+
 3. Run the update-consent script in heroku to update the live `consented_email` database using
 ```
 $ cat ./tmp/consented-latest.json | heroku run --no-tty yarn run update-consent

--- a/README.md
+++ b/README.md
@@ -130,6 +130,31 @@ Other Heroku docs:
 - [Node.js on Heroku](https://devcenter.heroku.com/categories/nodejs)
 - [Best Practices for Node.js Development](https://devcenter.heroku.com/articles/node-best-practices)
 
+## Maintaining Researcher Portal
+### Whitelist database
+Researchers and teacher educators (TEs) looking to use data collected in Teacher Moments must be registered with the Teaching Systems Lab. To give researchers and TEs access to the researcher portal, their email addresses must be manually added to the `whitelist` database.
+
+### Access database
+Once a researcher or TE has been given access to the portal, they need to be given access to a specific instance of Teacher Moments. 
+
+For example, if they are using the Jessica Turner scenario for their thesis project, they might collect data using the following url: `https://teachermoments.teachingsystemslab.org/teachermoments/turner?KevinThesis20180319`. Teacher candidates would engage with the Teacher Moments simulation at that url and we would use that link to extract the data collected. To view the data, we would need to add an entry into the `access` database linking the TE's email to the url.
+
+### Consented_Email database
+All data collected by Teacher Moments is protected to ensure the privacy of participants. In order for a researcher or TE to view the data collected on a specific participant, the participant must fill out a [TSL consent form.](https://tsl.mit.edu/consent)
+
+To update Teacher Moments on who has consented to share their data, you need to:
+1. Download a CSV version of the consent spreadsheet. Search for `User Testing Consent Form (Responses)` in the TSL team Google Drive. Rename the file to `consented-latest-raw.csv` and save this file in the `threeflows/tmp` folder
+2. Run the prep-consent script to process the CSV file using
+```
+$ yarn run prep-consent
+```
+This should generate 2 files: `consented-latest.json` and `consented-YYYY-MM-DD.json`
+3. Run the update-consent script in heroku to update the live `consented_email` database using
+```
+$ cat ./tmp/consented-latest.json | heroku run --no-tty yarn run update-consent
+```
+
+
 ## Other services
 [Travis](https://travis-ci.org/mit-teaching-systems-lab/threeflows) is setup for CI.  It will run on pull requests and on commits to master.
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "yarn run lint && cd client && yarn run test",
     "db-create-dev": "node scripts/db-create.js teacher-moments-db",
     "update-consent": "node scripts/updateConsent.js",
-    "prep-consent": "node scripts/prepConsent.js tmp/consented-latest-raw.csv",
+    "prep-consent": "node scripts/prepConsent.js tmp/consented-latest-raw.csv"
   },
   "dependencies": {
     "aws-sdk": "^2.4.8",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "db-create-dev": "node scripts/db-create.js teacher-moments-db",
     "update-consent": "node scripts/updateConsent.js",
     "prep-consent": "node scripts/prepConsent.js tmp/consented-latest-raw.csv",
-    "update-consent-db": "yarn run prep-consent && yarn run update-consent"
   },
   "dependencies": {
     "aws-sdk": "^2.4.8",

--- a/scripts/db-create.js
+++ b/scripts/db-create.js
@@ -81,6 +81,10 @@ function createTables(database) {
     CREATE TABLE access (
       email text,
       url text
+    );
+    INSERT INTO whitelist VALUES (
+      DEFAULT,
+      'test@mit.edu'
     );`;
   console.log(`Creating tables...`);
   return pool.query(sql);

--- a/scripts/prepConsent.js
+++ b/scripts/prepConsent.js
@@ -59,9 +59,6 @@ function writeConsentToDisk(consentedRows, filename) {
   fs.writeFileSync(filename, output);
 }
 
-const dateString = moment().format('YYYY-MM-DD');
-const filenameWithDate = path.resolve(__dirname, `../tmp/consented-${dateString}.json`);
 const filenameLatest = path.resolve(__dirname, `../tmp/consented-latest.json`);
 writeConsentToDisk(consentedRows, filenameLatest);
-writeConsentToDisk(consentedRows, filenameWithDate);
 console.log('Done.');


### PR DESCRIPTION
This patch updates the README with all of the new scripts introduced with the new researcher portal. It address issue https://github.com/mit-teaching-systems-lab/threeflows/issues/350.

Notable updates include:
- new script to seed database
- small section on the Watson API and necessary credentials
- Viewing data section to introduce login portal
- jest section to replace mocha
- Maintaining Researcher Portal section to explain how to update consented users on live site.

[View changes here](https://github.com/mit-teaching-systems-lab/threeflows/blob/patch/readme/README.md)