### PR TITLE
Fix migration bug that dropped Rollbar

### DIFF
--- a/client/src/app.jsx
+++ b/client/src/app.jsx
@@ -9,6 +9,8 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 
+import {startRollbar} from './rollbar';
+
 import AuthContainer from './auth_container.jsx';
 import HomePage from './home/home_page.jsx';
 import DemosPage from './home/demos_page.jsx';
@@ -43,6 +45,7 @@ export default createReactClass({
 
   componentWillMount() {
     injectTapEventPlugin(); // material-ui, see https://github.com/zilverline/react-tap-event-plugin
+    startRollbar();
   },
 
   routes: {

--- a/client/src/message_popup/equity/equity_fair_page.jsx
+++ b/client/src/message_popup/equity/equity_fair_page.jsx
@@ -124,7 +124,7 @@ export default class extends React.Component {
           <div style={styles.link}><a href="http://tsl.mit.edu/practice-spaces-for-teacher-preparation/">Game-based practice spaces</a></div>
           <div style={styles.link}><a href="https://threeflows-blockly.herokuapp.com/">Prototype your own scenarios</a></div>
           <div style={styles.link}><a href="https://github.com/mit-teaching-systems-lab/threeflows">github.com/mit-teaching-systems-lab</a></div>
-          <a style={styles.link} href="http://csteachingtips.org/tip-sheets" target="_blank">CSTeachingTips game: Practice responding to microaggressions</a>
+          <a style={styles.link} href="http://csteachingtips.org/tip-sheets" target="_blank" rel="noopener noreferrer">CSTeachingTips game: Practice responding to microaggressions</a>
         </div>
         <Divider style={{marginTop: 30, marginBottom: 30}} />
         <div style={styles.header}>Read more papers</div>

--- a/client/src/rollbar.js
+++ b/client/src/rollbar.js
@@ -1,17 +1,7 @@
-/* @flow weak */
-import App from './app.jsx';
-import React from 'react';
-import ReactDOM from 'react-dom';
 import rollbar from 'rollbar-browser';
 
 
-document.addEventListener('DOMContentLoaded', () => {
-  startRollbar();
-  ReactDOM.render(<App history={true}/>, document.getElementById('app-main'));
-});
-
-
-function startRollbar() {
+export function startRollbar() {
   const {hostname, protocol, port} = window.location;
   const portString = port === '' ? '' : `:${port}`;
   const environment = `${protocol}//${hostname}${portString}`;


### PR DESCRIPTION
This must have gotten dropped in migrating the build process, so let's add it back to get more visibility into errors, especially with more new folks trying these out in more self-serve ways.

Also address linter warning on master.