### PR TITLE
Wrap isAudioSupport in try/catch

### DIFF
--- a/client/src/components/audio_capture.jsx
+++ b/client/src/components/audio_capture.jsx
@@ -22,12 +22,18 @@ export default class extends React.Component {
   };
 
   static isAudioSupported() {
-    const navigator = window.navigator;
-    const getUserMedia = navigator.getUserMedia ||
-      navigator.webkitGetUserMedia ||
-      navigator.mozGetUserMedia ||
-      navigator.msGetUserMedia;
-    return getUserMedia !== undefined;
+    // If this check raises for any reason then audio is
+    // not supported (eg iOS Chrome 68)
+    try {
+      const navigator = window.navigator;
+      const getUserMedia = navigator.getUserMedia ||
+        navigator.webkitGetUserMedia ||
+        navigator.mozGetUserMedia ||
+        navigator.msGetUserMedia;
+      return getUserMedia !== undefined;
+    } catch (err) {
+      return false;
+    }
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
Workaround for iOS Chrome 68 so the fall back to text works, rather than breaking.  See also https://github.com/mit-teaching-systems-lab/threeflows/issues/377#issuecomment-422954152 and  https://rollbar.com/threeflows/threeflows/items/147/#graphs