### PR TITLE
Patch/short transcript

### DIFF
--- a/server/speech.js
+++ b/server/speech.js
@@ -76,11 +76,11 @@ function speechToText(pool, s3, watsonConfig, audioID, request, response) {
         reject('Could not transcribe with IBM Watson:', error);
       }
       else{
-        var text = "";
+        var text = [];
         for (var i=0; i<transcript.results.length; i++) {
-          text = text+transcript.results[i].alternatives[0].transcript+ " ";
+          text.push(transcript.results[i].alternatives[0].transcript);
         }
-        updateTranscript(pool, text, audioID)
+        updateTranscript(pool, text.join(' [PAUSE] '), audioID)
           .then(results => {
             resolve(results);
           });

--- a/server/speech.js
+++ b/server/speech.js
@@ -76,7 +76,10 @@ function speechToText(pool, s3, watsonConfig, audioID, request, response) {
         reject('Could not transcribe with IBM Watson:', error);
       }
       else{
-        const text = transcript.results[0].alternatives[0].transcript;
+        var text = "";
+        for (var i=0; i<transcript.results.length; i++) {
+          text = text+transcript.results[i].alternatives[0].transcript+ " ";
+        }
         updateTranscript(pool, text, audioID)
           .then(results => {
             resolve(results);


### PR DESCRIPTION
Resolves Issue https://github.com/mit-teaching-systems-lab/threeflows/issues/358 where transcripts would cut off early if users had an extended pause in their audio responses.

<img width="417" alt="screen shot 2018-06-10 at 8 16 52 pm" src="https://user-images.githubusercontent.com/11862658/41207920-3fe85f04-6ceb-11e8-9d88-ce1ecb00d74b.png">
